### PR TITLE
JASPER 262: Globally Handle Exceptions with Snackbar

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -26,6 +26,7 @@
       <v-main>
         <router-view />
       </v-main>
+      <snackbar />
     </v-app>
   </v-theme-provider>
 </template>
@@ -34,6 +35,7 @@
   import { mdiAccountCircle } from '@mdi/js';
   import { ref } from 'vue';
   import ProfileOffCanvas from './components/shared/ProfileOffCanvas.vue';
+  import Snackbar from './components/shared/Snackbar.vue';
   import { useThemeStore } from './stores/ThemeStore';
 
   const themeStore = useThemeStore();

--- a/web/src/components/shared/Snackbar.vue
+++ b/web/src/components/shared/Snackbar.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-snackbar
+    v-model="snackbarStore.isVisible"
+    :timeout="-1"
+    :color="snackbarStore.color"
+    location="bottom right"
+  >
+    <h3>{{ snackbarStore.title }}</h3>
+    <span>{{ snackbarStore.message }}</span>
+    <template v-slot:actions>
+      <v-icon class="mx-2" :icon="mdiCloseCircle" @click="close" />
+    </template>
+  </v-snackbar>
+</template>
+
+<script setup>
+  import { useSnackbarStore } from '@/stores/SnackBarStore';
+  import { mdiCloseCircle } from '@mdi/js';
+  const snackbarStore = useSnackbarStore();
+  const close = () => {
+    snackbarStore.isVisible = false;
+  };
+</script>

