### PR TITLE
JASPER 346: Criminal appearance details

### DIFF
--- a/web/src/components/case-details/common/AppearancesView.vue
+++ b/web/src/components/case-details/common/AppearancesView.vue
@@ -9,99 +9,126 @@
       />
     </v-col>
   </v-row>
-  <div
-    v-for="(appearances, type) in {
-      past: pastAppearances,
-      future: futureAppearances,
-    }"
-    :key="type"
-  >
-    <v-card
-      class="my-6"
-      color="var(--bg-gray)"
-      elevation="0"
-      v-if="appearances?.length"
+  <template v-if="pastAppearances.length || futureAppearances.length">
+    <div
+      v-for="(appearances, type) in {
+        past: pastAppearances,
+        future: futureAppearances,
+      }"
+      :key="type"
     >
+      <v-card
+        class="my-6"
+        color="var(--bg-gray)"
+        elevation="0"
+        v-if="appearances?.length"
+      >
+        <v-card-text>
+          <v-row align="center" no-gutters>
+            <v-col class="text-h5" cols="6">
+              {{
+                type === 'future' ? 'Future Appearances' : 'Past Appearances'
+              }}
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+      <v-data-table-virtual
+        v-if="appearances?.length"
+        :headers="type === 'future' ? futureHeaders : pastHeaders"
+        :items="appearances"
+        :sort-by="sortBy"
+        :height="pastAppearances.length && futureAppearances.length ? 400 : 800"
+        item-value="appearanceId"
+        fixed-header
+        show-expand
+        variant="hover"
+      >
+        <template
+          v-slot:item.data-table-expand="{
+            internalItem,
+            isExpanded,
+            toggleExpand,
+          }"
+        >
+          <v-icon
+            color="primary"
+            :icon="isExpanded(internalItem) ? mdiChevronUp : mdiChevronDown"
+            @click="toggleExpand(internalItem)"
+          />
+        </template>
+        <template v-slot:expanded-row="{ columns, item }">
+          <tr class="expanded">
+            <td :colspan="columns.length">
+              <CivilAppearanceDetails
+                v-if="!isCriminal"
+                :fileId="fileNumber"
+                :appearanceId="item.appearanceId"
+              />
+              <CriminalAppearanceDetails
+                v-else
+                :fileId="fileNumber"
+                :appearanceId="item.appearanceId"
+                :partId="(item as criminalApprDetailType).partId"
+                :isPast="type === 'past'"
+              />
+            </td>
+          </tr>
+        </template>
+        <template v-slot:item.appearanceDt="{ value }">
+          <span> {{ value }} </span>
+        </template>
+        <template v-slot:item.DARS="{ item }">
+          <v-icon
+            v-if="item.appearanceStatusCd === 'SCHD'"
+            :icon="mdiHeadphones"
+          />
+        </template>
+        <template v-slot:item.appearanceReasonCd="{ value, item }">
+          <v-tooltip :text="item.appearanceReasonDsc" location="top">
+            <template v-slot:activator="{ props }">
+              <span v-bind="props" class="has-tooltip">{{ value }}</span>
+            </template>
+          </v-tooltip>
+        </template>
+        <template v-slot:item.appearanceTm="{ value, item }">
+          {{ value ? extractTime(value) : '' }} <br />
+          <span style="color: gray">
+            {{
+              hoursMinsFormatter(item.estimatedTimeHour, item.estimatedTimeMin)
+            }}
+          </span>
+        </template>
+        <template v-slot:item.courtLocation="{ value, item }">
+          {{ value }} <br />
+          <span style="color: gray">Room {{ item.courtRoomCd }}</span>
+        </template>
+        <template v-slot:item.appearanceStatusCd="{ value }">
+          <AppearanceStatusChip :status="value" />
+        </template>
+      </v-data-table-virtual>
+    </div>
+  </template>
+  <template v-else>
+    <v-card class="my-6" color="var(--bg-gray)" elevation="0">
       <v-card-text>
         <v-row align="center" no-gutters>
-          <v-col class="text-h5" cols="6">
-            {{ type === 'future' ? 'Future Appearances' : 'Past Appearances' }}
-          </v-col>
+          <v-col class="text-h5" cols="12"> Appearances </v-col>
         </v-row>
       </v-card-text>
     </v-card>
     <v-data-table-virtual
-      v-if="appearances?.length"
-      :headers="type === 'future' ? futureHeaders : pastHeaders"
-      :items="appearances"
-      :sort-by="sortBy"
-      :height="pastAppearances.length && futureAppearances.length ? 400 : 800"
-      item-value="appearanceId"
-      fixed-header
-      show-expand
-      variant="hover"
+      :headers="pastHeaders"
+      :items="pastAppearances"
+      no-data-text="No appearances"
     >
-      <template
-        v-slot:item.data-table-expand="{
-          internalItem,
-          isExpanded,
-          toggleExpand,
-        }"
-      >
-        <v-icon
-          color="primary"
-          :icon="isExpanded(internalItem) ? mdiChevronUp : mdiChevronDown"
-          @click="toggleExpand(internalItem)"
-        />
-      </template>
-      <template v-slot:expanded-row="{ columns, item }">
-        <tr class="expanded">
-          <td :colspan="columns.length">
-            <CivilAppearanceDetails
-              v-if="!isCriminal"
-              :fileId="fileNumber"
-              :appearanceId="item.appearanceId"
-            />
-          </td>
-        </tr>
-      </template>
-      <template v-slot:item.appearanceDt="{ value }">
-        <span> {{ value }} </span>
-      </template>
-      <template v-slot:item.DARS="{ item }">
-        <v-icon
-          v-if="item.appearanceStatusCd === 'SCHD'"
-          :icon="mdiHeadphones"
-        />
-      </template>
-      <template v-slot:item.appearanceReasonCd="{ value, item }">
-        <v-tooltip :text="item.appearanceReasonDsc" location="top">
-          <template v-slot:activator="{ props }">
-            <span v-bind="props" class="has-tooltip">{{ value }}</span>
-          </template>
-        </v-tooltip>
-      </template>
-      <template v-slot:item.appearanceTm="{ value, item }">
-        {{ value ? extractTime(value) : '' }} <br />
-        <span style="color: gray">
-          {{
-            hoursMinsFormatter(item.estimatedTimeHour, item.estimatedTimeMin)
-          }}
-        </span>
-      </template>
-      <template v-slot:item.courtLocation="{ value, item }">
-        {{ value }} <br />
-        <span style="color: gray">Room {{ item.courtRoomCd }}</span>
-      </template>
-      <template v-slot:item.appearanceStatusCd="{ value }">
-        <AppearanceStatusChip :status="value" />
-      </template>
     </v-data-table-virtual>
-  </div>
+  </template>
 </template>
 
 <script setup lang="ts">
   import CivilAppearanceDetails from '@/components/case-details/civil/appearances/CivilAppearanceDetails.vue';
+  import CriminalAppearanceDetails from '@/components/case-details/criminal/appearances/CriminalAppearanceDetails.vue';
   import AppearanceStatusChip from '@/components/shared/AppearanceStatusChip.vue';
   import { criminalApprDetailType } from '@/types/criminal/jsonTypes';
   import { ApprDetailType } from '@/types/shared';

--- a/web/src/components/case-details/common/AppearancesView.vue
+++ b/web/src/components/case-details/common/AppearancesView.vue
@@ -9,8 +9,8 @@
       />
     </v-col>
   </v-row>
-  <template v-if="pastAppearances.length || futureAppearances.length">
     <div
+      v-if="pastAppearances.length || futureAppearances.length"
       v-for="(appearances, type) in {
         past: pastAppearances,
         future: futureAppearances,
@@ -108,8 +108,7 @@
         </template>
       </v-data-table-virtual>
     </div>
-  </template>
-  <template v-else>
+  <div v-else>
     <v-card class="my-6" color="var(--bg-gray)" elevation="0">
       <v-card-text>
         <v-row align="center" no-gutters>
@@ -123,7 +122,7 @@
       no-data-text="No appearances"
     >
     </v-data-table-virtual>
-  </template>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/web/src/components/case-details/criminal/appearances/AppearanceCharges.vue
+++ b/web/src/components/case-details/criminal/appearances/AppearanceCharges.vue
@@ -1,0 +1,45 @@
+<template>
+  <v-data-table-virtual class="charges-table" :headers :items="charges">
+    <template v-slot:item.appearanceResultCd="{ value }">
+      <v-chip v-if="value" color="black" rounded="lg" variant="flat">
+        {{ value }}
+      </v-chip>
+    </template>
+  </v-data-table-virtual>
+</template>
+
+<script setup lang="ts">
+  import { CriminalCharges } from '@/types/criminal/jsonTypes/index';
+
+  defineProps<{ charges: CriminalCharges[] | undefined }>();
+
+  const headers = [
+    {
+      title: 'COUNT',
+      key: 'printSeqNo',
+    },
+    {
+      title: 'CRIMINAL CODE',
+      key: 'statuteSectionDsc',
+    },
+    {
+      title: 'DESCRIPTION',
+      key: 'statuteDsc',
+    },
+    {
+      title: 'LAST RESULTS',
+      key: 'appearanceResultCd',
+    },
+    {
+      title: 'FINDINGS',
+      key: 'findingCd',
+    },
+  ];
+</script>
+
+<style scoped>
+  .charges-table {
+    background-color: var(--bg-very-light-gray) !important;
+    padding-bottom: 2rem !important;
+  }
+</style>

--- a/web/src/components/case-details/criminal/appearances/AppearanceCounsel.vue
+++ b/web/src/components/case-details/criminal/appearances/AppearanceCounsel.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <span>No counsel.</span>
+  </div>
+</template>

--- a/web/src/components/case-details/criminal/appearances/AppearanceMethods.vue
+++ b/web/src/components/case-details/criminal/appearances/AppearanceMethods.vue
@@ -1,0 +1,22 @@
+<template>
+  <div v-if="appearanceMethods?.length">
+    <span v-for="method in appearanceMethods">
+      <div>
+        {{
+          `${method.roleTypeDsc} appearing by ${method.appearanceMethodDesc}`
+        }}
+      </div>
+    </span>
+  </div>
+  <div v-else>
+    <span>No appearance methods.</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { CriminalAppearanceMethod } from '@/types/criminal/jsonTypes';
+
+  defineProps<{
+    appearanceMethods: CriminalAppearanceMethod[] | undefined;
+  }>();
+</script>

--- a/web/src/components/case-details/criminal/appearances/CriminalAppearanceDetails.vue
+++ b/web/src/components/case-details/criminal/appearances/CriminalAppearanceDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <v-tabs v-model="tab" align-tabs="start" slider-color="primary">
     <v-tab value="charges">Charges</v-tab>
-    <v-tab value="methods">Appearance methods</v-tab>
+    <v-tab value="methods">Appearance Methods</v-tab>
     <v-tab value="counsel" v-if="isPast">Current Counsel</v-tab>
   </v-tabs>
 
@@ -21,7 +21,7 @@
           <AppearanceMethods :appearanceMethods="details.appearanceMethods" />
         </v-tabs-window-item>
         <v-tabs-window-item value="counsel">
-          <AppearanceCounsel />
+          <AppearanceCounsel v-if="isPast" />
         </v-tabs-window-item>
       </v-skeleton-loader>
     </v-tabs-window>

--- a/web/src/components/case-details/criminal/appearances/CriminalAppearanceDetails.vue
+++ b/web/src/components/case-details/criminal/appearances/CriminalAppearanceDetails.vue
@@ -1,0 +1,74 @@
+<template>
+  <v-tabs v-model="tab" align-tabs="start" slider-color="primary">
+    <v-tab value="charges">Charges</v-tab>
+    <v-tab value="methods">Appearance methods</v-tab>
+    <v-tab value="counsel" v-if="isPast">Current Counsel</v-tab>
+  </v-tabs>
+
+  <v-card-text>
+    <v-tabs-window v-model="tab">
+      <v-skeleton-loader
+        class="my-0"
+        type="table"
+        :height="200"
+        color="var(--bg-very-light-gray)"
+        :loading="loading"
+      >
+        <v-tabs-window-item value="charges">
+          <AppearanceCharges :charges="details.charges" />
+        </v-tabs-window-item>
+        <v-tabs-window-item value="methods">
+          <AppearanceMethods :appearanceMethods="details.appearanceMethods" />
+        </v-tabs-window-item>
+        <v-tabs-window-item value="counsel">
+          <AppearanceCounsel />
+        </v-tabs-window-item>
+      </v-skeleton-loader>
+    </v-tabs-window>
+  </v-card-text>
+</template>
+
+<script setup lang="ts">
+  import { FilesService } from '@/services/FilesService';
+  import { CriminalAppearanceDetails } from '@/types/criminal/jsonTypes';
+  import { inject, onMounted, ref } from 'vue';
+  import AppearanceCharges from './AppearanceCharges.vue';
+  import AppearanceCounsel from './AppearanceCounsel.vue';
+  import AppearanceMethods from './AppearanceMethods.vue';
+
+  const props = defineProps<{
+    fileId: string;
+    appearanceId: string;
+    partId: string;
+    isPast: boolean;
+  }>();
+
+  const filesService = inject<FilesService>('filesService');
+  const tab = ref('charges');
+  const details = ref<CriminalAppearanceDetails>(
+    {} as CriminalAppearanceDetails
+  );
+  const loading = ref(false);
+  if (!filesService) {
+    throw new Error('Files service is undefined.');
+  }
+
+  onMounted(async () => {
+    loading.value = true;
+    details.value = await filesService.criminalAppearanceDetails(
+      props.fileId,
+      props.appearanceId,
+      props.partId
+    );
+    loading.value = false;
+  });
+</script>
+
+<style scoped>
+  .v-tabs {
+    flex: 10;
+  }
+  .v-skeleton-loader {
+    display: block;
+  }
+</style>

--- a/web/src/components/criminal/CriminalCaseDetails.vue
+++ b/web/src/components/criminal/CriminalCaseDetails.vue
@@ -34,6 +34,7 @@
             <CaseHeader
               :details="details"
               :activityClassCd="details.activityClassCd"
+              :fileId="fileId"
             />
             <!-- Comment this out for now as we continue to deprecate it -->
             <!-- 
@@ -183,6 +184,7 @@
       const errorText = ref('');
       const loading = ref(false);
       const fileNumber = ref('');
+      const fileId = ref('');
 
       watch(fileNumber, () => {
         reloadCaseDetails();
@@ -270,6 +272,7 @@
                 criminalFileStore.criminalFileInformation
               );
               details.value = data;
+              fileId.value = data.justinNo;
               isDataReady.value = true;
               loading.value = false;
             } else if (errorCode.value == 0) errorCode.value = 200;
@@ -587,6 +590,7 @@
         showFutureAppearances,
         showWitnesses,
         fileNumber,
+        fileId,
         loading,
         details,
         adjudicatorRestrictions: adjudicatorRestrictionsInfo,

--- a/web/src/services/FilesService.ts
+++ b/web/src/services/FilesService.ts
@@ -1,6 +1,7 @@
 import { CourtFileSearchResponse } from '@/types/courtFileSearch';
 import { HttpService } from './HttpService';
 import { CivilAppearanceDetails } from '@/types/civil/jsonTypes/index';
+import { CriminalAppearanceDetails } from '@/types/criminal/jsonTypes/index'
 
 export class FilesService {
   private httpService: HttpService;
@@ -29,6 +30,12 @@ export class FilesService {
   async civilAppearanceDetails(fileId: string, appearanceId: string): Promise<CivilAppearanceDetails> {
     return this.httpService.get<any>(
       `${this.baseUrl}/civil/${fileId}/appearance-detail/${appearanceId}`
+    );
+  }
+
+  async criminalAppearanceDetails(fileId: string, appearanceId: string, partId: string): Promise<CriminalAppearanceDetails> {
+    return this.httpService.get<any>(
+      `${this.baseUrl}/criminal/${fileId}/appearance-detail/${appearanceId}/${partId}`
     );
   }
 }

--- a/web/src/types/criminal/jsonTypes/index.ts
+++ b/web/src/types/criminal/jsonTypes/index.ts
@@ -221,3 +221,126 @@ export interface criminalFileDetailsType extends FileDetailsType {
   hearingRestriction: criminalHearingRestrictionType[];
   appearances: criminalAppearancesType;
 }
+
+export interface JustinCounsel {
+  fullName: string;
+  counselLastNm: string;
+  counselGivenNm: string;
+  counselEnteredDt: string;
+  counselPartId: string;
+  counselRelatedRepTypeCd: string;
+  counselRrepId: string;
+  partyAppearanceMethod: string;
+  partyAppearanceMethodDesc: string;
+  attendanceMethodCd: string;
+  attendanceMethodDesc: string;
+  appearanceMethodCd: string;
+  appearanceMethodDesc: string;
+}
+
+export interface CriminalAccused {
+  fullName: string;
+  partId: string;
+  partyAppearanceMethod: string;
+  partyAppearanceMethodDesc: string;
+  attendanceMethodCd: string;
+  attendanceMethodDesc: string;
+  appearanceMethodCd: string;
+  appearanceMethodDesc: string;
+}
+
+export interface Prosecutor {
+  fullName: string;
+  partId: string;
+  partyAppearanceMethod: string;
+  partyAppearanceMethodDesc: string;
+  attendanceMethodCd: string;
+  attendanceMethodDesc: string;
+  appearanceMethodCd: string;
+  appearanceMethodDesc: string;
+}
+
+export interface CriminalAdjudicator {
+  fullName: string;
+  partId: string;
+  partyAppearanceMethod: string;
+  partyAppearanceMethodDesc: string;
+  attendanceMethodCd: string;
+  attendanceMethodDesc: string;
+  appearanceMethodCd: string;
+  appearanceMethodDesc: string;
+}
+
+export interface CriminalAppearanceCount {
+  printSeqNo: string;
+  statuteSectionDsc: string;
+  statuteDsc: string;
+  appearanceReasonCd: string;
+  appearanceResultCd: string;
+  findingCd: string;
+  additionalProperties: { [key: string]: any };
+}
+
+export interface CriminalCharges extends CriminalAppearanceCount {
+  appearanceReasonDsc: string;
+  appearanceResultDesc: string;
+  findingDsc: string;
+}
+
+export interface CfcDocument {
+  docmClassification: string;
+  docmId: string;
+  issueDate: string;
+  docmFormId: string;
+  docmFormDsc: string;
+  docmDispositionDsc: string;
+  docmDispositionDate: string;
+  imageId: string;
+  documentPageCount: string;
+  additionalProperties: { [key: string]: any };
+}
+
+export interface CriminalDocument extends CfcDocument {
+  partId: string;
+  category: string;
+  documentTypeDescription: string;
+  hasFutureAppearance: boolean | null;
+}
+
+export enum CriminalFileDetailResponseCourtLevelCd {
+  P = 0,
+  S = 1,
+  A = 2,
+}
+
+export interface CriminalAppearanceMethod {
+  roleTypeDsc: string;
+  appearanceMethodDesc: string;
+  assetUsageSeqNo: string;
+  roleTypeCd: string;
+  appearanceMethodCd: string;
+  apprMethodCcn: string;
+}
+
+export interface CriminalAppearanceDetails {
+  justinNo: string;
+  appearanceId: string;
+  partId: string;
+  agencyId: string;
+  profSeqNo: string;
+  courtRoomCd: string;
+  fileNumberTxt: string;
+  appearanceDt: string;
+  justinCounsel: JustinCounsel;
+  accused: CriminalAccused;
+  prosecutor: Prosecutor;
+  adjudicator: CriminalAdjudicator;
+  judgesRecommendation: string;
+  appearanceNote: string;
+  charges: CriminalCharges[];
+  appearanceMethods: CriminalAppearanceMethod[];
+  estimatedTimeHour: string;
+  estimatedTimeMin: string;
+  initiatingDocuments: CriminalDocument[];
+  courtLevelCd: CriminalFileDetailResponseCourtLevelCd;
+}

--- a/web/tests/components/case-details/common/AppearancesView.test.ts
+++ b/web/tests/components/case-details/common/AppearancesView.test.ts
@@ -45,11 +45,13 @@ describe('AppearancesView.vue', () => {
     };
   });
 
-  it('does not render cards or tables if no appearances are provided', () => {
+  it('renders default card and table if no appearances are provided', () => {
     const wrapper = mount(AppearancesView, { props: { appearances: [] } });
 
-    expect(wrapper.find('v-card').exists()).toBe(false);
-    expect(wrapper.find('v-data-table-virtual').exists()).toBe(false);
+    const card = wrapper.find('v-card');
+    expect(card.exists()).toBe(true);
+    expect(card.text()).toContain('Appearances');
+    expect(wrapper.find('v-data-table-virtual').exists()).toBe(true);
   });
 
   it('renders only past appearances', () => {

--- a/web/tests/components/case-details/criminal/appearances/AppearanceMethods.test.ts
+++ b/web/tests/components/case-details/criminal/appearances/AppearanceMethods.test.ts
@@ -1,0 +1,34 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import AppearanceMethods from 'CMP/case-details/criminal/appearances/AppearanceMethods.vue'
+
+describe('AppearanceMethods.vue', () => {
+  it('renders appearance methods when provided', () => {
+    const appearanceMethods = [
+      {
+        roleTypeDsc: 'Defendant',
+        appearanceMethodDesc: 'In Person'
+      },
+      {
+        roleTypeDsc: 'Witness',
+        appearanceMethodDesc: 'Video Conference'
+      }
+    ]
+    const wrapper = mount(AppearanceMethods, {
+      props: { appearanceMethods }
+    })
+    expect(wrapper.text()).toContain('Defendant appearing by In Person')
+    expect(wrapper.text()).toContain('Witness appearing by Video Conference')
+  })
+
+    it.each([
+    { method: undefined },
+    { method: null },
+    { method: [] },
+  ])('renders default text when appearanceMethods is falsy', ({ method }) => {
+    const wrapper = mount(AppearanceMethods, {
+      props: { appearanceMethods: method }
+    })
+    expect(wrapper.text()).toContain('No appearance methods.')
+  })
+})

--- a/web/tests/components/case-details/criminal/appearances/CriminalAppearanceDetails.test.ts
+++ b/web/tests/components/case-details/criminal/appearances/CriminalAppearanceDetails.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CriminalAppearanceDetails from 'CMP/case-details/criminal/appearances/CriminalAppearanceDetails.vue';
+import { FilesService } from '@/services/FilesService';
+
+vi.mock('@/services/FilesService');
+
+describe('CriminalAppearanceDetails.vue', () => {
+  let wrapper: any;
+  let filesService: any;
+
+  const mockDetails = {
+    appearanceMethod: [
+      { roleTypeDesc: 'Plaintiff', appearanceMethodDesc: 'In Person' },
+    ],
+    document: [{ id: 1, name: 'Document 1' }],
+    party: [{ id: 1, name: 'Party 1' }],
+  };
+
+  beforeEach(() => {
+    filesService = {
+      criminalAppearanceDetails: vi.fn().mockResolvedValue([
+        mockDetails
+      ])
+    };
+    (FilesService as any).mockReturnValue(filesService);
+    wrapper = mount(CriminalAppearanceDetails, {
+      global: {
+        provide: {
+          filesService
+        }
+      },
+      props: {
+        fileId: '123',
+        appearanceId: '456',
+        partId: '789',
+        isPast: true
+      },
+    });
+  });
+
+  it('renders the tabs correctly', () => {
+    const tabs = wrapper.findAll('v-tab');
+    expect(tabs.length).toBe(3);
+    expect(tabs[0].text()).toBe('Charges');
+    expect(tabs[1].text()).toBe('Appearance Methods');
+    expect(tabs[2].text()).toBe('Current Counsel');
+  });
+
+  it('calls appearance details api with correct parameters', async () => {
+    expect(filesService.criminalAppearanceDetails).toHaveBeenCalledWith(
+      '123',
+      '456',
+      '789'
+    );
+  });
+
+  it('renders AppearanceMethods component when "methods" tab is active', async () => {
+    wrapper.vm.tab = 'methods';
+    expect(wrapper.findComponent({name: 'AppearanceMethods'}).exists()).toBe(true);
+  });
+
+  it('renders AppearanceCounsel component when "counsel" tab is active', async () => {
+    wrapper.vm.tab = 'counsel';
+    expect(wrapper.findComponent({name: 'AppearanceCounsel'}).exists()).toBe(true);
+  });
+
+    it('does not render AppearanceCounsel component when is future appearance', async () => {
+    wrapper = mount(CriminalAppearanceDetails, {
+      global: {
+        provide: {
+          filesService
+        }
+      },
+      props: {
+        fileId: '123',
+        appearanceId: '456',
+        partId: '789',
+        isPast: false
+      },
+    });
+    wrapper.vm.tab = 'counsel';
+    expect(wrapper.findComponent({name: 'AppearanceCounsel'}).exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[346](https://jira.justice.gov.bc.ca/browse/JASPER-346)**----    

## 🦹 Criminal appearance expandable row 🚣
Add ability to drop down a criminal appearance in the appearances table to view it's information at a finer detail.
The counsel tab will not be hooked up until we are able to call the PCSS endpoint to get that info.
This PR also changes the default behavior for how the UI displays no appearances. Before the component was just empty, but now it will show an empty table and a card above it that reads "Appearances".

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran `./manage` script
- [x] Unit tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Screengrab of changes

https://github.com/user-attachments/assets/eabc815b-aa5c-4273-89c0-27a19b2f0b07

