### PR TITLE
JASPER 178: Court file search result

### DIFF
--- a/web/src/components/courtfilesearch/CourtFileSearchResult.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchResult.vue
@@ -1,33 +1,163 @@
 <template>
   <div>
-    <b-card class="mt-3" bg-variant="light" v-if="isSearching">
-      <b-overlay :show="true">
-        <b-card style="min-height: 100px" />
-        <template v-slot:overlay>
-          <div>
-            <loading-spinner />
-            <p id="loading-label">Loading ...</p>
-          </div>
-        </template>
-      </b-overlay>
-    </b-card>
-    <div v-if="!isSearching">
-      <div class="my-3 bg-warning p-2" v-if="isSearchResultsOver">
+    <!-- Do we need this? -->
+    <!-- <div class="my-3 bg-warning p-2" v-if="isSearchResultsOver">
         <span
           >More than 100 records match the search criteria, only the first 100
           are returned.</span
         >
-      </div>
-      <h3 class="mt-3">Search Results</h3>
+      </div> -->
+    <v-banner bg-color="#efedf5">
+      <h3 class="px-2 py-2">Search Results</h3>
+    </v-banner>
+    <v-skeleton-loader v-if="isSearching" type="table"></v-skeleton-loader>
+    <v-data-table
+      v-model="selectedFiles"
+      :group-by="groupBy"
+      :items="searchResults"
+      :headers="headers"
+      item-value="fileNumberTxt"
+      items-per-page="100"
+      hover
+      show-select
+      return-object
+    >
+      <template
+        v-slot:group-header="{ item, columns, isGroupOpen, toggleGroup }"
+      >
+        <tr>
+          <td class="pa-0" :colspan="columns.length">
+            <v-banner
+              class="courtRowBanner"
+              :ref="
+                () => {
+                  if (!isGroupOpen(item)) toggleGroup(item);
+                }
+              "
+            >
+              {{
+                isCriminal
+                  ? 'Criminal - ' + getClass(item.value)
+                  : getClass(item.value)
+              }}
+            </v-banner>
+          </td>
+        </tr>
+      </template>
+      <!-- return this.getLocation(item.fileHomeAgencyId); -->
+
+      <!-- <template v-slot:item.participant="{ data }">
+          {{[...new Set(item.participant.map((p) => p.fullNm))].join('; ')}}
+      </template> -->
+      <!-- <template v-slot:cell(participant)="{ data }">
+          <span>{{
+            [...new Set(data.map((p) => p.fullNm))].join('; ')
+          }}</span>
+        </template> -->
+      <!-- formatter: (value, key, item) => {
+              return [...new Set(item.participant.map((p) => p.fullNm))].join(
+                '; '
+              );
+            }, -->
+      <!-- <template #head(nextApprDt)="data">
+          <span class="text-danger no-wrap">{{ data.label }}</span>
+        </template>
+        <template v-slot:cell(sealStatusCd)="data">
+          <span v-if="data.item.sealStatusCd === 'SD'" class="text-danger"
+            >(Sealed)</span
+          >
+        </template>
+        <template v-slot:cell(courtClassCd)="data">
+          <span :class="getClassColor(data.item.courtClassCd)">
+            {{ getClass(data.item.courtClassCd) }}
+          </span>
+        </template>
+        <template v-slot:cell(warrantYN)="data">
+          <b-badge
+            v-if="data.item.warrantYN === 'Y'"
+            variant="primary text-light"
+            :style="data.field.cellStyle"
+            v-b-tooltip.hover
+            title="Outstanding warrant"
+          > -->
+      <!-- <span>W</span>
+          </b-badge>
+        </template> -->
+      <!-- <template v-slot:cell(inCustodyYN)="data">
+          <b-badge
+            v-if="data.item.inCustodyYN === 'Y'"
+            variant="primary text-light"
+            :style="data.field.cellStyle"
+            v-b-tooltip.hover
+            title="In custody"
+          >
+            IC
+          </b-badge>
+        </template>
+        <template v-slot:cell(nextApprDt)="data">
+          <span>
+            {{ beautifyDate(data.item.nextApprDt) }}
+          </span>
+        </template>
+        <template v-slot:cell(action)="data">
+          <div class="d-flex justify-content-end no-wrap">
+            <b-button
+              variant="outline-primary"
+              class="mr-3"
+              @click="() => handleCaseClick(data.item[idSelector])"
+              >Add File</b-button
+            >
+            <b-button
+              variant="primary"
+              @click="() => handleAddFileAndViewClick(data.item[idSelector])"
+              >Add File and View</b-button
+            >
+          </div>
+        </template> -->
+    </v-data-table>
+    <div v-if="selectedFiles.length > 0">
+      <!-- Here we put out actionbar -->
+
+      <v-app-bar
+        :elevation="2"
+        location="bottom"
+        color="#183a4a"
+        rounded
+        style="
+          max-width: 50%;
+          margin: 0 auto;
+          left: 50%;
+          transform: translateX(-50%);
+          margin-bottom: 2.5rem;
+        "
+      >
+        <v-app-bar-title>Application Bar</v-app-bar-title>
+      </v-app-bar>
+
+      <!-- <v-toolbar dense floating style="position: fixed">
+        <v-text-field
+          prepend-icon="mdi-magnify"
+          hide-details
+          single-line
+        ></v-text-field>
+
+        <v-btn icon>
+          <v-icon>mdi-crosshairs-gps</v-icon>
+        </v-btn>
+
+        <v-btn icon>
+          <v-icon>mdi-dots-vertical</v-icon>
+        </v-btn>
+      </v-toolbar> -->
+
+      <!-- <h3 class="mt-3">Files to View</h3>
       <b-table
         :fields="filteredFields"
