### PR TITLE
JASPER 283: Display correct Ban information

### DIFF
--- a/web/src/components/case-details/Accused/Accused.vue
+++ b/web/src/components/case-details/Accused/Accused.vue
@@ -43,14 +43,15 @@
       <v-col cols="6" class="data-label">Counsel Desig. Filed</v-col>
       <v-col>{{ accused.designatedCounselYN }}</v-col>
     </v-row>
-    <v-row class="mx-1 mt-2">
+    <!-- Comment these fields until we have more information on them -->
+    <!-- <v-row class="mx-1 mt-2">
       <v-col cols="6" class="data-label">Bail status</v-col>
       <v-col></v-col>
     </v-row>
     <v-row class="mx-1 mt-2">
       <v-col cols="6" class="data-label">Plea</v-col>
       <v-col></v-col>
-    </v-row>
+    </v-row> -->
     <v-row class="mx-1 mt-2">
       <v-col cols="6" class="data-label">Appearances</v-col>
       <v-col>{{ appearances.length }}</v-col>

--- a/web/src/components/case-details/Accused/Accused.vue
+++ b/web/src/components/case-details/Accused/Accused.vue
@@ -56,7 +56,7 @@
       <v-col>{{ appearances.length }}</v-col>
     </v-row>
   </v-card>
-  <Ban v-if="showBanModal" :bans="accused.ban" v-model="showBanModal" />
+  <Bans v-if="showBanModal" :bans="accused.ban" v-model="showBanModal" />
 </template>
 
 <script setup lang="ts">
@@ -64,13 +64,12 @@
   import { formatDateToDDMMMYYYY } from '@/utils/utils';
   import { mdiInformationSlabCircleOutline } from '@mdi/js';
   import { computed, defineProps, ref } from 'vue';
-  import Ban from './Ban.vue';
+  import Bans from './Bans.vue';
 
   const props = defineProps<{
     accused: criminalParticipantType;
     appearances: any;
   }>();
-
   const showBanModal = ref(false);
   const counselName = computed(() =>
     props.accused.counselLastNm && props.accused.counselGivenNm
@@ -78,11 +77,14 @@
       : ''
   );
   const groupedBans = computed(() =>
-    props.accused.ban.reduce((acc, ban) => {
-      const { banTypeDescription } = ban;
-      acc[banTypeDescription] = acc[banTypeDescription] || [];
-      acc[banTypeDescription].push(ban);
-      return acc;
-    }, {} as Record<string, typeof props.accused.ban>)
+    props.accused.ban.reduce(
+      (acc, ban) => {
+        const { banTypeDescription } = ban;
+        acc[banTypeDescription] = acc[banTypeDescription] || [];
+        acc[banTypeDescription].push(ban);
+        return acc;
+      },
+      {} as Record<string, typeof props.accused.ban>
+    )
   );
 </script>

--- a/web/src/components/case-details/Accused/Bans.vue
+++ b/web/src/components/case-details/Accused/Bans.vue
@@ -16,16 +16,14 @@
           </thead>
           <tbody>
             <tr v-for="ban in bans" :key="ban.banStatuteId">
-              <td>{{ ban.banTypeCd }}</td>
+              <td>{{ ban.banTypeDescription }}</td>
               <td>
-                {{
-                  formatDateToDDMMMYYYY(ban.banOrderedDate)
-                }}
+                {{ formatDateToDDMMMYYYY(ban.banOrderedDate) }}
               </td>
               <td>{{ ban.banTypeAct }}</td>
               <td>{{ ban.banTypeSection }}</td>
               <td>{{ ban.banTypeSubSection }}</td>
-              <td>{{ ban.banTypeDescription }}</td>
+              <td>{{ ban.banCommentText }}</td>
             </tr>
           </tbody>
         </v-table>
@@ -40,7 +38,7 @@
 <script setup lang="ts">
   import { formatDateToDDMMMYYYY } from '@/utils/utils';
 
-  defineProps<{ bans: any; }>();
-  
+  defineProps<{ bans: any }>();
+
   const show = defineModel<boolean>({ type: Boolean, required: true });
 </script>

