### PR TITLE
JASPER 323: Civil-details Appearances View

### DIFF
--- a/web/src/components/case-details/common/AppearancesView.vue
+++ b/web/src/components/case-details/common/AppearancesView.vue
@@ -2,7 +2,7 @@
   <v-row>
     <v-col cols="9" />
     <v-col>
-      <name-filter
+      <NameFilter
         v-if="isCriminal"
         v-model="selectedAccused"
         :people="appearances"

--- a/web/src/components/case-details/common/AppearancesView.vue
+++ b/web/src/components/case-details/common/AppearancesView.vue
@@ -2,7 +2,11 @@
   <v-row>
     <v-col cols="9" />
     <v-col>
-      <name-filter v-model="selectedAccused" :people="appearances" />
+      <name-filter
+        v-if="isCriminal"
+        v-model="selectedAccused"
+        :people="appearances"
+      />
     </v-col>
   </v-row>
   <div
@@ -70,24 +74,27 @@
 
 <script setup lang="ts">
   import AppearanceStatusChip from '@/components/shared/AppearanceStatusChip.vue';
-  import { criminalApprDetailType } from '@/types/criminal/jsonTypes';
-  import {
-    extractTime,
-    formatDateToDDMMMYYYY,
-    hoursMinsFormatter,
-  } from '@/utils/dateUtils';
-  import { formatToFullName } from '@/utils/utils';
-  import { mdiHeadphones } from '@mdi/js';
-  import { computed, ref } from 'vue';
-  import NameFilter from '@/components/shared/Form/NameFilter.vue';
+import { criminalApprDetailType } from '@/types/criminal/jsonTypes';
+import { apprDetailType } from '@/types/shared';
+import {
+  extractTime,
+  formatDateToDDMMMYYYY,
+  hoursMinsFormatter,
+} from '@/utils/dateUtils';
+import { formatToFullName } from '@/utils/utils';
+import { mdiHeadphones } from '@mdi/js';
+import { computed, ref } from 'vue';
 
-  const props = defineProps<{ appearances: criminalApprDetailType[] }>();
+  const props = defineProps<{
+    appearances: apprDetailType[];
+    isCriminal: boolean;
+  }>();
   const pastHeaders = [
     {
       title: 'DATE',
       key: 'appearanceDt',
       value: (item) => formatDateToDDMMMYYYY(item.appearanceDt),
-      sortRaw: (a: criminalApprDetailType, b: criminalApprDetailType) =>
+      sortRaw: (a: apprDetailType, b: apprDetailType) =>
         new Date(a.appearanceDt).getTime() - new Date(b.appearanceDt).getTime(),
       width: '13%',
     },
@@ -105,12 +112,18 @@
         // Check for empty string with comma, this seems to be very common
         item.judgeFullNm && item.judgeFullNm !== ', ' ? item.judgeFullNm : '',
     },
-    {
-      title: 'ACCUSED',
-      key: 'name',
-      value: (item) =>
-        item.lastNm && item.givenNm ? item.lastNm + ', ' + item.givenNm : '',
-    },
+    ...(props.isCriminal
+      ? [
+        {
+        title: 'ACCUSED',
+        key: 'name',
+        value: (item) =>
+          item.lastNm && item.givenNm
+          ? item.lastNm + ', ' + item.givenNm
+          : '',
+        },
+      ]
+      : []),
     { title: 'STATUS', key: 'appearanceStatusCd' },
   ];
   const futureHeaders = [
@@ -126,11 +139,16 @@
     },
     { title: 'LOCATION ROOM', key: 'courtLocation' },
     { title: 'ACTIVITY', key: 'activity' },
-    {
-      title: 'ACCUSED',
-      key: 'name',
-      value: (item) => formatToFullName(item.lastNm, item.givenNm),
-    },
+    ...(props.isCriminal
+      ? [
+        {
+        title: 'ACCUSED',
+        key: 'name',
+        value: (item) => formatToFullName(item.lastNm, item.givenNm),
+        },
+      ]
+      : []),
+
     { title: 'STATUS', key: 'appearanceStatusCd' },
   ];
 
@@ -144,16 +162,16 @@
       selectedAccused.value;
   const futureAppearances = computed(() =>
     props.appearances
-      ?.filter(
-        (app: criminalApprDetailType) => new Date(app?.appearanceDt) > now
+      ?.filter((app: apprDetailType) => new Date(app?.appearanceDt) > now)
+      .filter((app) =>
+        props.isCriminal ? filterByAccused(app as criminalApprDetailType) : true
       )
-      .filter(filterByAccused)
   );
   const pastAppearances = computed(() =>
     props.appearances
-      ?.filter(
-        (app: criminalApprDetailType) => new Date(app?.appearanceDt) <= now
+      ?.filter((app: apprDetailType) => new Date(app?.appearanceDt) <= now)
+      .filter((app) =>
+        props.isCriminal ? filterByAccused(app as criminalApprDetailType) : true
       )
-      .filter(filterByAccused)
   );
 </script>

--- a/web/src/components/case-details/common/AppearancesView.vue
+++ b/web/src/components/case-details/common/AppearancesView.vue
@@ -74,16 +74,16 @@
 
 <script setup lang="ts">
   import AppearanceStatusChip from '@/components/shared/AppearanceStatusChip.vue';
-import { criminalApprDetailType } from '@/types/criminal/jsonTypes';
-import { ApprDetailType } from '@/types/shared';
-import {
-  extractTime,
-  formatDateToDDMMMYYYY,
-  hoursMinsFormatter,
-} from '@/utils/dateUtils';
-import { formatToFullName } from '@/utils/utils';
-import { mdiHeadphones } from '@mdi/js';
-import { computed, ref } from 'vue';
+  import { criminalApprDetailType } from '@/types/criminal/jsonTypes';
+  import { ApprDetailType } from '@/types/shared';
+  import {
+    extractTime,
+    formatDateToDDMMMYYYY,
+    hoursMinsFormatter,
+  } from '@/utils/dateUtils';
+  import { formatToFullName } from '@/utils/utils';
+  import { mdiHeadphones } from '@mdi/js';
+  import { computed, ref } from 'vue';
 
   const props = defineProps<{
     appearances: ApprDetailType[];
@@ -114,15 +114,15 @@ import { computed, ref } from 'vue';
     },
     ...(props.isCriminal
       ? [
-        {
-        title: 'ACCUSED',
-        key: 'name',
-        value: (item) =>
-          item.lastNm && item.givenNm
-          ? item.lastNm + ', ' + item.givenNm
-          : '',
-        },
-      ]
+          {
+            title: 'ACCUSED',
+            key: 'name',
+            value: (item) =>
+              item.lastNm && item.givenNm
+                ? item.lastNm + ', ' + item.givenNm
+                : '',
+          },
+        ]
       : []),
     { title: 'STATUS', key: 'appearanceStatusCd' },
   ];
@@ -141,12 +141,12 @@ import { computed, ref } from 'vue';
     { title: 'ACTIVITY', key: 'activity' },
     ...(props.isCriminal
       ? [
-        {
-        title: 'ACCUSED',
-        key: 'name',
-        value: (item) => formatToFullName(item.lastNm, item.givenNm),
-        },
-      ]
+          {
+            title: 'ACCUSED',
+            key: 'name',
+            value: (item) => formatToFullName(item.lastNm, item.givenNm),
+          },
+        ]
       : []),
 
     { title: 'STATUS', key: 'appearanceStatusCd' },

--- a/web/src/components/case-details/common/AppearancesView.vue
+++ b/web/src/components/case-details/common/AppearancesView.vue
@@ -75,7 +75,7 @@
 <script setup lang="ts">
   import AppearanceStatusChip from '@/components/shared/AppearanceStatusChip.vue';
 import { criminalApprDetailType } from '@/types/criminal/jsonTypes';
