### PR TITLE
JASPER 238: Court-list data filter

### DIFF
--- a/web/src/components/courtlist/CourtList.vue
+++ b/web/src/components/courtlist/CourtList.vue
@@ -45,7 +45,8 @@
         class="w-100"
       >
         <court-list-card :cardInfo="pairing.card" />
-        <v-data-table
+        <!-- Wait until we can get real data back before enabling data-table -->
+        <!-- <v-data-table
           v-model="selectedItems"
           :items="pairing.table"
           :headers
@@ -54,7 +55,7 @@
           class="pb-5"
         >
           <template v-slot:bottom />
-        </v-data-table>
+        </v-data-table> -->
       </template>
     </v-skeleton-loader>
   </v-container>
@@ -76,7 +77,6 @@
   const search = ref();
   const selectedFilesFilter = ref();
   const selectedAMPMFilter = ref();
-  const selectedItems = ref();
   const cardTablePairings = ref<{ card: CourtListCardInfo; table: any }[]>([]);
   const filesFilterMap: { [key: string]: (appearance: any) => boolean } = {
     Complete: (appearance: any) => appearance.isComplete,
@@ -110,10 +110,6 @@
         })
       : ''
   );
-  const headers = ref([
-    { title: 'File Number', key: 'courtFileNumber' },
-    { title: 'Accused/Parties', key: 'accusedNm' },
-  ]);
 
   const httpService = inject<HttpService>('httpService');
   if (!httpService) {

--- a/web/src/components/courtlist/CourtList.vue
+++ b/web/src/components/courtlist/CourtList.vue
@@ -21,7 +21,7 @@
   </banner>
 
   <v-expand-transition>
-    <v-card v-show="showDropdown" height="100" elevation="16">
+    <v-card v-show="showDropdown" height="100" elevation="7">
       <court-list-search
         v-model:date="selectedDate"
         v-model:isSearching="searchingRequest"

--- a/web/src/components/courtlist/CourtListSearch.vue
+++ b/web/src/components/courtlist/CourtListSearch.vue
@@ -1,6 +1,6 @@
 <template>
   <v-expand-transition>
-    <v-card v-show="showDropdown" class="mx-auto" height="100" elevation="15">
+    <v-card v-show="showDropdown" class="mx-auto" height="100">
       <v-container>
         <v-form @submit.prevent="searchForCourtList(true)">
           <v-row class="py-1">

--- a/web/src/components/courtlist/CourtListTableSearch.vue
+++ b/web/src/components/courtlist/CourtListTableSearch.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-row class="pb-3">
+    <v-col cols="4">
+      <v-text-field
+        id="search"
+        v-model="search"
+        title="Search"
+        label="Search"
+        variant="outlined"
+        clearable
+        hide-details
+        single-line
+        :prepend-inner-icon="mdiMagnify"
+      />
+    </v-col>
+    <v-col cols="2">
+      <v-select
+        v-model="selectedFiles"
+        label="Files"
+        placeholder="All files"
+        :items="['To be called', 'Complete', 'Cancelled']"
+      >
+      </v-select>
+    </v-col>
+    <v-col cols="2">
+      <v-select
+        v-model="selectedAMPM"
+        label="Time"
+        placeholder="AM and PM"
+        :items="['AM', 'PM']"
+      >
+      </v-select>
+    </v-col>
+    <v-col cols="2">
+      <action-buttons :showSearch="false" size="large" @reset="reset" />
+    </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+  import { mdiMagnify } from '@mdi/js';
+  import ActionButtons from '../shared/Form/ActionButtons.vue';
+
+  const selectedFiles = defineModel<string>('filesFilter');
+  const selectedAMPM = defineModel<string>('AMPMFilter');
+  const search = defineModel<string>('search');
+
+  const reset = () => {
+    selectedFiles.value = undefined;
+    selectedAMPM.value = undefined;
+    search.value = undefined;
+  };
+</script>

--- a/web/src/components/shared/Banner.vue
+++ b/web/src/components/shared/Banner.vue
@@ -1,8 +1,8 @@
 <template>
-  <v-banner :style="{ backgroundColor: bgColor, color: color }">
+  <v-banner :style="{ backgroundColor: bgColor}">
     <v-row class="my-1">
       <v-col cols="9">
-        <h3>
+        <h3 :style="{ color: color }">
           {{ title }}
           <slot name="left" />
         </h3>

--- a/web/tests/components/courtList/CourtListTableSearch.test.ts
+++ b/web/tests/components/courtList/CourtListTableSearch.test.ts
@@ -1,0 +1,14 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import CourtListTableSearch from 'CMP/courtlist/CourtListTableSearch.vue';
+
+describe('CourtListTableSearch.vue', () => {
+    it('resets filters when reset button is clicked', async () => {
+        const wrapper = mount(CourtListTableSearch);
+        await wrapper.find('v-btn').trigger('click');
+
+        expect(wrapper.vm.selectedFiles).toBeUndefined();
+        expect(wrapper.vm.selectedAMPM).toBeUndefined();
+        expect(wrapper.vm.search).toBeUndefined();
+    });
+});

--- a/web/tests/components/shared/Banner.test.ts
+++ b/web/tests/components/shared/Banner.test.ts
@@ -23,7 +23,8 @@ describe('Banner.vue', () => {
             },
         });
         const banner = wrapper.find('v-banner');
+        const header = wrapper.find('h3');
         expect(banner.attributes('style')).toContain('background-color: red;');
-        expect(banner.attributes('style')).toContain('color: orange;');
+        expect(header.attributes('style')).toContain('color: orange;');
     });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[238](https://jira.justice.gov.bc.ca/browse/JASPER-238)**----    

## 🪮 Ability to filter the retrieved court-list data 📃
This PR allows the ability to filter the retrieved data from the court-list search. Fuzzy search, time (AM/PM) and file status filters.
The AM/PM search will filter out unmatching cards(and tables), whereas the other filters only filter the table data directly.
Right now the table implementation has been omitted until we get `appearances` data back from the court-list api call.
The implementation of filtering everything including the omitted tables is done in this PR that way we are prepared once the table is ready to be displayed in the system.

feat: introduce in place court-list data filtering
refactor: adjust how color is considered in banner component
style: lower elevation on court-list search component

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tested
- [x] Ran `./manage debug` and `./manage start`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Screenshot of changes
![image](https://github.com/user-attachments/assets/93638225-dd0f-4db4-9c04-cbebc15601d1)
