### PR TITLE
[DRAFT] JASPER 269: Move Data-Table count from Footer to top

### DIFF
--- a/web/src/components/courtfilesearch/CourtFileSearchResult.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchResult.vue
@@ -1,5 +1,14 @@
 <template>
   <div>
+    <v-row>
+      <v-col>
+        <span>
+          <strong>
+            {{ searchResults.length ? resultsText : '&nbsp;' }}
+          </strong>
+        </span>
+      </v-col>
+    </v-row>
     <v-banner bg-color="#efedf5">
       <h3 class="px-2 py-2">Search Results</h3>
     </v-banner>
@@ -7,7 +16,7 @@
       <v-data-table
         v-model="selectedItems"
         :group-by
-        :items-per-page
+        :items-per-page="maxItemsPerPage"
         :headers
         :items="searchResults"
         :item-value="idSelector"
@@ -34,6 +43,7 @@
             </td>
           </tr>
         </template>
+        <template v-slot:bottom />
       </v-data-table>
     </v-skeleton-loader>
     <action-bar :selected="selectedItems" @clicked="handleViewFilesClick">
@@ -77,7 +87,13 @@
   }>();
 
   // The reason we use 103 instead of 100 is due to the ability to have up to 3 group headers in the table
-  const itemsPerPage = 103;
+  const maxItemsPerPage = 103;
+
+  const resultsText = computed(
+    () =>
+      `${props.searchResults.length ? props.searchResults.length + ' results' : ''}`
+  );
+
   const selectedItems = ref<FileDetail[]>([]);
   const idSelector = computed(() =>
     props.isCriminal ? 'mdocJustinNo' : 'physicalFileId'

--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -157,7 +157,7 @@
       </v-row>
     </v-form>
     <court-file-search-result
-      class="mb-5 mt-10"
+      class="mb-5 mt-2"
       :isLookupDataMounted="isLookupDataMounted"
       :isLookupDataReady="isLookupDataReady"
       :courtRooms="courtRooms"


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[269](https://jag.gov.bc.ca/jira/browse/JASPER-269)**----    

## 🔢 Move the count out of the footer and remove footer entirely 🦶
The footer housed the total count of the table and the pagination commands.
Due to the fact the API caps a return out at 100 records I really dont see pagination being useful to us yet.
I moved the record count to the top to match the wireframes.

refactor: display result count at top of table
refactor: remove v-data-table footer

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Ran `./manage debug` and `./manage start`

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules   