### PR TITLE
JASPER-324: Case details: Civil - Small Claims - Parties Information

### DIFF
--- a/api/Models/Civil/Detail/CivilParty.cs
+++ b/api/Models/Civil/Detail/CivilParty.cs
@@ -1,4 +1,5 @@
-﻿using JCCommon.Clients.FileServices;
+﻿using System.Collections.Generic;
+using JCCommon.Clients.FileServices;
 
 namespace Scv.Api.Models.Civil.Detail
 {
@@ -11,5 +12,6 @@ namespace Scv.Api.Models.Civil.Detail
             ? $"{GivenNm?.Trim()} {LastNm?.Trim()}"
             : OrgNm;
         public string RoleTypeDescription { get; set; }
+        public ICollection<ClPartyName> Aliases { get; set; }
     }
 }

--- a/api/Models/Location/Location.cs
+++ b/api/Models/Location/Location.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Scv.Api.Models.Location;
 
-public class Location 
+public class Location
 {
     private const string BASE_URL = "https://provincialcourt.bc.ca/court-locations/";
     private static readonly string[] invalidWords = ["Law", "Courts", "Court", "Provincial"];
@@ -12,6 +12,7 @@ public class Location
     public string Name { get; set; }
     public string Code { get; set; }
     public string LocationId { get; set; }
+    public string AgencyIdentifierCd { get; set; }
     public bool? Active { get; set; }
     public Uri InfoLink => ParseCourtLocationUrl(Name);
     public ICollection<CourtRoom> CourtRooms { get; set; }
@@ -25,6 +26,12 @@ public class Location
         CourtRooms = courtRooms;
     }
 
+    private Location(string name, string code, string locationId, string agencyIdentifierCd, bool? active, ICollection<CourtRoom> courtRooms)
+        : this(name, code, locationId, active, courtRooms)
+    {
+        AgencyIdentifierCd = agencyIdentifierCd;
+    }
+
     public static Location Create(string name, string code, string locationId, bool? active, ICollection<CourtRoom> courtRooms)
     {
         return new Location(name, code, locationId, active, courtRooms);
@@ -33,10 +40,11 @@ public class Location
     public static Location Create(Location jcLocation, Location pcssLocation)
     {
         return new Location(
-            jcLocation.Name, 
-            jcLocation.LocationId, 
-            pcssLocation?.LocationId, 
-            jcLocation.Active, 
+            jcLocation.Name,
+            jcLocation.LocationId,
+            pcssLocation?.LocationId,
+            jcLocation.Code,
+            jcLocation.Active,
             pcssLocation != null ? pcssLocation.CourtRooms : jcLocation.CourtRooms);
     }
 

--- a/api/Services/Files/CivilFilesService.cs
+++ b/api/Services/Files/CivilFilesService.cs
@@ -168,19 +168,19 @@ namespace Scv.Api.Services.Files
                 // Division Code, File Number and CourtLevel params appears to be not working and may introduce performance issues
                 // because the endpoint returns all court list data.
                 var latestApprearance = detail.Appearances.ApprDetail.OrderByDescending(a => a.AppearanceDt).FirstOrDefault();
-                var agencyId = await _locationService.GetLocationAgencyIdentifier(detail.HomeLocationAgenId);
-                var courtList = await _filesClient.FilesCourtlistAsync(
-                    _requestAgencyIdentifierId,
-                    _requestPartId,
-                    _applicationCode,
-                    agencyId,
-                    latestApprearance.CourtRoomCd,
-                    latestApprearance.AppearanceDt,
-                    "CV",
-                    detail.FileNumberTxt);
-                var civilCourtListFileDetail = courtList.CivilCourtList.FirstOrDefault(c => c.PhysicalFile.PhysicalFileID == detail.PhysicalFileId);
-                if (civilCourtListFileDetail != null)
+                if (latestApprearance != null)
                 {
+                    var agencyId = await _locationService.GetLocationAgencyIdentifier(detail.HomeLocationAgenId);
+                    var courtList = await _filesClient.FilesCourtlistAsync(
+                        _requestAgencyIdentifierId,
+                        _requestPartId,
+                        _applicationCode,
+                        agencyId,
+                        latestApprearance.CourtRoomCd,
+                        latestApprearance.AppearanceDt,
+                        "CV",
+                        detail.FileNumberTxt);
+                    var civilCourtListFileDetail = courtList.CivilCourtList.FirstOrDefault(c => c.PhysicalFile.PhysicalFileID == detail.PhysicalFileId);
                     courtListParties = civilCourtListFileDetail?.Parties;
                 }
             }

--- a/api/Services/Files/CivilFilesService.cs
+++ b/api/Services/Files/CivilFilesService.cs
@@ -161,8 +161,32 @@ namespace Scv.Api.Services.Files
             detail = await PopulateBaseDetail(detail);
             detail.Appearances = appearances;
 
+            ICollection<ClParty> courtListParties = [];
+            if (detail.Appearances != null && detail.Appearances.ApprDetail.Count != 0)
+            {
+                // Call CourtList to get Party alias when case detail has an appearance.
+                // Division Code, File Number and CourtLevel params appears to be not working and may introduce performance issues
+                // because the endpoint returns all court list data.
+                var latestApprearance = detail.Appearances.ApprDetail.OrderByDescending(a => a.AppearanceDt).FirstOrDefault();
+                var agencyId = await _locationService.GetLocationAgencyIdentifier(detail.HomeLocationAgenId);
+                var courtList = await _filesClient.FilesCourtlistAsync(
+                    _requestAgencyIdentifierId,
+                    _requestPartId,
+                    _applicationCode,
+                    agencyId,
+                    latestApprearance.CourtRoomCd,
+                    latestApprearance.AppearanceDt,
+                    "CV",
+                    detail.FileNumberTxt);
+                var civilCourtListFileDetail = courtList.CivilCourtList.FirstOrDefault(c => c.PhysicalFile.PhysicalFileID == detail.PhysicalFileId);
+                if (civilCourtListFileDetail != null)
+                {
+                    courtListParties = civilCourtListFileDetail?.Parties;
+                }
+            }
+
             var fileContentCivilFile = fileContent?.CivilFile?.First(cf => cf.PhysicalFileID == fileId);
-            detail.Party = await PopulateDetailParties(detail.Party);
+            detail.Party = await PopulateDetailParties(detail.Party, courtListParties);
             detail.Document = await PopulateDetailDocuments(detail.Document, fileContentCivilFile, isVcUser, isStaff);
             detail.HearingRestriction = await PopulateDetailHearingRestrictions(fileDetail.HearingRestriction);
             if (isVcUser)
@@ -342,11 +366,18 @@ namespace Scv.Api.Services.Files
             return documents;
         }
 
-        private async Task<ICollection<CivilParty>> PopulateDetailParties(ICollection<CivilParty> parties)
+        private async Task<ICollection<CivilParty>> PopulateDetailParties(ICollection<CivilParty> parties, ICollection<ClParty> courtListParties)
         {
             //Populate extra fields for party.
             foreach (var party in parties)
+            {
+                var courtListParty = courtListParties.FirstOrDefault(clp => clp.PartyId == party.PartyId);
+                if (courtListParty != null)
+                {
+                    party.Aliases = [.. courtListParty.PartyName.Where(p => p.NameTypeCd != "CUR")];
+                }
                 party.RoleTypeDescription = await _lookupService.GetCivilRoleTypeDescription(party.RoleTypeCd);
+            }
             return parties;
         }
 

--- a/api/Services/LocationService.cs
+++ b/api/Services/LocationService.cs
@@ -152,7 +152,7 @@ namespace Scv.Api.Services
 
         private static string FindLongDescriptionFromCode(ICollection<Location> lookupCodes, string code) => lookupCodes.FirstOrDefault(lookupCode => lookupCode.Code == code)?.Name;
 
-        private static string FindShortDescriptionFromCode(ICollection<Location> lookupCodes, string code) => lookupCodes.FirstOrDefault(lookupCode => lookupCode.Code == code)?.Name;
+        private static string FindShortDescriptionFromCode(ICollection<Location> lookupCodes, string code) => lookupCodes.FirstOrDefault(lookupCode => lookupCode.Code == code)?.AgencyIdentifierCd;
 
         private void SetupLocationServicesClient()
         {

--- a/tests/api/Models/Location/LocationTests.cs
+++ b/tests/api/Models/Location/LocationTests.cs
@@ -68,6 +68,7 @@ public class LocationTest
         Assert.Equal("Vancouver Law Courts", result.Name);
         Assert.Equal("456", result.Code);
         Assert.Equal("789", result.LocationId);
+        Assert.Equal(jcLocation.Code, result.AgencyIdentifierCd);
         Assert.True(result.Active);
         Assert.Equal(pcssLocation.CourtRooms, result.CourtRooms);
     }

--- a/web/src/assets/colors.css
+++ b/web/src/assets/colors.css
@@ -5,6 +5,8 @@
   --bg-light-green: #86b28a;
   --bg-light-purple: #ae81be;
 
+  --bg-pale-blue: #d9e5f4;
+
   --bg-blue: #4092c1;
   --bg-gray: #efedf5;
   --bg-green: #2e8540;
@@ -15,9 +17,12 @@
   --border-blue: #4092c1;
 
   /* Text colors */
+  --text-deep-blue: #183a4a; /* base font color*/
+
+  --text-light-gray: #8c8c8c;
+
+  --text-black: #000000;
   --text-blue: #4092c1;
   --text-red: #db1e05;
-  --text-light-gray: #8c8c8c;
-  --text-black: #000000;
   --text-white: #ffffff;
 }

--- a/web/src/components/case-details/civil/CivilSidePanel.vue
+++ b/web/src/components/case-details/civil/CivilSidePanel.vue
@@ -4,15 +4,19 @@
     v-if="adjudicatorRestrictions?.length > 0"
     :adjudicatorRestrictions
   />
+  <PartiesPanel :parties />
 </template>
 <script setup lang="ts">
   import { civilFileDetailsType } from '@/types/civil/jsonTypes';
   import { AdjudicatorRestrictionsInfoType } from '@/types/common';
   import AdjudicatorRestrictionsPanel from '../common/adjudicator-restrictions/AdjudicatorRestrictionsPanel.vue';
   import CivilSummary from './CivilSummary.vue';
+  import PartiesPanel from './parties/PartiesPanel.vue';
 
   const props = defineProps<{
     details: civilFileDetailsType;
     adjudicatorRestrictions: AdjudicatorRestrictionsInfoType[];
   }>();
+
+  const parties = props.details.party;
 </script>

--- a/web/src/components/case-details/civil/parties/PartiesPanel.vue
+++ b/web/src/components/case-details/civil/parties/PartiesPanel.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="pt-4">
+    <h5>Parties ({{ parties.length }})</h5>
+    <Party v-for="party in parties" :key="party.partyId" :party />
+  </div>
+</template>
+<script setup lang="ts">
+  import { partyType } from '@/types/civil/jsonTypes';
+  import Party from './Party.vue';
+
+  const props = defineProps<{
+    parties: partyType[];
+  }>();
+</script>

--- a/web/src/components/case-details/civil/parties/PartiesPanel.vue
+++ b/web/src/components/case-details/civil/parties/PartiesPanel.vue
@@ -8,7 +8,7 @@
   import { partyType } from '@/types/civil/jsonTypes';
   import Party from './Party.vue';
 
