### PR TITLE
JASPER 267: Court-list auto-refresh and message

### DIFF
--- a/web/src/components/courtlist/CourtListSearch.vue
+++ b/web/src/components/courtlist/CourtListSearch.vue
@@ -124,19 +124,12 @@
   const searchAllowed = ref(true);
   const selectedCourtRoom = ref();
   const formSubmit = ref(false);
-  // Timer stuff //////
-  let searchInterval;
-  let warningInterval;
   const TEN_MINUTES = 600000;
   const NINE_MINUTES = 540000;
   const ONE_MINUTE = 60000;
-  const THIRTY_SECONDS = 30000;
-  const TWENTY_SECONDS = 20000;
-  const TEN_SECONDS = 10000;
   const courtRefreshInterval = TEN_MINUTES;
   const warningRefreshInterval = NINE_MINUTES;
   const warningTime = ONE_MINUTE;
-  /////////////////////
   const schedule = ref('room_schedule');
   const shortHandDate = computed(() =>
     date.value ? date.value.toISOString().substring(0, 10) : ''
@@ -150,6 +143,8 @@
   const locationsAndCourtRooms = ref<LocationInfo[]>();
   const locationsService = inject<LocationService>('locationService');
   const snackBarStore = useSnackbarStore();
+  let searchInterval: NodeJS.Timeout;
+  let warningInterval: NodeJS.Timeout;
 
   watch(
     appliedDate,

--- a/web/src/components/courtlist/CourtListSearch.vue
+++ b/web/src/components/courtlist/CourtListSearch.vue
@@ -93,17 +93,26 @@
   import { LocationService } from '@/services';
   import { HttpService } from '@/services/HttpService';
   import { useCommonStore, useCourtListStore } from '@/stores';
+  import { useSnackbarStore } from '@/stores/SnackbarStore';
   import { LocationInfo } from '@/types/courtlist';
   import { courtListType } from '@/types/courtlist/jsonTypes';
   import { mdiClose } from '@mdi/js';
-  import { computed, inject, onMounted, reactive, ref, watch } from 'vue';
+  import {
+    computed,
+    inject,
+    onMounted,
+    onUnmounted,
+    reactive,
+    ref,
+    watch,
+  } from 'vue';
 
   // Component v-models
   const showDropdown = defineModel<boolean>('showDropdown');
   const isSearching = defineModel<boolean>('isSearching');
   const date = defineModel<Date>('date');
   const appliedDate = defineModel<Date | null>('appliedDate');
-  
+
   const emit = defineEmits(['courtListSearched']);
   const GREEN = '#62d3a4';
   const commonStore = useCommonStore();
@@ -115,6 +124,19 @@
   const searchAllowed = ref(true);
   const selectedCourtRoom = ref();
   const formSubmit = ref(false);
+  // Timer stuff //////
+  let searchInterval;
+  let warningInterval;
+  const TEN_MINUTES = 600000;
+  const NINE_MINUTES = 540000;
+  const ONE_MINUTE = 60000;
+  const THIRTY_SECONDS = 30000;
+  const TWENTY_SECONDS = 20000;
+  const TEN_SECONDS = 10000;
+  const courtRefreshInterval = TEN_MINUTES;
+  const warningRefreshInterval = NINE_MINUTES;
+  const warningTime = ONE_MINUTE;
+  /////////////////////
   const schedule = ref('room_schedule');
   const shortHandDate = computed(() =>
     date.value ? date.value.toISOString().substring(0, 10) : ''
@@ -127,6 +149,7 @@
   const httpService = inject<HttpService>('httpService');
   const locationsAndCourtRooms = ref<LocationInfo[]>();
   const locationsService = inject<LocationService>('locationService');
+  const snackBarStore = useSnackbarStore();
 
   watch(
     appliedDate,
@@ -139,6 +162,10 @@
     { immediate: true }
   );
 
+  watch([selectedCourtRoom, schedule, selectedCourtLocation, date], () =>
+    setupAutoRefresh()
+  );
+
   if (!httpService) {
     throw new Error('Service is undefined.');
   }
@@ -147,6 +174,8 @@
     await getListOfAvailableCourts();
     isLoading.value = false;
   });
+
+  onUnmounted(() => clearTimers());
 
   const getListOfAvailableCourts = async () => {
     locationsAndCourtRooms.value = await locationsService?.getLocations(true);
@@ -185,6 +214,7 @@
         isDataReady.value = true;
         isSearching.value = false;
         formSubmit.value = false;
+        setupAutoRefresh();
       });
   };
 
@@ -207,5 +237,34 @@
     searchAllowed.value = false;
     appliedDate.value = date.value ?? null;
     getCourtListDetails();
+  };
+
+  const setupAutoRefresh = () => {
+    clearTimers();
+    searchInterval = setInterval(() => {
+      if (appliedDate.value) {
+        searchForCourtList(true);
+      }
+    }, courtRefreshInterval);
+    warningInterval = setInterval(() => {
+      if (appliedDate.value) {
+        showWarning();
+      }
+    }, warningRefreshInterval);
+  };
+
+  const showWarning = () => {
+    snackBarStore.showSnackbar(
+      'This page will refresh in 1 minute to ensure you see the latest updates.',
+      '#b4e6ff',
+      '🔄 Heads-up!',
+      warningTime
+    );
+  };
+
+  const clearTimers = () => {
+    clearInterval(searchInterval);
+    clearInterval(warningInterval);
+    snackBarStore.hideSnackbar();
   };
 </script>

