### PR TITLE
JASPER 268: Fix Criminal-document download functionality

### DIFF
--- a/.github/workflows/actions/build-web/action.yml
+++ b/.github/workflows/actions/build-web/action.yml
@@ -32,7 +32,6 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working_directory }}
 
-    # Unit test is not configured in SCC and will be worked on separately.
-    - run: npm run test --if-present
+    - run: npm run test
       shell: bash
       working-directory: ${{ inputs.working_directory }}

--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -1,23 +1,10 @@
+
 <template>
   <!-- todo: Extract this out to more generic location -->
   <v-overlay :opacity="0.333" v-model="isLoading" />
-  <b-card
-    body-class="px-0"
-    bg-variant="light"
-    v-if="isLookupDataMounted && !isLookupDataReady"
-  >
-    <b-card style="min-height: 40px">
-      <span v-if="errorCode != '0'">
-        <span v-if="errorCode === '403'">
-          You are not authorized to access this page.
-        </span>
-        <span v-else>
-          Server is not responding.
-          <b>({{ errorText }} "{{ errorCode }}")</b></span
-        >
-      </span>
-      <span v-else> No Court File Search Found. </span>
-    </b-card>
+
+  <b-card style="min-height: 40px" v-if="errorCode > 0 && errorCode == '403'">
+    <span> You are not authorized to access this page. </span>
   </b-card>
   <!------------------------------------------------------->
   <v-banner style="background-color: #62d3a4; color: #183a4a">

--- a/web/src/components/criminal/CriminalDocumentsView.vue
+++ b/web/src/components/criminal/CriminalDocumentsView.vue
@@ -377,8 +377,8 @@
 
       const getNameOfParticipant = (num) => {
         commonStore.updateDisplayName({
-          lastName: participantFiles[num].lastName,
-          givenName: participantFiles[num].firstName,
+          lastName: participantFiles[num]?.lastName || '',
+          givenName: participantFiles[num]?.firstName || '',
         });
         return commonStore.displayName;
       };

--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -5,10 +5,18 @@ import { v4 as uuidv4 } from 'uuid';
 export default {
   convertToBase64Url(inputText: string): string {
     const base64 = btoa(inputText);
-    return base64
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/((?=(=+))\2)+$/, '');
+    return base64.replace(/[+/=]/g, (char) => {
+      switch (char) {
+      case '+':
+        return '-';
+      case '/':
+        return '_';
+      case '=':
+        return '';
+      default:
+        return char;
+      }
+    });
   },
   openDocumentsPdf(
     documentType: CourtDocumentType,

--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -5,7 +5,10 @@ import { v4 as uuidv4 } from 'uuid';
 export default {
   convertToBase64Url(inputText: string): string {
     const base64 = btoa(inputText);
-    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    return base64
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/((?=(=+))\2)+$/, '');
   },
   openDocumentsPdf(
     documentType: CourtDocumentType,

--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -1,22 +1,25 @@
-import { CourtDocumentType, DocumentData } from "@/types/shared"
-import { splunkLog } from "@/utils/utils"
-import base64url from "base64url"
-import { v4 as uuidv4 } from "uuid"
+import { CourtDocumentType, DocumentData } from '@/types/shared';
+import { splunkLog } from '@/utils/utils';
+import { v4 as uuidv4 } from 'uuid';
 
 export default {
+  convertToBase64Url(inputText: string): string {
+    const base64 = btoa(inputText);
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  },
   openDocumentsPdf(
     documentType: CourtDocumentType,
     documentData: DocumentData
   ): void {
     const fileName = this.generateFileName(documentType, documentData).replace(
       /\//g,
-      "_"
-    )
-    const isCriminal = documentType == CourtDocumentType.Criminal
+      '_'
+    );
+    const isCriminal = documentType == CourtDocumentType.Criminal;
     const documentId = documentData.documentId
-      ? base64url(documentData.documentId)
-      : documentData.documentId
-    const correlationId = uuidv4()
+      ? this.convertToBase64Url(documentData.documentId)
+      : documentData.documentId;
+    const correlationId = uuidv4();
 
     switch (documentType) {
       case CourtDocumentType.CSR:
@@ -26,8 +29,8 @@ export default {
           }/${encodeURIComponent(fileName)}?vcCivilFileId=${
             documentData.fileId
           }`
-        )
-        break
+        );
+        break;
       case CourtDocumentType.ROP:
         window.open(
           `${
@@ -39,8 +42,8 @@ export default {
           }&courtLevelCode=${documentData.courtLevel}&courtClassCode=${
             documentData.courtClass
           }`
-        )
-        break
+        );
+        break;
       default:
         this.openRequestedTab(
           `${
@@ -51,8 +54,8 @@ export default {
             documentData.fileId
           }&CorrelationId=${correlationId}`,
           correlationId
-        )
-        break
+        );
+        break;
     }
   },
 
@@ -62,53 +65,53 @@ export default {
   ): string {
     const locationAbbreviation = (
       documentData.location.match(/[A-Z]/g) || []
-    ).join("")
+    ).join('');
     switch (documentType) {
       case CourtDocumentType.Civil:
-        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.dateFiled}-${documentData.documentId}.pdf`
+        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.dateFiled}-${documentData.documentId}.pdf`;
       case CourtDocumentType.ProvidedCivil:
-        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.appearanceDate}-${documentData.partyName}.pdf`
+        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.appearanceDate}-${documentData.partyName}.pdf`;
       case CourtDocumentType.CSR:
-        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.appearanceDate}.pdf`
+        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.appearanceDate}.pdf`;
       case CourtDocumentType.Criminal:
-        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.courtClass}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.dateFiled}-${documentData.documentId}.pdf`
+        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.courtClass}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.dateFiled}-${documentData.documentId}.pdf`;
       case CourtDocumentType.ROP:
-        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.courtClass}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.partId}.pdf`
+        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.courtClass}-${documentData.fileNumberText}-${documentData.documentDescription}-${documentData.partId}.pdf`;
       case CourtDocumentType.CivilZip:
-        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.fileNumberText}-documents.zip`
+        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.fileNumberText}-documents.zip`;
       case CourtDocumentType.CriminalZip:
-        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.courtClass}-${documentData.fileNumberText}-documents.zip`
+        return `${locationAbbreviation}-${documentData.courtLevel}-${documentData.courtClass}-${documentData.fileNumberText}-documents.zip`;
       default:
-        throw Error(`No file structure for type: ${documentType}`)
+        throw Error(`No file structure for type: ${documentType}`);
     }
   },
 
   openRequestedTab(url, correlationId) {
-    const start = new Date()
-    const startStr = start.toLocaleString("en-US", {
-      timeZone: "America/Vancouver"
-    })
-    const startMsg = `Request Tracking - Frontend request to API - CorrelationId: ${correlationId} Start time: ${startStr}`
+    const start = new Date();
+    const startStr = start.toLocaleString('en-US', {
+      timeZone: 'America/Vancouver',
+    });
+    const startMsg = `Request Tracking - Frontend request to API - CorrelationId: ${correlationId} Start time: ${startStr}`;
     //console.log(startMsg);
-    splunkLog(startMsg)
+    splunkLog(startMsg);
 
-    const windowObjectReference = window.open(url)
+    const windowObjectReference = window.open(url);
     if (windowObjectReference !== null) {
-      const end = new Date()
-      const endStr = start.toLocaleString("en-US", {
-        timeZone: "America/Vancouver"
-      })
+      const end = new Date();
+      const endStr = start.toLocaleString('en-US', {
+        timeZone: 'America/Vancouver',
+      });
 
-      const duration = (end.getTime() - start.getTime()) / 1000
-      const endMsg = `Request Tracking - API response received - CorrelationId: ${correlationId} End time: ${endStr} Duration: ${duration}s`
+      const duration = (end.getTime() - start.getTime()) / 1000;
+      const endMsg = `Request Tracking - API response received - CorrelationId: ${correlationId} End time: ${endStr} Duration: ${duration}s`;
 
       // eslint-disable-next-line
       windowObjectReference.onload = (event) => {
-        if (windowObjectReference.document.readyState === "complete") {
+        if (windowObjectReference.document.readyState === 'complete') {
           //console.log(endMsg);
-          splunkLog(endMsg)
+          splunkLog(endMsg);
         }
-      }
+      };
     }
-  }
-}
+  },
+};


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[268](https://jag.gov.bc.ca/jira/browse/JASPER-268)**----    

## 1️⃣ Use our own base64url logic utilizing `btoa` 0️⃣
The package we currently rely on to base64 our urls has [issues](https://github.com/brianloveswords/base64url/issues) regarding latest JS frameworks.
This PR forgoes that package and uses our own base64url functionality.

We should at some point completely deprecate this package from the project and use the method I introduced here.

fix: criminal document download functionality
refactor: remove unneeded error handling from courtfilesearch
refactor: prettify shared.ts
build: remove if exists flag from unit-tests in FE build

Fixes # [268](https://jag.gov.bc.ca/jira/browse/JASPER-268)  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested locally with `./manage debug` and `./manage start`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Documentation References  
base64url package -https://github.com/brianloveswords/base64url