### PR TITLE
JASPER 270: Location/File# required when searching for File#

### DIFF
--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -234,6 +234,8 @@
   }
 
   onMounted(async () => {
+    // We want to clear the data-table on page load
+    courtFileSearchStore.clearSelectedFiles();
     await loadData();
     isLoading.value = false;
   });

--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -1,4 +1,3 @@
-
 <template>
   <!-- todo: Extract this out to more generic location -->
   <v-overlay :opacity="0.333" v-model="isLoading" />
@@ -70,6 +69,10 @@
             :items="courtRooms"
             item-title="text"
             label="Location"
+            :required="true"
+            :error-messages="
+              errors.isMissingLocation ? ['Location is required'] : []
+            "
           />
         </v-col>
         <v-col cols="2">
@@ -219,6 +222,7 @@
     isMissingFileNo: false,
     isMissingSurname: false,
     isMissingOrg: false,
+    isMissingLocation: false,
   });
 
   const locationService = inject<LocationService>('locationService');
@@ -276,6 +280,9 @@
 
     errors.isMissingFileNo =
       searchCriteria.searchBy === 'fileNumber' && !searchCriteria.fileNumberTxt;
+    errors.isMissingLocation =
+      searchCriteria.searchBy === 'fileNumber' &&
+      !searchCriteria.fileHomeAgencyId;
     errors.isMissingSurname =
       searchCriteria.searchBy === 'lastName' && !searchCriteria.lastName;
     errors.isMissingOrg =
@@ -351,6 +358,7 @@
     errors.isMissingFileNo = false;
     errors.isMissingSurname = false;
     errors.isMissingOrg = false;
+    errors.isMissingLocation = false;
   };
 
   const loadClasses = () => {


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[270](https://jira.justice.gov.bc.ca/browse/JASPER-270)**----    

## 🌟 Require # and Location when searching for File# and refresh court-file-search data-table on page load 🔃

When searching for File number we want to require File number and Location.
Also snuck in a change to force refresh the v-data-table's data by dropping the store on page refresh.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x]  Ran `./manage debug` and `./manage start`
- [x] Unit tests passing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

![image](https://github.com/user-attachments/assets/30562d0c-cd67-49e3-8c45-4143b90375ff)
