### PR TITLE
JASPER-245: Add Vuetify

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,12 +8,12 @@
       "name": "scv-web",
       "version": "0.1.0",
       "dependencies": {
-        "@bcgov/bootstrap-theme": "https://github.com/bcgov/bootstrap-theme/releases/download/v1.1.3/bcgov-bootstrap-theme-1.1.3.tgz",
         "@fullcalendar/core": "^6.1.15",
         "@fullcalendar/daygrid": "^6.1.15",
         "@fullcalendar/interaction": "^6.1.15",
         "@fullcalendar/timegrid": "^6.1.15",
         "@fullcalendar/vue3": "^6.1.15",
+        "@mdi/font": "^7.4.47",
         "@types/underscore": "^1.13.0",
         "@vitejs/plugin-basic-ssl": "^1.2.0",
         "axios": "^1.7.9",
@@ -26,14 +26,14 @@
         "lodash": "^4.17.21",
         "pinia": "^2.3.0",
         "regenerator-runtime": "^0.14.1",
-        "sass": "^1.82.0",
         "splunk-logging": "^0.11.1",
         "style-loader": "^4.0.0",
         "underscore": "^1.13.7",
         "uuid": "^11.0.3",
         "vue": "^3.5.13",
         "vue-month-picker": "^1.7.2",
-        "vue-router": "^4.5.0"
+        "vue-router": "^4.5.0",
+        "vuetify": "^3.7.5"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.17.0",
@@ -107,15 +107,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bcgov/bootstrap-theme": {
-      "version": "1.1.3",
-      "resolved": "https://github.com/bcgov/bootstrap-theme/releases/download/v1.1.3/bcgov-bootstrap-theme-1.1.3.tgz",
-      "integrity": "sha512-D37u71R8TWdGlhM7KY0ENLqgB2M+A8GLBPGi7FZ/ovR2WipRcSTeLGgm8x4KkXiYs+XY0LiLbbYCi/YLpVzCGA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bootstrap": "~4.3.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -842,6 +833,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mdi/font": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
+      "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -887,6 +884,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -928,6 +926,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -948,6 +947,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -968,6 +968,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -988,6 +989,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1008,6 +1010,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1028,6 +1031,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1048,6 +1052,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1068,6 +1073,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1088,6 +1094,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1108,6 +1115,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1128,6 +1136,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1148,6 +1157,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1168,6 +1178,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2200,16 +2211,23 @@
       "license": "ISC"
     },
     "node_modules/bootstrap": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
-      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
-        "popper.js": "^1.14.7"
+        "popper.js": "^1.16.1"
       }
     },
     "node_modules/bootstrap-vue-next": {
@@ -2366,6 +2384,8 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
       "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -2530,6 +2550,7 @@
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -3168,7 +3189,9 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
       "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -3571,7 +3594,8 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
@@ -3896,6 +3920,8 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
       "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14.16.0"
       },
@@ -4024,6 +4050,8 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.82.0.tgz",
       "integrity": "sha512-j4GMCTa8elGyN9A7x7bEglx0VgSpNUG4W4wNedQ33wSMdnkqQCT8HTwOaVSV4e6yQovcu/3Oc4coJP/l0xhL2Q==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -4763,6 +4791,36 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vuetify": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.5.tgz",
