### PR TITLE
JASPER: Add back in accidentally removed V-Data-Table default

### DIFF
--- a/web/src/plugins/vuetify.ts
+++ b/web/src/plugins/vuetify.ts
@@ -63,5 +63,10 @@ export default createVuetify({
       label: 'Date',
       clearable: false,
     },
+    VDataTable: {
+      hover: true,
+      showSelect: true,
+      returnObject: true,
+    },
   },
 });


### PR DESCRIPTION
##  🔧Add back in mistakenly removed Vuetify data table default 🛠️ 

A previous [PR ](https://github.com/bcgov/jasper/pull/135/files#diff-b9409e644568d2b55e23be531e98022fa61119ad2f4ea1afbf8bfde23ddaac4b) accidentally removed the defaults for Vuetify's data-table.
This PR adds it back in

fix: add back in Vuetify data table default