-        :items="searchResults"
+        :items="selectedFiles"
         borderless
         small
         responsive="md"
         sort-icon-left
-        empty-text="No cases matching the filter criteria were found. Please check to ensure the search criteria is correct."
-        show-empty
         striped
       >
         <template #head(nextApprDt)="data">
@@ -73,96 +203,25 @@
         <template v-slot:cell(action)="data">
           <div class="d-flex justify-content-end no-wrap">
             <b-button
-              variant="outline-primary"
-              class="mr-3"
-              @click="() => handleCaseClick(data.item[idSelector])"
-              >Add File</b-button
+              variant="link"
+              class="remove"
+              @click="() => handleDeleteClick(data.item[idSelector])"
             >
-            <b-button
-              variant="primary"
-              @click="() => handleAddFileAndViewClick(data.item[idSelector])"
-              >Add File and View</b-button
-            >
+              <b-icon icon="trash"></b-icon> Remove
+            </b-button>
           </div>
         </template>
       </b-table>
-      <div v-if="selectedFiles.length > 0">
-        <h3 class="mt-3">Files to View</h3>
-        <b-table
-          :fields="filteredFields"
-          :items="selectedFiles"
-          borderless
-          small
-          responsive="md"
-          sort-icon-left
-          striped
-        >
-          <template #head(nextApprDt)="data">
-            <span class="text-danger no-wrap">{{ data.label }}</span>
-          </template>
-          <template v-slot:cell(sealStatusCd)="data">
-            <span v-if="data.item.sealStatusCd === 'SD'" class="text-danger"
-              >(Sealed)</span
-            >
-          </template>
-          <template v-slot:cell(courtClassCd)="data">
-            <span :class="getClassColor(data.item.courtClassCd)">
-              {{ getClass(data.item.courtClassCd) }}
-            </span>
-          </template>
-          <template v-slot:cell(warrantYN)="data">
-            <b-badge
-              v-if="data.item.warrantYN === 'Y'"
-              variant="primary text-light"
-              :style="data.field.cellStyle"
-              v-b-tooltip.hover
-              title="Outstanding warrant"
-            >
-              <span>W</span>
-            </b-badge>
-          </template>
-          <template v-slot:cell(inCustodyYN)="data">
-            <b-badge
-              v-if="data.item.inCustodyYN === 'Y'"
-              variant="primary text-light"
-              :style="data.field.cellStyle"
-              v-b-tooltip.hover
-              title="In custody"
-            >
-              IC
-            </b-badge>
-          </template>
-          <template v-slot:cell(nextApprDt)="data">
-            <span>
-              {{ beautifyDate(data.item.nextApprDt) }}
-            </span>
-          </template>
-          <template v-slot:cell(action)="data">
-            <div class="d-flex justify-content-end no-wrap">
-              <b-button
-                variant="link"
-                class="remove"
-                @click="() => handleDeleteClick(data.item[idSelector])"
-              >
-                <b-icon icon="trash"></b-icon> Remove
-              </b-button>
-            </div>
-          </template>
-        </b-table>
-        <div class="my-3 bg-light p-3">
-          <div class="d-flex">
-            <b-button
-              variant="primary"
-              class="mr-3"
-              @click="handleViewFilesClick"
-              >View File(s)</b-button
-            >
-            <b-button variant="outline-primary" @click="handleDeleteAllClick"
-              >Remove All Files and Start Over</b-button
-            >
-          </div>
-        </div>
-      </div>
+      <div class="my-3 bg-light p-3">
+        <div class="d-flex">
+          <b-button variant="primary" class="mr-3" @click="handleViewFilesClick"
+            >View File(s)</b-button
+          >
+          <b-button variant="outline-primary" @click="handleDeleteAllClick"
+            >Remove All Files and Start Over</b-button
+          >
+        </div> 
+      </div>-->
     </div>
   </div>
 </template>