--- a/web/src/components/criminal/CriminalCaseDetails.vue
+++ b/web/src/components/criminal/CriminalCaseDetails.vue
@@ -38,7 +38,7 @@
         :loading="loading || !isMounted"
       >
         <v-row style="display: flex; flex-wrap: nowrap">
-          <v-col cols="2" style="overflow-y: auto">
+          <v-col cols="3" style="overflow-y: auto">
             <criminal-side-panel-v2
               v-if="isDataReady && details"
               :details="details"

--- a/web/tests/components/case-details/Accused/Accused.test.ts
+++ b/web/tests/components/case-details/Accused/Accused.test.ts
@@ -83,7 +83,7 @@ describe('Accused.vue', () => {
       props: { accused: accusedMock, appearances: appearancesMock },
     });
 
-    const appearancesCount = wrapper.findAll('v-row')[7].find('v-col:last-child').text();
+    const appearancesCount = wrapper.findAll('v-row')[5].find('v-col:last-child').text();
     expect(appearancesCount).toBe('3');
   });
 });

--- a/web/tests/components/case-details/Accused/Accused.test.ts
+++ b/web/tests/components/case-details/Accused/Accused.test.ts
@@ -48,7 +48,7 @@ describe('Accused.vue', () => {
     expect(icon.exists()).toBe(true);
 
     await icon.trigger('click');
-    expect(wrapper.findComponent({ name: 'Ban' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'Bans' }).exists()).toBe(true);
   });
 
   it('renders formatted DOB', () => {

--- a/web/tests/components/case-details/Accused/Bans.test.ts
+++ b/web/tests/components/case-details/Accused/Bans.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
-import Ban from 'CMP/case-details/Accused/Ban.vue';
+import Bans from 'CMP/case-details/Accused/Bans.vue';
 
-describe('Ban.vue', () => {
+describe('Bans.vue', () => {
   const bansMock = [
     {
       banStatuteId: 1,
@@ -12,6 +12,7 @@ describe('Ban.vue', () => {
       banTypeSection: 'Section1',
       banTypeSubSection: 'Sub1',
       banTypeDescription: 'Description1',
+      banCommentText: 'Comment1',
     },
     {
       banStatuteId: 2,
@@ -21,12 +22,13 @@ describe('Ban.vue', () => {
       banTypeSection: 'Section2',
       banTypeSubSection: 'Sub2',
       banTypeDescription: 'Description2',
+      banCommentText: 'Comment2',
 
     },
   ];
 
   it('renders the correct number of rows in the table', () => {
-    const wrapper = mount(Ban, {
+    const wrapper = mount(Bans, {
       props: {
         bans: bansMock,
         modelValue: true,
@@ -38,7 +40,7 @@ describe('Ban.vue', () => {
   });
 
   it('renders the correct data in the table', () => {
-    const wrapper = mount(Ban, {
+    const wrapper = mount(Bans, {
       props: {
         bans: bansMock,
         modelValue: true,
@@ -46,11 +48,11 @@ describe('Ban.vue', () => {
     });
 
     const firstRowCells = wrapper.findAll('tbody tr').at(0)?.findAll('td');
-    expect(firstRowCells?.at(0)?.text()).toBe(bansMock[0].banTypeCd);
+    expect(firstRowCells?.at(0)?.text()).toBe(bansMock[0].banTypeDescription);
     expect(firstRowCells?.at(1)?.text()).toBe('01-Jan-2025');
     expect(firstRowCells?.at(2)?.text()).toBe(bansMock[0].banTypeAct);
     expect(firstRowCells?.at(3)?.text()).toBe(bansMock[0].banTypeSection);
     expect(firstRowCells?.at(4)?.text()).toBe(bansMock[0].banTypeSubSection);
-    expect(firstRowCells?.at(5)?.text()).toBe(bansMock[0].banTypeDescription);
+    expect(firstRowCells?.at(5)?.text()).toBe(bansMock[0].banCommentText);
   });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[283](https://jira.justice.gov.bc.ca/browse/JASPER-283)**----    

## Description
Ban modal was displaying incorrect information


refactor: display different properties

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- [x] `./manage debug` and `./manage start`
- [x] Unit tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   