--- a/web/src/components/shared/Snackbar.vue
+++ b/web/src/components/shared/Snackbar.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup>
-  import { useSnackbarStore } from '@/stores/SnackBarStore';
+  import { useSnackbarStore } from '@/stores/SnackbarStore';
   import { mdiCloseCircle } from '@mdi/js';
   const snackbarStore = useSnackbarStore();
   const close = () => {

--- a/web/src/services/HttpService.ts
+++ b/web/src/services/HttpService.ts
@@ -1,10 +1,10 @@
+import { useSnackbarStore } from '@/stores/SnackbarStore';
 import axios, {
   AxiosInstance,
   AxiosRequestConfig,
   InternalAxiosRequestConfig,
 } from 'axios';
 import redirectHandlerService from './RedirectHandlerService';
-import { useSnackbarStore } from '@/stores/SnackBarStore';
 
 export interface IHttpService {
   get<T>(resource: string, queryParams?: Record<string, any>): Promise<T>;

--- a/web/src/services/HttpService.ts
+++ b/web/src/services/HttpService.ts
@@ -4,6 +4,7 @@ import axios, {
   InternalAxiosRequestConfig,
 } from 'axios';
 import redirectHandlerService from './RedirectHandlerService';
+import { useSnackbarStore } from '@/stores/SnackBarStore';
 
 export interface IHttpService {
   get<T>(resource: string, queryParams?: Record<string, any>): Promise<T>;
@@ -17,6 +18,7 @@ export interface IHttpService {
 
 export class HttpService implements IHttpService {
   readonly client: AxiosInstance;
+  snackBarStore = useSnackbarStore();
 
   constructor(baseURL: string) {
     this.client = axios.create({
@@ -47,8 +49,16 @@ export class HttpService implements IHttpService {
   private handleAuthError(error: any) {
     console.error(error);
     console.log('User unauthenticated.');
+    // todo: check for a 403 and handle it
     if (error.response && error.response.status === 401) {
       redirectHandlerService.handleUnauthorized(window.location.href);
+    } else {
+      // The user should be notified about unhandled server exceptions.
+      this.snackBarStore.showSnackbar(
+        'Something went wrong, please contact your Administrator.',
+        '#b84157',
+        'Error'
+      );
     }
     return Promise.reject(new Error(error));
   }

--- a/web/src/stores/SnackbarStore.ts
+++ b/web/src/stores/SnackbarStore.ts
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useSnackbarStore = defineStore('snackbar', () => {
+  const isVisible = ref(false);
+  const message = ref('');
+  const color = ref('success');
+  const title = ref('');
+
+  const showSnackbar = (msg = '', col = 'success', ti = '') => {
+    message.value = msg;
+    color.value = col;
+    title.value = ti;
+    isVisible.value = true;
+  };
+
+  return { isVisible, message, color, showSnackbar, title };
+});

--- a/web/src/stores/index.ts
+++ b/web/src/stores/index.ts
@@ -14,4 +14,4 @@ export { useCommonStore } from './CommonStore';
 export { useCourtFileSearchStore } from './CourtFileSearchStore';
 export { useCourtListStore } from './CourtListStore';
 export { useCriminalFileStore } from './CriminalFileStore';
-export { useSnackbarStore } from './SnackBarStore';
+export { useSnackbarStore } from './SnackbarStore';

--- a/web/src/stores/index.ts
+++ b/web/src/stores/index.ts
@@ -14,3 +14,4 @@ export { useCommonStore } from './CommonStore';
 export { useCourtFileSearchStore } from './CourtFileSearchStore';
 export { useCourtListStore } from './CourtListStore';
 export { useCriminalFileStore } from './CriminalFileStore';
+export { useSnackbarStore } from './SnackBarStore';

--- a/web/tests/components/shared/Snackbar.test.ts
+++ b/web/tests/components/shared/Snackbar.test.ts
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils';
+import { useSnackbarStore } from '@/stores/SnackBarStore';
+import { describe, it, expect, beforeEach } from 'vitest';
+import Snackbar from '@/components/shared/Snackbar.vue';
+import { setActivePinia, createPinia } from 'pinia'
+
+describe('Snackbar.vue', () => {
+    let store: ReturnType<typeof useSnackbarStore>;
+
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        store = useSnackbarStore();
+    });
+
+  it('renders snackbar with correct props', () => {
+    store.showSnackbar('Test message', 'error', 'Test title');
+    const wrapper = mount(Snackbar);
+
+    expect(wrapper.find('h3').text()).toBe('Test title');
+    expect(wrapper.text()).toContain('Test message');
+    expect(store.isVisible).toBe(true);
+  });
+
+  it('closes snackbar when close button is clicked', async () => {
+    const wrapper = mount(Snackbar);
+
+    await wrapper.find('v-snackbar__actions v-icon').trigger('click');
+
+    expect(store.isVisible).toBe(false);
+  });
+});

--- a/web/tests/components/shared/Snackbar.test.ts
+++ b/web/tests/components/shared/Snackbar.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { useSnackbarStore } from '@/stores/SnackBarStore';
+import { useSnackbarStore } from '@/stores/SnackbarStore';
 import { describe, it, expect, beforeEach } from 'vitest';
 import Snackbar from '@/components/shared/Snackbar.vue';
 import { setActivePinia, createPinia } from 'pinia'

--- a/web/tests/stores/SnackbarStore.test.ts
+++ b/web/tests/stores/SnackbarStore.test.ts
@@ -1,5 +1,5 @@
 import { setActivePinia, createPinia } from 'pinia'
-import { useSnackbarStore } from '@/stores/SnackBarStore';
+import { useSnackbarStore } from '@/stores/SnackbarStore';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('SnackBarStore', () => {

--- a/web/tests/stores/SnackbarStore.test.ts
+++ b/web/tests/stores/SnackbarStore.test.ts
@@ -1,0 +1,35 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { useSnackbarStore } from '@/stores/SnackBarStore';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('SnackBarStore', () => {
+  let store: ReturnType<typeof useSnackbarStore>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useSnackbarStore();
+  });
+
+  it('initializes with default values', () => {
+    expect(store.isVisible).toBe(false);
+    expect(store.message).toBe('');
+    expect(store.color).toBe('success');
+    expect(store.title).toBe('');
+  });
+
+  it('shows snackbar with given message, color, and title', () => {
+    store.showSnackbar('Test message', 'error', 'Test title');
+    expect(store.isVisible).toBe(true);
+    expect(store.message).toBe('Test message');
+    expect(store.color).toBe('error');
+    expect(store.title).toBe('Test title');
+  });
+
+  it('shows snackbar with default values when no arguments are passed', () => {
+    store.showSnackbar();
+    expect(store.isVisible).toBe(true);
+    expect(store.message).toBe('');
+    expect(store.color).toBe('success');
+    expect(store.title).toBe('');
+  });
+});


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[262](https://jag.gov.bc.ca/jira/browse/JASPER-262)**----    

## Description
### 💥 Global exception raising utilizing Vuetify Snackbar! 🍫

I began working on upgrading Court-list to Vuetify and noticed this page also had its own unhandled exception handling logic.
I decided to move the logic out and encapsulate it into the httpservice class itself, that way any api call made by a page that experiences a server exception will raise a [snack ](https://vuetifyjs.com/en/components/snackbars/) (toast) message the same way

feat: snackbar store
feat: raise snacks globally

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update    

## How Has This Been Tested?

- [x] Unit tested
- [x] Ran `./manage debug` and `./manage start` 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Documentation References  
https://vuetifyjs.com/en/components/snackbars/

![image](https://github.com/user-attachments/assets/a2efdd49-ad65-47e6-980d-41a976106136)