@@ -177,7 +236,15 @@
     data() {
       return {
         beautifyDate,
+        groupBy: [
+          {
+            key: 'courtClassCd',
+            order: 'asc' as const,
+          },
+        ],
         idSelector: '',
+        selected: [],
+        selectedFiles: [],
         allFields: [
           {
             key: 'location',
@@ -261,6 +328,9 @@
             label: 'Next appearance',
             tdClass: 'border-top',
             sortable: true,
+            formatter: (value, key, item) => {
+              return beautifyDate(item.nextApprDt);
+            },
           },
           {
             key: 'sealStatusCd',
@@ -272,6 +342,62 @@
             label: '',
             tdClass: 'border-top',
           },
+        ],
+        headers: [
+          { key: 'data-table-group' },
+          {
+            title: 'File #',
+            key: 'fileNumberTxt',
+            width: '15%',
+            value: (item: FileDetail) => `${this.getFormattedFileNumber(item)}`,
+          },
+          {
+            title: 'Accused / Parties',
+            key: 'participant',
+            width: '15%',
+            value: (item: FileDetail) =>
+              `${[...new Set(item.participant.map((p) => p.fullNm))].join('; ')}`,
+          },
+          {
+            title: 'Class',
+            key: 'courtClassCd',
+            width: '15%',
+            value: (item: FileDetail) => `${this.getClass(item.courtClassCd)}`,
+          },
+          {
+            title: 'Location',
+            key: 'location',
+            width: '15%',
+            value: (item: FileDetail) =>
+              `${this.getLocation(item.fileHomeAgencyId)}`,
+          },
+          {
+            title: 'Charges',
+            key: 'charges',
+            width: '15%',
+            value: (item: FileDetail) => {
+              const uniqueCharges = [
+                ...new Set(
+                  item.participant
+                    .flatMap((p) => p.charge)
+                    .map((c) => c.sectionTxt)
+                ),
+              ];
+              const firstCharge =
+                uniqueCharges.length > 0 ? uniqueCharges[0] : '';
+              return uniqueCharges.length > 1
+                ? `${firstCharge} + [${uniqueCharges.length - 1}]`
+                : firstCharge;
+            },
+          },
+          {
+            title: 'Next appearance',
+            key: 'nextApprDt',
+            width: '15%',
+            value: (item: FileDetail) => `${beautifyDate(item.nextApprDt)}`,
+          },
+          { title: 'OW', key: 'warrantyYN', width: '5%' },
+          { title: 'IC', key: 'inCustodyYN', width: '5%' },
         ],
       };
     },
