### PR TITLE
Add support for AWS ECS Exec

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,19 +2,31 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
 # Install dependencies
 RUN apt-get update && \
-    apt-get install -y wget tar && \
+    apt-get install -y \
+            curl \
+            tar \
+            wget && \
     apt-get clean
 
-# Set environment variables
+# ==========================================================================================================================
+# Install S2I
+# --------------------------------------------------------------------------------------------------------------------------
 ENV S2I_VERSION=source-to-image-v1.4.0-d3544c7e-linux-arm64.tar.gz
-
-# Download and install S2I
 RUN wget https://github.com/openshift/source-to-image/releases/download/v1.4.0/${S2I_VERSION} -O /tmp/${S2I_VERSION} && \
     tar -xzf /tmp/${S2I_VERSION} -C /usr/local/bin && \
     rm /tmp/${S2I_VERSION}
 
 # Verify installation
 RUN s2i version
+# ==========================================================================================================================
+
+# ==========================================================================================================================
+# Install AWS Session Manager Plugin
+# --------------------------------------------------------------------------------------------------------------------------
+RUN curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb" && \
+    dpkg -i session-manager-plugin.deb && \
+    rm session-manager-plugin.deb
+# ==========================================================================================================================
 
 # Set the default command
 CMD ["bash"]

--- a/infrastructure/cloud/README.md
+++ b/infrastructure/cloud/README.md
@@ -7,9 +7,9 @@ This repository includes Terraform scripts for provisioning and managing JASPER'
 1. Navigate to [BC Gov's AWS instance](https://login.nimbus.cloud.gov.bc.ca/api).
 2. Configure AWS CLI
 
-```
-aws configure sso
-```
+   ```
+   aws configure sso
+   ```
 
 3. Follow instructions from CLI.
 
@@ -18,21 +18,21 @@ aws configure sso
 1. Navigate to the desired environment (`/dev` or `/test`) where you want the Terraform scripts to be executed.
 2. Initialize the working directory.
 
-```
-terraform init -backend-config=backend.tfvars
-```
+   ```
+   terraform init -backend-config=backend.tfvars
+   ```
 
 3. Preview the changes that Terraform plans to deploy.
 
-```
-terraform plan -var-file="./<environment>.tfvars"
-```
+   ```
+   terraform plan -var-file="./<environment>.tfvars"
+   ```
 
 4. If everything looks good, execute the actions propsed Terraform plan.
 
-```
-terraform apply -var-file="./<environment>.tfvars"
-```
+   ```
+   terraform apply -var-file="./<environment>.tfvars"
+   ```
 
 ## Deploying Terraform changes via Github Actions
 
@@ -42,3 +42,40 @@ terraform apply -var-file="./<environment>.tfvars"
 4. Click `Run workflow` dropdown.
 5. Select working branch
 6. Click `Run workflow` button.
+
+## Connecting to an ECS container
+
+The DevContainer for the project includes the tools needed to shell into an ECS container. This includes the `aws` cli and the AWS Session Manager Plugin.
+
+Following is and example of the steps needed to shell into a container.
+
+1. Login to the [BC Gov's AWS instance](https://login.nimbus.cloud.gov.bc.ca/api) portal.
+2. Get the credentials for the desired environment and paste them into a DevContainer terminal session.
+3. Enable the Execute Command on the continer(s).
+   ```
+   aws ecs update-service --cluster jasper-app-cluster-dev --service jasper-api-ecs-service-dev --enable-execute-command --force-new-deployment
+   ```
+4. Once the new task rolls out, verify the execute command is enabled.
+   ```
+   aws ecs describe-tasks \
+       --cluster jasper-app-cluster-dev  \
+       --tasks arn:aws:ecs:ca-central-1:381491824201:task/jasper-app-cluster-dev/5f8eeabe7e1943c5ba93c3ae55d48933
+   ```
+   Look for the following in the output:
+   ```
+       ...
+       "enableExecuteCommand": true,
+       ...
+   ```
+5. Shell into the container
+   ```
+   aws ecs execute-command --cluster jasper-app-cluster-dev \
+       --task arn:aws:ecs:ca-central-1:381491824201:task/jasper-app-cluster-dev/5f8eeabe7e1943c5ba93c3ae55d48933 \
+       --interactive \
+       --command "/bin/sh"
+   ```
+6. When complete `exit` the container.
+7. Disable the Execute Command on the continer(s).
+   ```
+   aws ecs update-service --cluster jasper-app-cluster-dev --service jasper-api-ecs-service-dev --disable-execute-command --force-new-deployment
+   ```


### PR DESCRIPTION
- Adds the AWS Session Manager Plugin required to use `aws ecs execute-command` to shell into running containers.
- Adds example documentation.