### PR TITLE
Fix incorrect stylesheet import

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-    <link rel="stylesheet" href="./styles/fonts.css" />
-    <link rel="stylesheet" href="./styles/common.css" />
+    <link rel="stylesheet" type="text/css" href="/styles/fonts.css" />
+    <link rel="stylesheet" type="text/css" href="/styles/common.css" />
     <link rel="icon" href="./favicon.ico" />
     <title>JASPER</title>
   </head>


### PR DESCRIPTION
## Fix incorrect stylesheet import and hook up civil details to new selector changes
Stylesheets were being referenced incorrectly `./` => `/` which was causing an inability to find the css files at times.
This PR also hooks up the civil details flow to the new selector changes made in this [PR](https://github.com/bcgov/jasper/pull/218)

fix: fix incorrect css import
fix: hook up civil details to selector changes


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran `./manage debug` and `./manage start`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   