@@ -416,5 +542,13 @@
     text-decoration: none !important;
     color: #dc3545 !important;
     box-shadow: none;
+  }
+  .v-toolbar--rounded {
+    border-radius: 70px;
+  }
+  .courtRowBanner {
+    background-color: #3095b0;
+    color: white;
+    text-transform: uppercase;
   }
 </style>

--- a/web/src/components/courtfilesearch/CourtFileSearchResult.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchResult.vue
@@ -3,42 +3,6 @@
     <v-banner bg-color="#efedf5">
       <h3 class="px-2 py-2">Search Results</h3>
     </v-banner>
-    <!-- <data-table
-      :items="searchResults"
-      :groupBy="groupBy"
-      :headers="filteredHeaders"
-      itemKey="physicalFileId"
-    >
-      <template v-slot:test="{ item }">
-        {{
-          isCriminal
-            ? 'Criminal - ' + getClass(item?.value)
-            : getClass(item?.value)
-        }}
-      </template> -->
-    <!-- <template
-        v-slot:group-header="{ item, columns, isGroupOpen, toggleGroup }"
-      >
-        <tr>
-          <td class="pa-0" :colspan="columns?.length">
-            <v-banner
-              class="courtRowBanner"
-              :ref="
-                () => {
-                  if (!isGroupOpen(item)) toggleGroup(item);
-                }
-              "
-            >
-              {{
-                isCriminal
-                  ? 'Criminal - ' + getClass(item?.value)
-                  : getClass(item?.value)
-              }}
-            </v-banner>
-          </td>
-        </tr>
-      </template> -->
-    <!-- </data-table> -->
     <v-skeleton-loader type="table" :loading="isSearching">
       <v-data-table
         v-model="selectedFiles"
@@ -72,12 +36,11 @@
         </template>
       </v-data-table>
     </v-skeleton-loader>
-    <!-- <action-bar :selected="selectedFiles" /> -->
+    <!-- todo: action-bar goes here -->
   </div>
 </template>
 
 <script setup lang="ts">
-  //import ActionBar from '@/components/shared/table/ActionBar.vue';
   import { beautifyDate } from '@/filters';
   import { LookupCode } from '@/types/common';
   import { FileDetail } from '@/types/courtFileSearch';
@@ -95,7 +58,7 @@
   }>();
 
   // The reason we use 103 instead of 100 is due to the ability to have up to 3 group headers in the table
-  const itemsPerPage = ref(103);
+  const itemsPerPage = 103;
   const selectedFiles = ref<FileDetail[]>([]);
   const idSelector = computed(() =>
     props.isCriminal ? 'mdocJustinNo' : 'physicalFileId'
@@ -176,59 +139,6 @@
   const getClass = (courtClassCd: string) =>
     props.classes.find((lookup) => lookup.code === courtClassCd)?.shortDesc ||
     '';
-
-  // These methods are commented out until we have the action bar component fully in place to utilize them
-  //
-  // const emit = defineEmits<{
-  //   (e: 'add-selected', file: FileDetail): void;
-  //   (e: 'remove-selected', idSelector: string, id: string): void;
-  //   (e: 'clear-selected'): void;
-  //   (e: 'files-viewed', files: KeyValueInfo[]): void;
-  // }>();
-
-  // function handleCaseClick(id: string) {
-  //   const isExist = props.selectedFiles.find((c) => c[idSelector.value] === id);
-  //   if (isExist) {
-  //     return;
-  //   }
-
-  //   const file = props.searchResults.find((c) => c[idSelector.value] === id);
-  //   if (file) {
-  //     emit('add-selected', file);
-  //   }
-  // }
-
-  // function handleAddFileAndViewClick(id: string) {
-  //   const isExist = props.selectedFiles.find((c) => c[idSelector.value] === id);
-  //   if (!isExist) {
-  //     const file = props.searchResults.find((c) => c[idSelector.value] === id);
-  //     if (file) {
-  //       emit('add-selected', file);
-  //     }
-  //   }
-
-  //   handleViewFilesClick();
-  // }
-
-  // function handleDeleteClick(id: string) {
-  //   emit('remove-selected', idSelector.value, id);
-  // }
-
-  // function handleDeleteAllClick() {
-  //   emit('clear-selected');
-  // }
-
-  // function handleViewFilesClick() {
-  //   const files = props.selectedFiles.map(
-  //     (c) =>
-  //       ({
-  //         key: c[idSelector.value],
-  //         value: getFormattedFileNumber(c),
-  //       }) as KeyValueInfo
-  //   );
-
-  //   emit('files-viewed', files);
-  // }
 </script>
 
 <style scoped>

--- a/web/src/components/courtfilesearch/CourtFileSearchResult.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchResult.vue
@@ -37,15 +37,9 @@
       </v-data-table>
     </v-skeleton-loader>
     <action-bar :selected="selectedItems" @clicked="handleViewFilesClick">
-      <!-- todo Implement document bundle navigation -->
-      <!-- <v-btn
-        :prepend-icon="mdiFileDocumentMultipleOutline"
-        style="letter-spacing: 0.001rem"
-        @click="handleViewFilesClick"
-      >
-        View document bundle
-      </v-btn> -->
       <v-btn
+        size="large"
+        class="mx-2"
         :prepend-icon="mdiFileDocumentOutline"
         style="letter-spacing: 0.001rem"
         @click="handleViewFilesClick"
@@ -62,10 +56,7 @@
   import { KeyValueInfo, LookupCode } from '@/types/common';
   import { FileDetail } from '@/types/courtFileSearch';
   import { roomsInfoType } from '@/types/courtlist';
-  import {
-    mdiFileDocumentMultipleOutline,
-    mdiFileDocumentOutline,
-  } from '@mdi/js';
+  import { mdiFileDocumentOutline } from '@mdi/js';
   import { computed, defineProps, ref } from 'vue';
 
   const props = defineProps<{

--- a/web/src/components/courtfilesearch/CourtFileSearchResult.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchResult.vue
@@ -16,7 +16,7 @@
       :group-by="groupBy"
       :items="searchResults"
       :headers="filteredHeaders"
-      item-value="fileNumberTxt"
+      item-value="physicalFileId"
       items-per-page="100"
       hover
       show-select
@@ -44,172 +44,13 @@
           </td>
         </tr>
       </template>
-      <!-- return this.getLocation(item.fileHomeAgencyId); -->
-
-      <!-- <template v-slot:item.participant="{ data }">
-          {{[...new Set(item.participant.map((p) => p.fullNm))].join('; ')}}
-      </template> -->
-      <!-- <template v-slot:cell(participant)="{ data }">
-          <span>{{
-            [...new Set(data.map((p) => p.fullNm))].join('; ')
-          }}</span>
-        </template> -->
-      <!-- formatter: (value, key, item) => {
-              return [...new Set(item.participant.map((p) => p.fullNm))].join(
-                '; '
-              );
-            }, -->
-      <!-- <template #head(nextApprDt)="data">
-          <span class="text-danger no-wrap">{{ data.label }}</span>
-        </template>
-        <template v-slot:cell(sealStatusCd)="data">
-          <span v-if="data.item.sealStatusCd === 'SD'" class="text-danger"
-            >(Sealed)</span
-          >
-        </template>
-        <template v-slot:cell(courtClassCd)="data">
-          <span :class="getClassColor(data.item.courtClassCd)">
-            {{ getClass(data.item.courtClassCd) }}
-          </span>
-        </template>
-        <template v-slot:cell(warrantYN)="data">
-          <b-badge
-            v-if="data.item.warrantYN === 'Y'"
-            variant="primary text-light"
-            :style="data.field.cellStyle"
-            v-b-tooltip.hover
-            title="Outstanding warrant"
-          > -->
-      <!-- <span>W</span>
-          </b-badge>
-        </template> -->
-      <!-- <template v-slot:cell(inCustodyYN)="data">
-          <b-badge
-            v-if="data.item.inCustodyYN === 'Y'"
-            variant="primary text-light"
-            :style="data.field.cellStyle"
-            v-b-tooltip.hover
-            title="In custody"
-          >
-            IC
-          </b-badge>
-        </template>
-        <template v-slot:cell(nextApprDt)="data">
-          <span>
-            {{ beautifyDate(data.item.nextApprDt) }}
-          </span>
-        </template>
-        <template v-slot:cell(action)="data">
-          <div class="d-flex justify-content-end no-wrap">
-            <b-button
-              variant="outline-primary"
-              class="mr-3"
-              @click="() => handleCaseClick(data.item[idSelector])"
-              >Add File</b-button
-            >
-            <b-button
-              variant="primary"
-              @click="() => handleAddFileAndViewClick(data.item[idSelector])"
-              >Add File and View</b-button
-            >
-          </div>
-        </template> -->
     </v-data-table>
-    <action-bar :selected="selectedFiles" />
-
-    <!-- <v-toolbar dense floating style="position: fixed">
-        <v-text-field
-          prepend-icon="mdi-magnify"
-          hide-details
-          single-line
-        ></v-text-field>
-
-        <v-btn icon>
-          <v-icon>mdi-crosshairs-gps</v-icon>
-        </v-btn>
-
-        <v-btn icon>
-          <v-icon>mdi-dots-vertical</v-icon>
-        </v-btn>
-      </v-toolbar> -->
-
-    <!-- <h3 class="mt-3">Files to View</h3>
-      <b-table
-        :fields="filteredFields"
-        :items="selectedFiles"
-        borderless
-        small
-        responsive="md"
-        sort-icon-left
-        striped
-      >
-        <template #head(nextApprDt)="data">
-          <span class="text-danger no-wrap">{{ data.label }}</span>
-        </template>
-        <template v-slot:cell(sealStatusCd)="data">
-          <span v-if="data.item.sealStatusCd === 'SD'" class="text-danger"
-            >(Sealed)</span
-          >
-        </template>
-        <template v-slot:cell(courtClassCd)="data">
-          <span :class="getClassColor(data.item.courtClassCd)">
-            {{ getClass(data.item.courtClassCd) }}
-          </span>
-        </template>
-        <template v-slot:cell(warrantYN)="data">
-          <b-badge
-            v-if="data.item.warrantYN === 'Y'"
-            variant="primary text-light"
-            :style="data.field.cellStyle"
-            v-b-tooltip.hover
-            title="Outstanding warrant"
-          >
-            <span>W</span>
-          </b-badge>
-        </template>
-        <template v-slot:cell(inCustodyYN)="data">
-          <b-badge
-            v-if="data.item.inCustodyYN === 'Y'"
-            variant="primary text-light"
-            :style="data.field.cellStyle"
-            v-b-tooltip.hover
-            title="In custody"
-          >
-            IC
-          </b-badge>
-        </template>
-        <template v-slot:cell(nextApprDt)="data">
-          <span>
-            {{ beautifyDate(data.item.nextApprDt) }}
-          </span>
-        </template>
-        <template v-slot:cell(action)="data">
-          <div class="d-flex justify-content-end no-wrap">
-            <b-button
-              variant="link"
-              class="remove"
-              @click="() => handleDeleteClick(data.item[idSelector])"
-            >
-              <b-icon icon="trash"></b-icon> Remove
-            </b-button>
-          </div>
-        </template>
-      </b-table>
-      <div class="my-3 bg-light p-3">
-        <div class="d-flex">
-          <b-button variant="primary" class="mr-3" @click="handleViewFilesClick"
-            >View File(s)</b-button
-          >
-          <b-button variant="outline-primary" @click="handleDeleteAllClick"
-            >Remove All Files and Start Over</b-button
-          >
-        </div> 
-      </div>-->
+    <!-- <action-bar :selected="selectedFiles" /> -->
   </div>
 </template>
 
 <script setup lang="ts">
-  import ActionBar from '@/components/shared/table/ActionBar.vue';
+  //import ActionBar from '@/components/shared/table/ActionBar.vue';
   import { beautifyDate } from '@/filters';
   import { KeyValueInfo, LookupCode } from '@/types/common';
   import { FileDetail } from '@/types/courtFileSearch';

--- a/web/src/components/criminal/CriminalAdjudicatorRestrictions.vue
+++ b/web/src/components/criminal/CriminalAdjudicatorRestrictions.vue
@@ -44,6 +44,7 @@
 <script lang="ts">
   import { useCriminalFileStore } from '@/stores';
   import { AdjudicatorRestrictionsInfoType } from '@/types/common';
+  import { type BTableSortBy } from 'bootstrap-vue-next';
   import { defineComponent, onMounted, ref } from 'vue';
 
   export default defineComponent({
@@ -54,7 +55,7 @@
         []
       );
 
-      const sortBy = ref('adjudicator');
+      const sortBy = ref<BTableSortBy[]>(['adjudicator']);
       const sortDesc = ref(false);
       const isMounted = ref(false);
 

--- a/web/src/components/criminal/CriminalDocumentsView.vue
+++ b/web/src/components/criminal/CriminalDocumentsView.vue
@@ -156,6 +156,7 @@
   import { useCommonStore, useCriminalFileStore } from '@/stores';
   import { ArchiveInfoType, DocumentRequestsInfoType } from '@/types/common';
   import { CourtDocumentType, DocumentData } from '@/types/shared';
+  import { type BTableSortBy } from 'bootstrap-vue-next';
   import {
     computed,
     defineComponent,
@@ -197,7 +198,7 @@
       const loadingPdf = ref(false);
       const activetab = ref('ALL');
       //      const tabIndex = ref(0);
-      const sortBy = ref('date');
+      const sortBy = ref<BTableSortBy[]>(['date']);
       const sortDesc = ref(true);
       //      const hoverRow = ref(-1);
       //      const hoverCol = ref(0);

--- a/web/src/components/criminal/CriminalFutureAppearancesTable.vue
+++ b/web/src/components/criminal/CriminalFutureAppearancesTable.vue
@@ -84,6 +84,7 @@
 <script lang="ts">
   import { useCriminalFileStore } from '@/stores';
   import { criminalAppearancesListType } from '@/types/criminal';
+  import { type BTableSortBy } from 'bootstrap-vue-next';
   import { defineComponent, PropType, ref } from 'vue';
   import CriminalAppearanceDetails from './CriminalAppearanceDetails.vue';
 
@@ -98,7 +99,7 @@
       },
     },
     setup(props) {
-      const sortBy = ref('date');
+      const sortBy = ref<BTableSortBy[]>(['date']);
       const sortDesc = ref(true);
       const criminalFileStore = useCriminalFileStore();
 

--- a/web/src/components/criminal/CriminalParticipants.vue
+++ b/web/src/components/criminal/CriminalParticipants.vue
@@ -101,6 +101,7 @@
 <script lang="ts">
   import { useCriminalFileStore } from '@/stores';
   import { participantListInfoType } from '@/types/criminal';
+  import { type BTableSortBy } from 'bootstrap-vue-next';
   import { defineComponent, onMounted, ref } from 'vue';
 
   export default defineComponent({
@@ -111,7 +112,7 @@
 
       const isMounted = ref(false);
       const numberOfParticipants = ref(0);
-      const sortBy = ref('name');
+      const sortBy = ref<BTableSortBy[]>(['name']);
       const sortDesc = ref(false);
 
       const fields = [

--- a/web/src/components/criminal/CriminalPastAppearancesTable.vue
+++ b/web/src/components/criminal/CriminalPastAppearancesTable.vue
@@ -93,6 +93,7 @@
 <script lang="ts">
   import { useCriminalFileStore } from '@/stores';
   import { criminalAppearancesListType } from '@/types/criminal';
+  import { type BTableSortBy } from 'bootstrap-vue-next';
   import { defineComponent, PropType, ref } from 'vue';
   import CriminalAppearanceDetails from './CriminalAppearanceDetails.vue';
 
@@ -108,7 +109,7 @@
     },
     setup(props) {
       const criminalFileStore = useCriminalFileStore();
-      const sortBy = 'dateref';
+      const sortBy = ref<BTableSortBy[]>(['dateref']);
       const sortDesc = ref(true);
 
       const defaultStyles = {

--- a/web/src/components/criminal/CriminalWitnesses.vue
+++ b/web/src/components/criminal/CriminalWitnesses.vue
@@ -103,6 +103,7 @@
   import { witnessCountInfoType, witnessListInfoType } from '@/types/criminal';
   import { witnessType } from '@/types/criminal/jsonTypes';
   import { computed, defineComponent, onMounted, ref } from 'vue';
+  import { type BTableSortBy } from 'bootstrap-vue-next';
 
   export default defineComponent({
     setup() {
@@ -119,7 +120,7 @@
       let numberOfPersonnelWitnesses = 0;
       let numberOfCivilianWitnesses = 0;
       let numberOfExpertWitnesses = 0;
-      const sortBy = ref('name');
+      const sortBy = ref<BTableSortBy[]>(['name']);
       const sortDesc = ref(false);
       const selectedType = ref('Required Only');
 

--- a/web/src/components/shared/table/ActionBar.vue
+++ b/web/src/components/shared/table/ActionBar.vue
@@ -7,9 +7,10 @@
       color="#183a4a"
       rounded
     >
-      <v-app-bar-title class="px-5"
-        >{{ selected.length }} selected</v-app-bar-title
-      >
+      <v-app-bar-title class="px-5">
+        {{ selected.length }} selected
+      </v-app-bar-title>
+      <slot></slot>
     </v-app-bar>
   </div>
 </template>

--- a/web/src/plugins/vuetify.ts
+++ b/web/src/plugins/vuetify.ts
@@ -52,5 +52,10 @@ export default createVuetify({
       dense: true,
       variant: 'outlined',
     },
+    VDataTable: {
+      hover: true,
+      showSelect: true,
+      returnObject: true,
+    }
   },
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[178](https://jag.gov.bc.ca/jira/browse/JASPER-178)**----    

## 🔨 Court file search table results 🧑‍⚖️
Necessary changes to facilitate the matching of the court search table to the wireframe!
Adjusted some of the non-working case detail tables (those are the files changed that youll see under the 'criminal' folder in this PR) as well that broke as a result of migrating to vue-bootstrap-next. More on that in 'Documentation References' section of this PR

feat: court file search table
feat: action bar slot
fix: case detail tables not displaying
refactor: upgrade court-file-result sfc to composition api
style: data table defaults

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Ran `./manage debug` and `./manage start` both locally 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Documentation References  
Reason for the `sortBy` changes
https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/table.html#sorting

## Screenshot of changes (ignore the blocked out data boxes)
![court-file-search-results](https://github.com/user-attachments/assets/78fb3506-d05f-40e1-8eb8-d97868286022)