+      "integrity": "sha512-5aiSz8WJyGzYe3yfgDbzxsFATwHvKtdvFAaUJEDTx7xRv55s3YiOho/MFhs5iTbmh2VT4ToRgP0imBUP660UOw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/johnleider"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7",
+        "vite-plugin-vuetify": ">=1.0.0",
+        "vue": "^3.3.0",
+        "webpack-plugin-vuetify": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vite-plugin-vuetify": {
+          "optional": true
+        },
+        "webpack-plugin-vuetify": {
+          "optional": true
+        }
       }
     },
     "node_modules/watchpack": {

--- a/web/package.json
+++ b/web/package.json
@@ -20,12 +20,12 @@
     "json-schema": ">=0.4.0"
   },
   "dependencies": {
-    "@bcgov/bootstrap-theme": "https://github.com/bcgov/bootstrap-theme/releases/download/v1.1.3/bcgov-bootstrap-theme-1.1.3.tgz",
     "@fullcalendar/core": "^6.1.15",
     "@fullcalendar/daygrid": "^6.1.15",
     "@fullcalendar/interaction": "^6.1.15",
     "@fullcalendar/timegrid": "^6.1.15",
     "@fullcalendar/vue3": "^6.1.15",
+    "@mdi/font": "^7.4.47",
     "@types/underscore": "^1.13.0",
     "@vitejs/plugin-basic-ssl": "^1.2.0",
     "axios": "^1.7.9",
@@ -38,14 +38,14 @@
     "lodash": "^4.17.21",
     "pinia": "^2.3.0",
     "regenerator-runtime": "^0.14.1",
-    "sass": "^1.82.0",
     "splunk-logging": "^0.11.1",
     "style-loader": "^4.0.0",
     "underscore": "^1.13.7",
     "uuid": "^11.0.3",
     "vue": "^3.5.13",
     "vue-month-picker": "^1.7.2",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "vuetify": "^3.7.5"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.17.0",

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -19,3 +19,12 @@
     },
   });
 </script>
+
+<style>
+/* todo: remove */
+  select {
+    -webkit-appearance: auto !important;
+    appearance: auto !important;
+    border-style: solid !important;
+  }
+</style>

--- a/web/src/components/NavigationTopbar.vue
+++ b/web/src/components/NavigationTopbar.vue
@@ -78,7 +78,29 @@
     },
   });
 </script>
+<style>
+ /* todo: remove in favor of vuetify component styling */
+  ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    background-color: #333333;
+  }
 
-<style lang="scss">
-  @import '../styles/header';
+  li {
+    float: left;
+  }
+
+  li a {
+    display: block;
+    color: white;
+    text-align: center;
+    padding: 16px;
+    text-decoration: none;
+  }
+
+  li a:hover {
+    background-color: #111111;
+  }
 </style>

--- a/web/src/components/courtfilesearch/CourtFileSearchResult.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchResult.vue
@@ -386,26 +386,24 @@
 </script>
 
 <style scoped lang="scss">
