### PR TITLE
JASPER 375: Move 'days' text to case-age label and header

### DIFF
--- a/web/src/components/case-details/criminal/CriminalSummary.vue
+++ b/web/src/components/case-details/criminal/CriminalSummary.vue
@@ -22,8 +22,8 @@
       <v-col>{{ crownName }}</v-col>
     </v-row>
     <v-row class="mx-1 mb-1">
-      <v-col cols="6" class="data-label">Case Age</v-col>
-      <v-col>{{ details.caseAgeDays }} days</v-col>
+      <v-col cols="6" class="data-label">Case Age (days)</v-col>
+      <v-col>{{ details.caseAgeDays }}</v-col>
     </v-row>
   </v-card>
 </template>

--- a/web/src/components/courtlist/CourtListTable.vue
+++ b/web/src/components/courtlist/CourtListTable.vue
@@ -71,8 +71,8 @@
 <script setup lang="ts">
   import { CourtListAppearance } from '@/types/courtlist';
   import { PcssCounsel } from '@/types/criminal';
-  import { hoursMinsFormatter } from '@/utils/dateUtils';
   import { criminalApprDetailType } from '@/types/criminal/jsonTypes';
+  import { hoursMinsFormatter } from '@/utils/dateUtils';
   import { mdiFileDocumentEditOutline, mdiNotebookEditOutline } from '@mdi/js';
   import { ref } from 'vue';
 
@@ -102,10 +102,9 @@
     { title: 'COUNSEL', key: 'counsel' },
     { title: 'CROWN', key: 'crown' },
     {
-      title: 'CASE AGE',
+      title: 'CASE AGE (days)',
       key: 'caseAgeDays',
-      value: (item: CourtListAppearance) =>
-        item.caseAgeDays ? item.caseAgeDays + 'd' : '',
+      value: (item: CourtListAppearance) => item.caseAgeDays ?? '',
     },
     { title: 'NOTES', key: 'actions', sortable: false },
   ]);
@@ -146,5 +145,4 @@
     const [firstName, lastName] = name.split(' ');
     return `${lastName}, ${firstName}`;
   };
-
 </script>

--- a/web/tests/components/case-details/criminal/CriminalSummary.test.ts
+++ b/web/tests/components/case-details/criminal/CriminalSummary.test.ts
@@ -106,7 +106,7 @@ describe('CriminalSummary.vue', () => {
     expect(wrapper.findAll('v-row')?.at(1)?.find('v-col').text()).toBe('Crown');
     expect(
       wrapper.findAll('v-row')?.at(2)?.findAll('v-col')?.at(1)?.text()
-    ).toBe('100 days');
+    ).toBe('100');
   });
 
   it('renders correct text when more than one particpant', () => {


### PR DESCRIPTION
# Pull Request for JIRA Ticket: [375](https://jira.justice.gov.bc.ca/browse/JASPER-375)

## Moved text from case-age data to label and header

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Ran `./manage` script
- [x] Unit tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   