--- a/web/src/components/courtlist/CourtListSearch.vue
+++ b/web/src/components/courtlist/CourtListSearch.vue
@@ -242,7 +242,7 @@
       }
     }, courtRefreshInterval);
     warningInterval = setInterval(() => {
-      if (appliedDate.value) {
+      if (appliedDate.value && !isSearching.value) {
         showWarning();
       }
     }, warningRefreshInterval);

--- a/web/src/components/shared/Snackbar.vue
+++ b/web/src/components/shared/Snackbar.vue
@@ -1,7 +1,7 @@
 <template>
   <v-snackbar
     v-model="snackbarStore.isVisible"
-    :timeout="15000"
+    :timeout="snackbarStore.timeout"
     :color="snackbarStore.color"
     location="bottom right"
   >

--- a/web/src/stores/SnackbarStore.ts
+++ b/web/src/stores/SnackbarStore.ts
@@ -6,13 +6,27 @@ export const useSnackbarStore = defineStore('snackbar', () => {
   const message = ref('');
   const color = ref('success');
   const title = ref('');
+  const timeout = ref<number>();
 
-  const showSnackbar = (msg = '', col = 'success', ti = '') => {
+  const showSnackbar = (msg = '', col = 'success', ti = '', time = 15000) => {
     message.value = msg;
     color.value = col;
     title.value = ti;
     isVisible.value = true;
+    timeout.value = time;
   };
 
-  return { isVisible, message, color, showSnackbar, title };
+  const hideSnackbar = () => {
+    isVisible.value = false;
+  };
+
+  return {
+    isVisible,
+    message,
+    color,
+    showSnackbar,
+    hideSnackbar,
+    title,
+    timeout,
+  };
 });

--- a/web/tests/components/courtList/CourtListSearch.test.ts
+++ b/web/tests/components/courtList/CourtListSearch.test.ts
@@ -146,8 +146,6 @@ describe('CourtListSearch.vue', () => {
       name: 'Location 1',
       courtRooms: [{ room: 'Room 1' }],
     };
-    wrapper.vm.selectedCourtRoom = 'Room 1';
-    wrapper.vm.date = new Date('2023-01-01');
     wrapper.vm.schedule = 'my_schedule';
     wrapper.vm.appliedDate = new Date();
 
@@ -162,13 +160,31 @@ describe('CourtListSearch.vue', () => {
       name: 'Location 1',
       courtRooms: [{ room: 'Room 1' }],
     };
-    wrapper.vm.selectedCourtRoom = 'Room 1';
-    wrapper.vm.date = new Date('2023-01-01');
     wrapper.vm.schedule = 'my_schedule';
     wrapper.vm.appliedDate = new Date();
 
+    await vi.advanceTimersByTimeAsync(NINE_MINUTES);
+    expect(snackbarStore.isVisible).toBe(true);
+    await vi.advanceTimersByTimeAsync(ONE_MINUTE);
+    expect(snackbarStore.isVisible).toBe(false);
+  });
+
+
+  it(`searches for new court-list data after ${TEN_MINUTES} ms`, async () => {
+    wrapper.vm.selectedCourtLocation = {
+      locationId: 1,
+      name: 'Location 1',
+      courtRooms: [{ room: 'Room 1' }],
+    };
+    wrapper.vm.schedule = 'my_schedule';
+    wrapper.vm.appliedDate = new Date('2023-01-01');
+    wrapper.vm.date = new Date('2023-01-01');
+    wrapper.vm.selectedCourtRoom = 'Room 1';
+
     await vi.advanceTimersByTimeAsync(TEN_MINUTES);
 
-    expect(snackbarStore.isVisible).toBe(false);
+    expect(httpService.get).toHaveBeenCalledWith(
+      'api/courtlist/court-list?agencyId=1&roomCode=Room 1&proceeding=2023-01-01'
+    );
   });
 });

--- a/web/tests/stores/SnackbarStore.test.ts
+++ b/web/tests/stores/SnackbarStore.test.ts
@@ -15,14 +15,16 @@ describe('SnackBarStore', () => {
     expect(store.message).toBe('');
     expect(store.color).toBe('success');
     expect(store.title).toBe('');
+    expect(store.timeout).toBe(undefined);
   });
 
-  it('shows snackbar with given message, color, and title', () => {
-    store.showSnackbar('Test message', 'error', 'Test title');
+  it('shows snackbar with given arguments', () => {
+    store.showSnackbar('Test message', 'error', 'Test title', 20000);
     expect(store.isVisible).toBe(true);
     expect(store.message).toBe('Test message');
     expect(store.color).toBe('error');
     expect(store.title).toBe('Test title');
+    expect(store.timeout).toBe(20000);
   });
 
   it('shows snackbar with default values when no arguments are passed', () => {
@@ -31,5 +33,6 @@ describe('SnackBarStore', () => {
     expect(store.message).toBe('');
     expect(store.color).toBe('success');
     expect(store.title).toBe('');
+    expect(store.timeout).toBe(15000);
   });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[267](https://jira.justice.gov.bc.ca/browse/JASPER-267)**----    

## 🔃 Auto-refresh data after 10 minutes and warn the user ⚠️

This PR implements auto refreshing into the court-list page. After 9 minutes of inactivity (no adjusting filters, no searching or swapping days) the page will display a notification letting the user know that in 1 minute the page will refresh. After that 1 minute is up, the page will take the current filters and make a query.
If 9 minutes pass and the warning is visible and the user takes an action on the page, all timers will be pushed back 10 minutes and the warning snack message will be hidden.
If more timer work is needed in JASPER then I will extract this logic out to it's own component(s).

feat: auto refresh court-list after 10 minutes
feat: show warning to user refresh will happen after 9 minutes
feat: snackbar now accepts a timeout param

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tested
- [x] Ran `./manage debug` and `./manage start`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules  
 
## Documentation References  
https://vuetifyjs.com/en/components/snackbars/

https://github.com/user-attachments/assets/435d9379-e129-4ecd-841c-919d96b63723