-  @import '../../assets/_custom.scss';
-
   .card {
     border: white;
   }
 
   .text-blue {
-    color: $blue-100;
+    color: #007bff;
   }
 
   .text-green {
-    color: $green;
+    color: #28a745;
   }
 
   .text-purple {
-    color: $purple;
+    color: #6f42c1;
   }
 
   table thead tr th {
-    color: $green;
+    color: #28a745;
   }
 
   .no-wrap {
@@ -416,7 +414,7 @@
   .remove:hover,
   .remove:focus {
     text-decoration: none !important;
-    color: $danger !important;
+    color: #dc3545 !important;
     box-shadow: none;
   }
 </style>

--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -588,14 +588,12 @@
 </script>
 
 <style scoped lang="scss">
-  @import '../../assets/_custom.scss';
-
   .card {
     border: white;
   }
 
   .btn-group.active {
-    color: $blue;
+    color: #1b4f86;
   }
 
   .transparent {
@@ -606,7 +604,7 @@
   .reset:hover,
   .reset:focus {
     text-decoration: none !important;
-    color: $primary !important;
+    color: #1b4f86 !important;
     box-shadow: none;
   }
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,5 +1,4 @@
 import LoadingSpinner from '@components/LoadingSpinner.vue';
-import '@styles/index.scss';
 import { createBootstrap } from 'bootstrap-vue-next';
 import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
 import 'bootstrap/dist/css/bootstrap.css';
@@ -10,12 +9,22 @@ import './filters';
 import router from './router/index';
 import { registerRouter } from './services';
 import { registerPinia } from './stores';
+import '@mdi/font/css/materialdesignicons.css';
+// Vuetify
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import 'vuetify/styles';
 
 const app = createApp(App);
-
+const vuetify = createVuetify({
+  components,
+  directives,
+});
 registerPinia(app);
 app.use(router);
 app.use(createBootstrap());
+app.use(vuetify);
 //Vue.config.productionTip = true
 app.component('loading-spinner', LoadingSpinner);
 

--- a/web/src/styles/_common.scss
+++ b/web/src/styles/_common.scss
@@ -1,4 +1,0 @@
-// define variables and functions for use by isolated components
-
-@import "variables";
-@import "~@bcgov/bootstrap-theme/dist/scss/common";

--- a/web/src/styles/index.scss
+++ b/web/src/styles/index.scss
@@ -1,8 +1,8 @@
 @import 'common';
 /* You can add global styles to this file, and also import other style files */
-@import '~@bcgov/bootstrap-theme/dist/scss/bootstrap-theme';
-@import '../assets/_custom.scss';
-@import '~bootstrap/scss/bootstrap.scss';
+// @import '~@bcgov/bootstrap-theme/dist/scss/bootstrap-theme';
+// @import '../assets/_custom.scss';
+// @import '~bootstrap/scss/bootstrap.scss';
 
 .max-width-300 {
   max-width: 300px;

--- a/web/src/styles/index.scss
+++ b/web/src/styles/index.scss
@@ -1,8 +1,5 @@
 @import 'common';
 /* You can add global styles to this file, and also import other style files */
-// @import '~@bcgov/bootstrap-theme/dist/scss/bootstrap-theme';
-// @import '../assets/_custom.scss';
-// @import '~bootstrap/scss/bootstrap.scss';
 
 .max-width-300 {
   max-width: 300px;

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -49,7 +49,6 @@ export default defineConfig({
       '@services': path.resolve(__dirname, vueSrc.concat('/services')),
       '@store': path.resolve(__dirname, vueSrc.concat('/store')),
       '@styles': path.resolve(__dirname, vueSrc.concat('/styles')),
-      '~@bcgov': path.resolve(__dirname, 'node_modules/@bcgov'),
       '~bootstrap': path.resolve(__dirname, 'node_modules/bootstrap'),
       '~bootstrap-vue-next': path.resolve(
         __dirname,

--- a/web/web.njsproj
+++ b/web/web.njsproj
@@ -97,10 +97,6 @@
     <Content Include="src\components\LoadingSpinner.vue" />
     <Content Include="src\components\NavigationFooter.vue" />
     <Content Include="src\components\NavigationTopbar.vue" />
-    <Content Include="src\styles\index.scss" />
-    <Content Include="src\styles\_common.scss" />
-    <Content Include="src\styles\_survey.scss" />
-    <Content Include="src\styles\_variables.scss" />
     <Content Include="tsconfig.json" />
     <Content Include="package.json" />
     <Content Include="README.md" />


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**245**----    
https://jag.gov.bc.ca/jira/browse/JASPER-245

## Description
### 🎯 Add Vuetify to the project and remove unneeded sass stylings 🖌️
This branch adds Vuetify to the project, but also removes some of the older styling while keeping 'bootstrap' and 'bootstrap-vue-next'. The idea being for the components that are leveraging Vuetify I will remove the existence of bootstrap/bootstrap-vue-next that way the components that are currently not being upgraded can take advantage of the old style.

With that being said I found no real need for our project to use SASS,  we fully expect Vuetify to do a majority of the styling for us, which makes something like SASS overkill in my eyes. This will also increase bundling and debugging speed as we no longer need to bundle the SASS files.
I have commented out the calls for these files mostly for now until Vuetify is more fleshed out, which then I will fully remove the `.scss` files.

build: remove sass
build: remove bcgov theme
refactor: comment out use of scss files
style: add some temporary styling to address ui issues until vuetify is standardized

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [ ] Local tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules   