### PR TITLE
JASPER-291: Use SSM Parameter to store the latest deployed image name

### DIFF
--- a/.github/workflows/actions/deploy-app/action.yml
+++ b/.github/workflows/actions/deploy-app/action.yml
@@ -104,6 +104,11 @@ runs:
         container-name: ${{ steps.vars.outputs.container_name }}
         image: "${{ steps.vars.outputs.full_ecr_repo_url }}:${{ inputs.image_name }}-${{ inputs.short_sha }}"
 
+    - name: Update SSM Param Store
+      shell: bash
+      run: |
+        aws ssm put-parameter --name "/images/${{ inputs.app_name }}-${{ inputs.tier_name }}-image-param-${{ inputs.environment }}" --value "${{ inputs.image_name }}-${{ inputs.short_sha }}" --type "String" --overwrite
+
     - name: Deploy Amazon ECS task definition
       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:

--- a/infrastructure/cloud/modules/ECS/TaskDefinition/variables.tf
+++ b/infrastructure/cloud/modules/ECS/TaskDefinition/variables.tf
@@ -63,12 +63,6 @@ variable "kms_key_arn" {
   type        = string
 }
 
-variable "image_name" {
-  description = "Image name that will be attached to the Task Definition"
-  type        = string
-  default     = "dummy-image"
-}
-
 variable "log_group_name" {
   description = "The Cloudwatch Log Group Name"
   type        = string


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JIRA-291

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-291

## Description
- Updates to deploy app pipelines to store the recently deployed `web` or `api` image to AWS Param Store
- Updated Terraform code to retrieve the saved image and use it on the ECS TD when infra code is deployed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Deployed working branch to DEV environment

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