-  const props = defineProps<{
+  defineProps<{
     parties: partyType[];
   }>();
 </script>

--- a/web/src/components/case-details/civil/parties/Party.vue
+++ b/web/src/components/case-details/civil/parties/Party.vue
@@ -33,6 +33,7 @@
 <script setup lang="ts">
   import LabelWithTooltip from '@/components/shared/LabelWithTooltip.vue';
   import { partyType } from '@/types/civil/jsonTypes';
+  import { formatToFullName } from '@/utils/utils';
   import { computed } from 'vue';
 
   const props = defineProps<{
@@ -43,14 +44,14 @@
   const aliases =
     props.party.aliases?.map((a) =>
       a.surnameNm && a.firstGivenNm
-        ? `${a.surnameNm?.toUpperCase()}, ${a.firstGivenNm} ${a.firstGivenNm ?? ''} ${a.thirdGivenNm ?? ''}`
+        ? `${a.surnameNm?.toUpperCase()}, ${a.firstGivenNm} ${a.secondGivenNm ?? ''} ${a.thirdGivenNm ?? ''}`
         : a.organizationNm
     ) ?? [];
 
   const getName = computed(() => {
     const { lastNm, givenNm, orgNm } = props.party;
     if (lastNm && givenNm) {
-      return `${lastNm}, ${givenNm}`;
+      return formatToFullName(lastNm, givenNm);
     }
     return orgNm;
   });

--- a/web/src/components/case-details/civil/parties/Party.vue
+++ b/web/src/components/case-details/civil/parties/Party.vue
@@ -1,0 +1,62 @@
+<template>
+  <v-card variant="text" class="mb-3">
+    <v-row>
+      <v-col class="pb-0">
+        <v-chip
+          variant="flat"
+          rounded="lg"
+          color="var(--bg-pale-blue)"
+          class="w-100 justify-center align-center text-uppercase"
+        >
+          {{ getName }}
+        </v-chip>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="6" class="data-label">Alias</v-col>
+      <v-col>
+        <LabelWithTooltip :values="aliases" />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="6" class="data-label">Role</v-col>
+      <v-col>{{ party.roleTypeDescription }}</v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="6" class="data-label">Counsel</v-col>
+      <v-col>
+        <LabelWithTooltip :values="counselNames" />
+      </v-col>
+    </v-row>
+  </v-card>
+</template>
+<script setup lang="ts">
+  import LabelWithTooltip from '@/components/shared/LabelWithTooltip.vue';
+  import { partyType } from '@/types/civil/jsonTypes';
+  import { computed } from 'vue';
+
+  const props = defineProps<{
+    party: partyType;
+  }>();
+
+  const counselNames = props.party.counsel?.map((c) => c.fullNm) ?? [];
+  const aliases =
+    props.party.aliases?.map((a) =>
+      a.surnameNm && a.firstGivenNm
+        ? `${a.surnameNm?.toUpperCase()}, ${a.firstGivenNm} ${a.firstGivenNm ?? ''} ${a.thirdGivenNm ?? ''}`
+        : a.organizationNm
+    ) ?? [];
+
+  const getName = computed(() => {
+    const { lastNm, givenNm, orgNm } = props.party;
+    if (lastNm && givenNm) {
+      return `${lastNm}, ${givenNm}`;
+    }
+    return orgNm;
+  });
+</script>
+<style scoped>
+  .v-chip {
+    color: var(--text-deep-blue);
+  }
+</style>

--- a/web/src/components/shared/LabelWithTooltip.vue
+++ b/web/src/components/shared/LabelWithTooltip.vue
@@ -1,0 +1,28 @@
+<template>
+  <v-tooltip :disabled="!showTooltip">
+    <template #activator="{ props }">
+      <span v-bind="props">{{ value }}</span>
+    </template>
+
+    <div class="d-flex flex-column">
+      <div v-for="(item, index) in values.slice(1)" :key="index">
+        {{ item }}
+      </div>
+    </div>
+  </v-tooltip>
+</template>
+<script setup lang="ts">
+  import { computed } from 'vue';
+
+  const props = defineProps<{
+    values: string[];
+  }>();
+
+  const value = computed(() =>
+    props.values.length > 1
+      ? `${props.values[0]} +${props.values.length - 1}`
+      : props.values[0] || ''
+  );
+
+  const showTooltip = computed(() => props.values.length > 1);
+</script>

--- a/web/src/types/civil/jsonTypes/index.ts
+++ b/web/src/types/civil/jsonTypes/index.ts
@@ -2,6 +2,16 @@ import { civilFiledByType } from '@/types/courtlist/jsonTypes';
 import { fileDetailsType } from '@/types/shared';
 import { AdditionalProperties } from '../../common';
 
+export interface partyAliasType {
+  nameTypeCd: string;
+  nameTypeDsc: string;
+  surnameNm: string;
+  firstGivenNm: string;
+  secondGivenNm: string;
+  thirdGivenNm: string;
+  organizationNm: string;
+}
+
 export interface partyCounselType {
   counselId: string;
   fullNm: string;
@@ -23,6 +33,7 @@ export interface partyType {
   leftRightCd: string;
   selfRepresentedYN: string;
   counsel: partyCounselType[];
+  aliases: partyAliasType[];
   additionalProperties: AdditionalProperties;
   additionalProp1: {};
   additionalProp2: {};

--- a/web/tests/components/case-details/civil/CivilSidePanel.test.ts
+++ b/web/tests/components/case-details/civil/CivilSidePanel.test.ts
@@ -24,4 +24,15 @@ describe('CivilSidePanel.vue', () => {
     });
     expect(summaryComponent.exists()).toBe(true);
   });
+
+  it('renders PartiesPanel component', () => {
+    const wrapper = shallowMount(CivilSidePanel, {
+      props: { details: { parties: [] }, adjudicatorRestrictions: [{}] },
+    });
+
+    const partiesComponent = wrapper.findComponent({
+      name: 'PartiesPanel',
+    });
+    expect(partiesComponent.exists()).toBe(true);
+  });
 });

