### PR TITLE
JASPER 287: Fix inability to filter Family/Claims by FileNumber

### DIFF
--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -91,7 +91,7 @@
         </v-col>
       </v-row>
       <v-row>
-        <v-col cols="2">
+        <v-col cols="2" v-if="searchCriteria.isCriminal">
           <v-select
             label="Class"
             :items="classOptions"
@@ -401,7 +401,11 @@
 
     if (searchCriteria.searchBy === 'fileNumber') {
       queryParams['searchMode'] = SearchModeEnum.FileNo;
-      queryParams['fileNumberTxt'] = searchCriteria.fileNumberTxt;
+      if (searchCriteria.isCriminal) {
+        queryParams['fileNumberTxt'] = searchCriteria.fileNumberTxt;
+      } else {
+        queryParams['fileNumber'] = searchCriteria.fileNumberTxt;
+      }
 
       if (searchCriteria.filePrefixTxt) {
         queryParams['filePrefixTxt'] = searchCriteria.filePrefixTxt;


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[287](https://jira.justice.gov.bc.ca/browse/JASPER-287)**----    

## Description
We were filtering for the wrong file-number search criteria when the class was set to anything but criminal

fix: filter by fileNumber when non criminal search
refactor: hide class dropdown when non criminal search

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran `./manage debug` and `./manage start`


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


### Screenshot of fix, blackbox to hide details, but you can see a value is in the table
![image](https://github.com/user-attachments/assets/8872e3fa-2eef-4c6c-8f29-d01e9fc09b54)
