### PR TITLE
JASPER-382: Court List - Update File Markers

### DIFF
--- a/web/src/components/shared/FileMarkers.vue
+++ b/web/src/components/shared/FileMarkers.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-chip
-      v-for="{ key, description, value } in data"
+      v-for="{ key, description, value, notes } in data"
       :key
       rounded="lg"
       variant="outlined"
@@ -10,8 +10,19 @@
       selected-class="selected"
     >
       {{ key }}
-      <v-tooltip activator="parent" location="bottom">
-        {{ description }}
+      <v-tooltip
+        v-if="(notes && notes.length > 0) || description"
+        activator="parent"
+        location="bottom"
+      >
+        <div v-if="notes" class="d-flex flex-column">
+          <div v-for="(item, index) in notes" :key="index">
+            {{ item }}
+          </div>
+        </div>
+        <div v-else-if="description">
+          {{ description }}
+        </div>
       </v-tooltip>
     </v-chip>
   </div>
@@ -22,16 +33,19 @@
 
   const props = defineProps<{
     classOverride: string;
-    markers: { marker: FileMarkerEnum; value: string }[];
+    markers: { marker: FileMarkerEnum; value: string; notes?: string[] }[];
   }>();
 
   const allMarkers = [
+    { marker: FileMarkerEnum.ADJ, description: '' },
     { marker: FileMarkerEnum.CNT, description: 'Continuation' },
     { marker: FileMarkerEnum.CPA, description: 'Child Protection Act' },
+    { marker: FileMarkerEnum.CSO, description: 'Conditional Sentence Order' },
     { marker: FileMarkerEnum.DO, description: 'Detention Order' },
     { marker: FileMarkerEnum.IC, description: 'In Custody' },
     { marker: FileMarkerEnum.INT, description: 'Interpreter Required' },
     { marker: FileMarkerEnum.LOCT, description: 'Lack of Court Time' },
+    { marker: FileMarkerEnum.OTH, description: '' },
     { marker: FileMarkerEnum.W, description: 'Warrant Issued' },
   ];
 

--- a/web/src/types/common/index.ts
+++ b/web/src/types/common/index.ts
@@ -114,11 +114,14 @@ export enum CourtClassEnum {
 }
 
 export enum FileMarkerEnum {
-  CNT = 0,
+  ADJ = 0,
+  CNT,
   CPA,
+  CSO,
   DO,
   IC,
   INT,
   LOCT,
+  OTH,
   W,
 }

--- a/web/src/types/courtlist/index.ts
+++ b/web/src/types/courtlist/index.ts
@@ -262,7 +262,7 @@ export interface CourtListAppearance {
   justinApprId: string;
   ceisAppearanceId: string;
   jcmComments?: JcmComment2[];
-  appearanceAdjudicatorRestriction?: any[];
+  appearanceAdjudicatorRestriction?: AppearanceAdjudicatorRestriction[];
   stoodDownJCMYn: string;
   courtClassCd: string;
   appearanceSequenceNumber: string;
@@ -339,4 +339,15 @@ export interface JcmComment2 {
   updDtm: string;
   rotaInitialsCd: string;
   fullName: string;
+}
+
+export interface AppearanceAdjudicatorRestriction {
+  appearanceAdjudicatorRestrictionId: number;
+  hearingRestrictionId: number;
+  hearingRestrictionCd: string;
+  judgeId: number;
+  judgesInitials: string;
+  fileNoTxt: string;
+  hearingRestrictionTxt: string;
+  hasIssue: boolean;
 }

--- a/web/tests/components/shared/FileMarkers.test.ts
+++ b/web/tests/components/shared/FileMarkers.test.ts
@@ -1,4 +1,5 @@
 import { FileMarkerEnum } from '@/types/common';
+import { faker } from '@faker-js/faker';
 import { mount } from '@vue/test-utils';
 import FileMarkers from 'CMP/shared/FileMarkers.vue';
 import { describe, expect, it } from 'vitest';
@@ -41,5 +42,33 @@ describe('FileMarkers.vue', () => {
     expect(descriptions).toContain('In Custody');
     expect(descriptions).toContain('Detention Order');
     expect(descriptions).toContain('Interpreter Required');
+  });
+
+  it('renders child divs when there are multiple notes', async () => {
+    const fakeNote1 = faker.lorem.words(5);
+    const fakeNote2 = faker.lorem.words(5);
+    const fakeNote3 = faker.lorem.words(5);
+
+    const wrapper = mount(FileMarkers, {
+      props: {
+        markers: [
+          {
+            marker: FileMarkerEnum.ADJ,
+            value: '',
+            notes: [fakeNote1, fakeNote2, fakeNote3],
+          },
+        ],
+      },
+    });
+
+    await nextTick();
+
+    const tooltip = wrapper.find('v-tooltip div');
+    const notes = tooltip.findAll('div');
+
+    expect(notes.length).toBe(3);
+    expect(notes[0].text()).toEqual(fakeNote1);
+    expect(notes[1].text()).toEqual(fakeNote2);
+    expect(notes[2].text()).toEqual(fakeNote3);
   });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-382

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-382

## Description
Update Court List to render appropriate file markers for criminal, sc, mva, enforcement, family and with adjudicator restrictions

_Note: Current implementation only shows `ADJ` file marker when there are AR. We are waiting for confirmation from client if this is the desired behavior._

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Local

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


https://github.com/user-attachments/assets/e11ec9a9-0649-4cab-ae10-c680681bb0cc