--- a/web/tests/components/case-details/civil/parties/PartiesPanel.test.ts
+++ b/web/tests/components/case-details/civil/parties/PartiesPanel.test.ts
@@ -23,8 +23,6 @@ describe('PartiesPanel.vue', () => {
       },
     });
 
-    console.log(wrapper.html());
-
     const partyComponents = wrapper.findAllComponents({
       name: 'party',
     });

--- a/web/tests/components/case-details/civil/parties/PartiesPanel.test.ts
+++ b/web/tests/components/case-details/civil/parties/PartiesPanel.test.ts
@@ -1,0 +1,33 @@
+import PartiesPanel from '@/components/case-details/civil/parties/PartiesPanel.vue';
+import { partyType } from '@/types/civil/jsonTypes';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+describe('PartiesPanel.vue', () => {
+  const partiesMock: partyType[] = [{} as partyType, {} as partyType];
+
+  it('renders the correct PartiesPanel title', () => {
+    const wrapper = shallowMount(PartiesPanel, {
+      props: {
+        parties: partiesMock,
+      },
+    });
+
+    expect(wrapper.find('h5').text()).toBe(`Parties (${partiesMock.length})`);
+  });
+
+  it('renders the correct number of PartiesPanel components', () => {
+    const wrapper = shallowMount(PartiesPanel, {
+      props: {
+        parties: partiesMock,
+      },
+    });
+
+    console.log(wrapper.html());
+
+    const partyComponents = wrapper.findAllComponents({
+      name: 'party',
+    });
+    expect(partyComponents).toHaveLength(partiesMock.length);
+  });
+});

--- a/web/tests/components/case-details/civil/parties/Party.test.ts
+++ b/web/tests/components/case-details/civil/parties/Party.test.ts
@@ -1,0 +1,28 @@
+import Party from '@/components/case-details/civil/parties/Party.vue';
+import { partyType } from '@/types/civil/jsonTypes';
+import { faker } from '@faker-js/faker';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+describe('Party.vue', () => {
+  it('renders Party component with correct details', () => {
+    const mockParty = {
+      givenNm: faker.person.firstName(),
+      lastNm: faker.person.lastName(),
+    } as partyType;
+    const wrapper = shallowMount(Party, {
+      props: {
+        party: mockParty,
+      },
+    });
+
+    const chip = wrapper.find('v-chip');
+    const labelWithTooltip = wrapper.findAllComponents({
+      name: 'label-with-tooltip',
+    });
+
+    expect(chip.classes()).toContain('text-uppercase');
+    expect(chip.text()).toBe(`${mockParty.lastNm}, ${mockParty.givenNm}`);
+    expect(labelWithTooltip.length).toBe(2);
+  });
+});

--- a/web/tests/components/shared/LabelWithTooltip.test.ts
+++ b/web/tests/components/shared/LabelWithTooltip.test.ts
@@ -1,0 +1,27 @@
+import LabelWithTooltip from '@/components/shared/LabelWithTooltip.vue';
+import { mount, shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+describe('LabelWithTooltip', () => {
+  it('renders single value without tooltip', () => {
+    const wrapper = mount(LabelWithTooltip, {
+      props: {
+        values: ['Item 1'],
+      },
+    });
+
+    expect(wrapper.find('v-tooltip').attributes('disabled')).toBe(
+      true.toString()
+    );
+  });
+
+  it('renders the tooltip with value from the second item', () => {
+    const wrapper = shallowMount(LabelWithTooltip, {
+      props: {
+        values: ['Item 1', 'Item 2'],
+      },
+    });
+
+    expect(wrapper.find('v-tooltip').text()).toBe('Item 2');
+  });
+});


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-324

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-324

## Description
- Add CourtList call when loading a Civil case detail to get party alias
- Update Location to include AgencyIdentifierCd as the value is used in JC Courtlist endpoint
- Add Party section in Civil case details page
- Add LabelWithTooltip component to handle scenarios where a list of string needs to display with plus sign and the rest is on tooltip

_NOTE: Data has been duplicated for `alias` and `counsel` to show how the tooltip and +1 label will look like_

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Local testing using `manage` script

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

https://github.com/user-attachments/assets/64c4b5ed-05e0-40a2-b207-f3ff0cc7739e