-import { apprDetailType } from '@/types/shared';
+import { ApprDetailType } from '@/types/shared';
 import {
   extractTime,
   formatDateToDDMMMYYYY,
@@ -86,7 +86,7 @@ import { mdiHeadphones } from '@mdi/js';
 import { computed, ref } from 'vue';
 
   const props = defineProps<{
-    appearances: apprDetailType[];
+    appearances: ApprDetailType[];
     isCriminal: boolean;
   }>();
   const pastHeaders = [
@@ -94,7 +94,7 @@ import { computed, ref } from 'vue';
       title: 'DATE',
       key: 'appearanceDt',
       value: (item) => formatDateToDDMMMYYYY(item.appearanceDt),
-      sortRaw: (a: apprDetailType, b: apprDetailType) =>
+      sortRaw: (a: ApprDetailType, b: ApprDetailType) =>
         new Date(a.appearanceDt).getTime() - new Date(b.appearanceDt).getTime(),
       width: '13%',
     },
@@ -162,14 +162,14 @@ import { computed, ref } from 'vue';
       selectedAccused.value;
   const futureAppearances = computed(() =>
     props.appearances
-      ?.filter((app: apprDetailType) => new Date(app?.appearanceDt) > now)
+      ?.filter((app: ApprDetailType) => new Date(app?.appearanceDt) > now)
       .filter((app) =>
         props.isCriminal ? filterByAccused(app as criminalApprDetailType) : true
       )
   );
   const pastAppearances = computed(() =>
     props.appearances
-      ?.filter((app: apprDetailType) => new Date(app?.appearanceDt) <= now)
+      ?.filter((app: ApprDetailType) => new Date(app?.appearanceDt) <= now)
       .filter((app) =>
         props.isCriminal ? filterByAccused(app as criminalApprDetailType) : true
       )

--- a/web/src/components/case-details/common/CaseHeader.vue
+++ b/web/src/components/case-details/common/CaseHeader.vue
@@ -75,13 +75,13 @@
   import { civilFileDetailsType } from '@/types/civil/jsonTypes';
   import { DivisionEnum } from '@/types/common/index';
   import { criminalFileDetailsType } from '@/types/criminal/jsonTypes';
-  import { fileDetailsType } from '@/types/shared';
+  import { FileDetailsType } from '@/types/shared';
   import { mdiCalendar, mdiScaleBalance, mdiTextBoxOutline } from '@mdi/js';
   import { computed, ref } from 'vue';
   import AppearancesView from './AppearancesView.vue';
 
   const props = defineProps<{
-    details: fileDetailsType;
+    details: FileDetailsType;
     activityClassCd: string;
   }>();
 

--- a/web/src/components/case-details/common/CaseHeader.vue
+++ b/web/src/components/case-details/common/CaseHeader.vue
@@ -46,11 +46,21 @@
     </v-row>
     <v-window mandatory continuous v-model="selectedTab" class="mt-3">
       <v-window-item value="documents">
-        <CriminalDocumentsView v-if="isCriminal" :participants="criminalDetails.participant" />
+        <CriminalDocumentsView
+          v-if="isCriminal"
+          :participants="criminalDetails.participant"
+        />
         <CivilDocumentsView v-else :documents="civilDetails.document" />
       </v-window-item>
       <v-window-item value="appearances">
-        <AppearancesView v-if="isCriminal" :appearances="criminalDetails.appearances?.apprDetail" />
+        <AppearancesView
+          :appearances="
+            isCriminal
+              ? criminalDetails.appearances?.apprDetail
+              : civilDetails.appearances?.apprDetail
+          "
+          :isCriminal="isCriminal"
+        />
       </v-window-item>
       <v-window-item value="sentence">
         <!-- <SentenceOrderDetailsView /> -->
@@ -62,9 +72,7 @@
 <script setup lang="ts">
   import CivilDocumentsView from '@/components/case-details/civil/CivilDocumentsView.vue';
   import CriminalDocumentsView from '@/components/case-details/criminal/CriminalDocumentsView.vue';
-  import {
-    civilFileDetailsType,
-  } from '@/types/civil/jsonTypes';
+  import { civilFileDetailsType } from '@/types/civil/jsonTypes';
   import { DivisionEnum } from '@/types/common/index';
   import { criminalFileDetailsType } from '@/types/criminal/jsonTypes';
   import { fileDetailsType } from '@/types/shared';
@@ -76,10 +84,12 @@
     details: fileDetailsType;
     activityClassCd: string;
   }>();
-  
+
   const isCriminal = computed(() => props.activityClassCd === DivisionEnum.R);
   const selectedTab = ref('documents');
-  const criminalDetails = ref<criminalFileDetailsType>({} as criminalFileDetailsType);
+  const criminalDetails = ref<criminalFileDetailsType>(
+    {} as criminalFileDetailsType
+  );
   const civilDetails = ref<civilFileDetailsType>({} as civilFileDetailsType);
 
   if (isCriminal.value) {

--- a/web/src/components/shared/Form/NameFilter.vue
+++ b/web/src/components/shared/Form/NameFilter.vue
@@ -10,13 +10,13 @@
 </template>
 
 <script setup lang="ts">
-  import { personType } from '@/types/criminal/jsonTypes';
+  import { PersonType } from '@/types/criminal/jsonTypes';
   import { formatToFullName } from '@/utils/utils';
   import { computed } from 'vue';
 
   const props = defineProps({
     people: {
-      type: Array<personType>,
+      type: Array<PersonType>,
       required: true,
     },
     label: {

--- a/web/src/types/civil/jsonTypes/index.ts
+++ b/web/src/types/civil/jsonTypes/index.ts
@@ -1,7 +1,6 @@
 import { civilFiledByType } from '@/types/courtlist/jsonTypes';
-import { fileDetailsType } from '@/types/shared';
+import { FileDetailsType } from '@/types/shared';
 import { AdditionalProperties } from '../../common';
-import { apprDetailType } from '../../shared';
 
 export interface partyAliasType {
   nameTypeCd: string;
@@ -145,12 +144,71 @@ export interface civilHearingRestrictionType {
   additionalProp2: {};
   additionalProp3: {};
 }
+export interface PersonType {
+  givenNm: string;
+  lastNm: string;
+}
 
-export interface civilApprDetailType extends apprDetailType {
+export interface criminalApprDetailType extends PersonType {
+  historyYN: string;
+  appearanceId: string;
+  appearanceDt: string;
+  appearanceTm: string;
+  appearanceReasonCd: string;
+  appearanceReasonDsc?: string;
+  courtLocation?: string;
+  courtAgencyId: string;
+  courtRoomCd: string;
+  judgeFullNm: string;
+  judgeInitials: string;
+  counselFullNm: string;
+  estimatedTimeHour: string;
+  estimatedTimeMin: string;
+  partOfTrialYN: string;
+  appearanceStatusCd: string;
+  partId: string;
+  profSeqNo: string;
+  orgNm: string;
+  appearanceResultCd: string;
+  appearanceCcn: string;
+  supplementalEquipmentTxt: string;
+  securityRestrictionTxt: string;
+  outOfTownJudgeTxt: string;
+  additionalProperties: AdditionalProperties;
+  additionalProp1: {};
+  additionalProp2: {};
+  additionalProp3: {};
+}
+
+export interface civilApprDetailType extends PersonType {
+  historyYN: string;
+  appearanceId: string;
+  appearanceDt: string;
+  appearanceTm: string;
+  appearanceReasonCd: string;
+  courtAgencyId: string;
+  courtRoomCd: string;
+  judgeFullNm: string;
+  judgeInitials: string;
+  estimatedTimeHour: string;
+  estimatedTimeMin: string;
+  partOfTrialYN: string;
+  appearanceStatusCd: string;
+  appearanceResultCd: string;
+  appearanceCcn: string;
   documentTypeCd: string;
   documentTypeDsc?: string;
   appearanceResultDsc?: string;
+  appearanceReasonDsc?: string;
+  courtLocation?: string;
   documentRecCount: string;
+  supplementalEquipmentTxt: string;
+  securityRestrictionTxt: string;
+  outOfTownJudgeTxt: string;
+  additionalProperties: AdditionalProperties;
+  additionalProp1: {};
+  additionalProp2: {};
+  additionalProp3: {};
 }
 
 export interface civilAppearancesType {
@@ -165,7 +223,7 @@ export interface civilAppearancesType {
   additionalProp3: {};
 }
 
-export interface civilFileDetailsType extends fileDetailsType {
+export interface civilFileDetailsType extends FileDetailsType {
   physicalFileId: string;
   socTxt: string;
   sealedYN: string;
@@ -179,5 +237,4 @@ export interface civilFileDetailsType extends fileDetailsType {
   document: civilDocumentType[];
   referenceDocument: civilReferenceDocumentJsonType[];
   hearingRestriction: civilHearingRestrictionType[];
-  appearances: civilAppearancesType;
 }

--- a/web/src/types/civil/jsonTypes/index.ts
+++ b/web/src/types/civil/jsonTypes/index.ts
@@ -1,6 +1,7 @@
 import { civilFiledByType } from '@/types/courtlist/jsonTypes';
 import { fileDetailsType } from '@/types/shared';
 import { AdditionalProperties } from '../../common';
+import { apprDetailType } from '../../shared';
 
 export interface partyAliasType {
   nameTypeCd: string;
@@ -145,35 +146,11 @@ export interface civilHearingRestrictionType {
   additionalProp3: {};
 }
 
-export interface civilApprDetailType {
-  historyYN: string;
-  appearanceId: string;
-  appearanceDt: string;
-  appearanceTm: string;
-  appearanceReasonCd: string;
-  courtAgencyId: string;
-  courtRoomCd: string;
-  judgeFullNm: string;
-  judgeInitials: string;
-  estimatedTimeHour: string;
-  estimatedTimeMin: string;
-  partOfTrialYN: string;
-  appearanceStatusCd: string;
-  appearanceResultCd: string;
-  appearanceCcn: string;
+export interface civilApprDetailType extends apprDetailType {
   documentTypeCd: string;
   documentTypeDsc?: string;
   appearanceResultDsc?: string;
-  appearanceReasonDsc?: string;
-  courtLocation?: string;
   documentRecCount: string;
-  supplementalEquipmentTxt: string;
-  securityRestrictionTxt: string;
-  outOfTownJudgeTxt: string;
-  additionalProperties: AdditionalProperties;
-  additionalProp1: {};
-  additionalProp2: {};
-  additionalProp3: {};
 }
 
 export interface civilAppearancesType {

--- a/web/src/types/civil/jsonTypes/index.ts
+++ b/web/src/types/civil/jsonTypes/index.ts
@@ -1,6 +1,7 @@
 import { civilFiledByType } from '@/types/courtlist/jsonTypes';
 import { FileDetailsType } from '@/types/shared';
 import { AdditionalProperties } from '../../common';
+import { ApprDetailType } from '../../shared';
 
 export interface partyAliasType {
   nameTypeCd: string;
@@ -180,35 +181,11 @@ export interface criminalApprDetailType extends PersonType {
   additionalProp3: {};
 }
 
-export interface civilApprDetailType extends PersonType {
-  historyYN: string;
-  appearanceId: string;
-  appearanceDt: string;
-  appearanceTm: string;
-  appearanceReasonCd: string;
-  courtAgencyId: string;
-  courtRoomCd: string;
-  judgeFullNm: string;
-  judgeInitials: string;
-  estimatedTimeHour: string;
-  estimatedTimeMin: string;
-  partOfTrialYN: string;
-  appearanceStatusCd: string;
-  appearanceResultCd: string;
-  appearanceCcn: string;
+export interface civilApprDetailType extends ApprDetailType {
   documentTypeCd: string;
   documentTypeDsc?: string;
   appearanceResultDsc?: string;
-  appearanceReasonDsc?: string;
-  courtLocation?: string;
   documentRecCount: string;
-  supplementalEquipmentTxt: string;
-  securityRestrictionTxt: string;
-  outOfTownJudgeTxt: string;
-  additionalProperties: AdditionalProperties;
-  additionalProp1: {};
-  additionalProp2: {};
-  additionalProp3: {};
 }
 
 export interface civilAppearancesType {

--- a/web/src/types/civil/jsonTypes/index.ts
+++ b/web/src/types/civil/jsonTypes/index.ts
@@ -150,37 +150,6 @@ export interface PersonType {
   lastNm: string;
 }
 
-export interface criminalApprDetailType extends PersonType {
-  historyYN: string;
-  appearanceId: string;
-  appearanceDt: string;
-  appearanceTm: string;
-  appearanceReasonCd: string;
-  appearanceReasonDsc?: string;
-  courtLocation?: string;
-  courtAgencyId: string;
-  courtRoomCd: string;
-  judgeFullNm: string;
-  judgeInitials: string;
-  counselFullNm: string;
-  estimatedTimeHour: string;
-  estimatedTimeMin: string;
-  partOfTrialYN: string;
-  appearanceStatusCd: string;
-  partId: string;
-  profSeqNo: string;
-  orgNm: string;
-  appearanceResultCd: string;
-  appearanceCcn: string;
-  supplementalEquipmentTxt: string;
-  securityRestrictionTxt: string;
-  outOfTownJudgeTxt: string;
-  additionalProperties: AdditionalProperties;
-  additionalProp1: {};
-  additionalProp2: {};
-  additionalProp3: {};
-}
-
 export interface civilApprDetailType extends ApprDetailType {
   documentTypeCd: string;
   documentTypeDsc?: string;

--- a/web/src/types/criminal/jsonTypes/index.ts
+++ b/web/src/types/criminal/jsonTypes/index.ts
@@ -1,6 +1,6 @@
+import { FileDetailsType } from '@/types/shared';
 import { AdditionalProperties } from '../../common';
-import { fileDetailsType } from '@/types/shared';
-import { apprDetailType } from '../../shared';
+import { ApprDetailType } from '../../shared';
 
 export interface countSentenceType {
   judgesRecommendation: string;
@@ -117,12 +117,12 @@ export interface criminalTrialRemarkType {
   additionalProp3: {};
 }
 
-export interface personType {
+export interface PersonType {
   givenNm: string;
   lastNm: string;
 }
 
-export interface criminalParticipantType extends personType {
+export interface criminalParticipantType extends PersonType {
   fullName: string;
   document: documentType[];
   hideJustinCounsel: boolean;
@@ -176,11 +176,35 @@ export interface crownType {
   givenNm: string;
 }
 
-export interface criminalApprDetailType extends apprDetailType, personType {
+export interface criminalApprDetailType extends ApprDetailType, PersonType {
+  historyYN: string;
+  appearanceId: string;
+  appearanceDt: string;
+  appearanceTm: string;
+  appearanceReasonCd: string;
+  appearanceReasonDsc?: string;
+  courtLocation?: string;
+  courtAgencyId: string;
+  courtRoomCd: string;
+  judgeFullNm: string;
+  judgeInitials: string;
   counselFullNm: string;
+  estimatedTimeHour: string;
+  estimatedTimeMin: string;
+  partOfTrialYN: string;
+  appearanceStatusCd: string;
   partId: string;
   profSeqNo: string;
   orgNm: string;
+  appearanceResultCd: string;
+  appearanceCcn: string;
+  supplementalEquipmentTxt: string;
+  securityRestrictionTxt: string;
+  outOfTownJudgeTxt: string;
+  additionalProperties: AdditionalProperties;
+  additionalProp1: {};
+  additionalProp2: {};
+  additionalProp3: {};
 }
 
 export interface criminalAppearancesType {
@@ -194,7 +218,7 @@ export interface criminalAppearancesType {
   additionalProp2: {};
   additionalProp3: {};
 }
-export interface criminalFileDetailsType extends fileDetailsType {
+export interface criminalFileDetailsType extends FileDetailsType {
   justinNo: string;
   currentEstimateLenQty: string;
   currentEstimateLenUnit: string;

--- a/web/src/types/criminal/jsonTypes/index.ts
+++ b/web/src/types/criminal/jsonTypes/index.ts
@@ -1,5 +1,6 @@
 import { AdditionalProperties } from '../../common';
 import { fileDetailsType } from '@/types/shared';
+import { apprDetailType } from '../../shared';
 
 export interface countSentenceType {
   judgesRecommendation: string;
@@ -175,35 +176,11 @@ export interface crownType {
   givenNm: string;
 }
 
-export interface criminalApprDetailType extends personType {
-  historyYN: string;
-  appearanceId: string;
-  appearanceDt: string;
-  appearanceTm: string;
-  appearanceReasonCd: string;
-  appearanceReasonDsc?: string;
-  courtLocation?: string;
-  courtAgencyId: string;
-  courtRoomCd: string;
-  judgeFullNm: string;
-  judgeInitials: string;
+export interface criminalApprDetailType extends apprDetailType, personType {
   counselFullNm: string;
-  estimatedTimeHour: string;
-  estimatedTimeMin: string;
-  partOfTrialYN: string;
-  appearanceStatusCd: string;
   partId: string;
   profSeqNo: string;
   orgNm: string;
-  appearanceResultCd: string;
-  appearanceCcn: string;
-  supplementalEquipmentTxt: string;
-  securityRestrictionTxt: string;
-  outOfTownJudgeTxt: string;
-  additionalProperties: AdditionalProperties;
-  additionalProp1: {};
-  additionalProp2: {};
-  additionalProp3: {};
 }
 
 export interface criminalAppearancesType {

--- a/web/src/types/criminal/jsonTypes/index.ts
+++ b/web/src/types/criminal/jsonTypes/index.ts
@@ -177,34 +177,10 @@ export interface crownType {
 }
 
 export interface criminalApprDetailType extends ApprDetailType, PersonType {
-  historyYN: string;
-  appearanceId: string;
-  appearanceDt: string;
-  appearanceTm: string;
-  appearanceReasonCd: string;
-  appearanceReasonDsc?: string;
-  courtLocation?: string;
-  courtAgencyId: string;
-  courtRoomCd: string;
-  judgeFullNm: string;
-  judgeInitials: string;
   counselFullNm: string;
-  estimatedTimeHour: string;
-  estimatedTimeMin: string;
-  partOfTrialYN: string;
-  appearanceStatusCd: string;
   partId: string;
   profSeqNo: string;
   orgNm: string;
-  appearanceResultCd: string;
-  appearanceCcn: string;
-  supplementalEquipmentTxt: string;
-  securityRestrictionTxt: string;
-  outOfTownJudgeTxt: string;
-  additionalProperties: AdditionalProperties;
-  additionalProp1: {};
-  additionalProp2: {};
-  additionalProp3: {};
 }
 
 export interface criminalAppearancesType {

--- a/web/src/types/shared.ts
+++ b/web/src/types/shared.ts
@@ -26,7 +26,7 @@ export enum CourtDocumentType {
   CivilZip,
 }
 
-export interface fileDetailsType {
+export interface FileDetailsType {
   responseCd: string;
   responseMessageTxt: string;
   fileNumberTxt: string;
@@ -34,7 +34,7 @@ export interface fileDetailsType {
   courtClassDescription: string;
   courtLevelCd: string;
   courtLevelDescription: string;
-  appearances: appearancesType;
+  appearances: AppearancesType;
   activityClassCd: string;
   activityClassDesc: string;
   homeLocationAgenId: string;
@@ -43,19 +43,19 @@ export interface fileDetailsType {
   homeLocationRegionName: string;
 }
 
-export interface appearancesType {
+export interface AppearancesType {
   responseCd: string;
   responseMessageTxt: string;
   futureRecCount: string;
   historyRecCount: string;
-  apprDetail: apprDetailType[];
+  apprDetail: ApprDetailType[];
   additionalProperties: AdditionalProperties;
   additionalProp1: {};
   additionalProp2: {};
   additionalProp3: {};
 }
 
-export interface apprDetailType {
+export interface ApprDetailType {
   historyYN: string;
   appearanceId: string;
   appearanceDt: string;
@@ -82,7 +82,7 @@ export interface apprDetailType {
   additionalProp3: {};
 }
 
-export interface personType {
+export interface PersonType {
   givenNm: string;
   lastNm: string;
 }

--- a/web/src/types/shared.ts
+++ b/web/src/types/shared.ts
@@ -1,3 +1,5 @@
+import { AdditionalProperties } from '@/types/common';
+
 export interface DocumentData {
   appearanceDate?: string;
   appearanceId?: string;
@@ -32,10 +34,55 @@ export interface fileDetailsType {
   courtClassDescription: string;
   courtLevelCd: string;
   courtLevelDescription: string;
+  appearances: appearancesType;
   activityClassCd: string;
   activityClassDesc: string;
   homeLocationAgenId: string;
   homeLocationAgencyName: string;
   homeLocationAgencyCode: string;
   homeLocationRegionName: string;
+}
+
+export interface appearancesType {
+  responseCd: string;
+  responseMessageTxt: string;
+  futureRecCount: string;
+  historyRecCount: string;
+  apprDetail: apprDetailType[];
+  additionalProperties: AdditionalProperties;
+  additionalProp1: {};
+  additionalProp2: {};
+  additionalProp3: {};
+}
+
+export interface apprDetailType {
+  historyYN: string;
+  appearanceId: string;
+  appearanceDt: string;
+  appearanceTm: string;
+  appearanceReasonCd: string;
+  courtAgencyId: string;
+  courtRoomCd: string;
+  judgeFullNm: string;
+  judgeInitials: string;
+  estimatedTimeHour: string;
+  estimatedTimeMin: string;
+  partOfTrialYN: string;
+  appearanceStatusCd: string;
+  appearanceResultCd: string;
+  appearanceReasonDsc?: string;
+  appearanceCcn: string;
+  courtLocation?: string;
+  supplementalEquipmentTxt: string;
+  securityRestrictionTxt: string;
+  outOfTownJudgeTxt: string;
+  additionalProperties: AdditionalProperties;
+  additionalProp1: {};
+  additionalProp2: {};
+  additionalProp3: {};
+}
+
+export interface personType {
+  givenNm: string;
+  lastNm: string;
 }

--- a/web/tests/components/case-details/common/AppearancesView.test.ts
+++ b/web/tests/components/case-details/common/AppearancesView.test.ts
@@ -138,7 +138,7 @@ describe('AppearancesView.vue', () => {
       props.isCriminal = isCriminal;
       const wrapper = mount(AppearancesView, { props });
 
-      expect(wrapper.find('name-filter').exists()).toBe(shouldExist);
+      expect(wrapper.find('NameFilter').exists()).toBe(shouldExist);
     }
   );
 });

--- a/web/tests/components/case-details/common/AppearancesView.test.ts
+++ b/web/tests/components/case-details/common/AppearancesView.test.ts
@@ -41,6 +41,7 @@ describe('AppearancesView.vue', () => {
           activity: 'Trial',
         },
       ],
+      isCriminal: true,
     };
   });
 
@@ -91,4 +92,53 @@ describe('AppearancesView.vue', () => {
     );
     expect(appearances.length).toBe(1);
   });
+
+  it('renders correct table headers for criminal appearances', () => {
+    const wrapper: any = mount(AppearancesView, { props });
+
+    const expectedHeaderKeys = [
+      "appearanceDt",
+      "DARS",
+      "appearanceReasonCd",
+      "appearanceTm",
+      "courtLocation",
+      "judgeFullNm",
+      "name",
+      "appearanceStatusCd",
+    ];
+    const headerKeys = wrapper.vm.pastHeaders.map((header: any) => header.key);
+
+    expect(headerKeys).toEqual(expectedHeaderKeys);
+  });
+
+  it('renders correct table headers for civil appearances', () => {
+    props.isCriminal = false;
+    const wrapper: any = mount(AppearancesView, { props });
+
+    const expectedHeaderKeys = [
+      "appearanceDt",
+      "DARS",
+      "appearanceReasonCd",
+      "appearanceTm",
+      "courtLocation",
+      "judgeFullNm",
+      "appearanceStatusCd",
+    ];
+    const headerKeys = wrapper.vm.pastHeaders.map((header: any) => header.key);
+
+    expect(headerKeys).toEqual(expectedHeaderKeys);
+  });
+
+  it.each([
+    { isCriminal: true, shouldExist: true },
+    { isCriminal: false, shouldExist: false },
+  ])(
+    'renders appearances filters based on isCriminal prop',
+    ({ isCriminal, shouldExist }) => {
+      props.isCriminal = isCriminal;
+      const wrapper = mount(AppearancesView, { props });
+
+      expect(wrapper.find('name-filter').exists()).toBe(shouldExist);
+    }
+  );
 });

--- a/web/tests/components/shared/Form/NameFilter.test.ts
+++ b/web/tests/components/shared/Form/NameFilter.test.ts
@@ -1,10 +1,10 @@
 import { shallowMount } from '@vue/test-utils';
 import { describe, it, expect } from 'vitest';
 import NameFilter from 'CMP/shared/Form/NameFilter.vue';
-import { personType } from '@/types/criminal/jsonTypes';
+import { PersonType } from '@/types/criminal/jsonTypes';
 
 describe('NameFilter.vue', () => {
-  const mockPeople: personType[] = [
+  const mockPeople: PersonType[] = [
     { lastNm: 'Doe', givenNm: 'John' },
     { lastNm: 'Smith', givenNm: 'Jane' },
     { lastNm: 'Doe', givenNm: 'John' }, // Duplicate to test unique names


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[323](https://jira.justice.gov.bc.ca/browse/JASPER-323)**----    

## 🧑‍⚖️ Case-details civil appearances view ✨
I was able to re-use the appearances view for both criminal and civil(including small claims)
The only difference is the lack of accused names, so I added in some checks to exclude all info relating to that from the appearances component
This involved having me extract out some of the repeated interfaces into some base shared interfaces.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Ran `./manage` script
- [x] Unit tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screengrab of changes

https://github.com/user-attachments/assets/880a6724-0c7f-495e-b68f-01ffbe4686a7

