### PR TITLE
Fix file marker description for DO and W

### DIFF
--- a/web/src/components/shared/FileMarkers.vue
+++ b/web/src/components/shared/FileMarkers.vue
@@ -28,11 +28,11 @@
   const allMarkers = [
     { marker: FileMarkerEnum.CNT, description: 'Continuation' },
     { marker: FileMarkerEnum.CPA, description: 'Child Protection Act' },
-    { marker: FileMarkerEnum.DO, description: 'Detained Order' },
+    { marker: FileMarkerEnum.DO, description: 'Detention Order' },
     { marker: FileMarkerEnum.IC, description: 'In Custody' },
     { marker: FileMarkerEnum.INT, description: 'Interpreter Required' },
     { marker: FileMarkerEnum.LOCT, description: 'Lack of Court Time' },
-    { marker: FileMarkerEnum.W, description: 'Warrant' },
+    { marker: FileMarkerEnum.W, description: 'Warrant Issued' },
   ];
 
   const data = props.markers.map((m) => {

--- a/web/tests/components/shared/FileMarkers.test.ts
+++ b/web/tests/components/shared/FileMarkers.test.ts
@@ -37,9 +37,9 @@ describe('FileMarkers.vue', () => {
     const descriptions = tooltips.map((tooltip) => tooltip.text());
 
     expect(tooltips.length).toBe(4);
-    expect(descriptions).toContain('Warrant');
+    expect(descriptions).toContain('Warrant Issued');
     expect(descriptions).toContain('In Custody');
-    expect(descriptions).toContain('Detained Order');
+    expect(descriptions).toContain('Detention Order');
     expect(descriptions).toContain('Interpreter Required');
   });
 });


### PR DESCRIPTION
Fixed incorrect tooltip for DO and W file markers that was found during Sprint demo.

https://github.com/user-attachments/assets/d33d9432-7bf3-49d4-8dc1-2194d664e949

