### PR TITLE
JASPER 408: Reduce whitespace in Case-Details side-panel

### DIFF
--- a/web/src/components/case-details/civil/parties/Party.vue
+++ b/web/src/components/case-details/civil/parties/Party.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-card variant="text" class="mb-4">
+  <v-card variant="text" class="my-2">
     <v-row>
-      <v-col class="pb-0">
+      <v-col>
         <v-chip
           variant="flat"
           rounded="lg"
@@ -12,17 +12,17 @@
         </v-chip>
       </v-col>
     </v-row>
-    <v-row v-if="showAlias">
+    <v-row v-if="showAlias" class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Alias</v-col>
       <v-col>
         <LabelWithTooltip :values="aliases" />
       </v-col>
     </v-row>
-    <v-row>
+    <v-row class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Role</v-col>
       <v-col>{{ party.roleTypeDescription }}</v-col>
     </v-row>
-    <v-row>
+    <v-row class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Counsel</v-col>
       <v-col>
         <LabelWithTooltip :values="counselNames" />

--- a/web/src/components/case-details/common/accused/Accused.vue
+++ b/web/src/components/case-details/common/accused/Accused.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card variant="text" class="my-3 pb-5">
+  <v-card variant="text" class="my-2">
     <v-row>
       <v-col cols="12">
         <v-chip
@@ -13,12 +13,12 @@
         </v-chip>
       </v-col>
     </v-row>
-    <v-row class="mx-1 mt-2">
+    <v-row class="mx-1 mt-0">
       <v-col cols="12">
         <FileMarkers class-override="mr-2" :markers="fileMarkers" />
       </v-col>
     </v-row>
-    <v-row class="mx-1 mt-2">
+    <v-row class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Ban</v-col>
       <v-col>
         <div v-for="(bans, banType, index) in groupedBans" :key="banType">
@@ -35,15 +35,15 @@
         </div>
       </v-col>
     </v-row>
-    <v-row class="mx-1 mt-2">
+    <v-row class="mx-1 mt-0">
       <v-col cols="6" class="data-label">DOB</v-col>
       <v-col>{{ formatDateToDDMMMYYYY(accused.birthDt) }}</v-col>
     </v-row>
-    <v-row class="mx-1 mt-2">
+    <v-row class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Counsel</v-col>
       <v-col>{{ counselName }}</v-col>
     </v-row>
-    <v-row class="mx-1 mt-2">
+    <v-row class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Counsel Desig. Filed</v-col>
       <v-col>{{ accused.designatedCounselYN }}</v-col>
     </v-row>
@@ -56,7 +56,7 @@
       <v-col cols="6" class="data-label">Plea</v-col>
       <v-col></v-col>
     </v-row> -->
-    <v-row class="mx-1 mt-2">
+    <v-row class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Appearances</v-col>
       <v-col>{{ appearances.length }}</v-col>
     </v-row>

--- a/web/src/components/case-details/common/accused/Accused.vue
+++ b/web/src/components/case-details/common/accused/Accused.vue
@@ -50,7 +50,6 @@
       <v-col cols="6" class="data-label">Age/Notice</v-col>
       <v-col> {{ ageNotice }} </v-col>
     </v-row>
-    <v-row class="mx-1 mt-2">
     <v-row class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Counsel Desig. Filed</v-col>
       <v-col>{{ accused.designatedCounselYN }}</v-col>

--- a/web/src/components/case-details/criminal/CriminalSummary.vue
+++ b/web/src/components/case-details/criminal/CriminalSummary.vue
@@ -1,21 +1,30 @@
 <template>
   <h5 class="my-1">Case Details</h5>
   <v-card color="var(--bg-gray)" flat>
-    <div class="m-3 d-flex align-center">
-      <DivisionBadge division="Criminal" :activityClassDesc :courtClassCd />
+    <div class="mx-2 d-flex align-center pt-2">
+      <DivisionBadge
+        division="Criminal"
+        :activityClassDesc
+        :courtClassCd
+        class="my-0"
+      />
       <span v-if="bansExist"><b style="color: var(--text-red)">BAN</b></span>
     </div>
-    <v-card-title style="text-wrap: wrap">{{ names }}</v-card-title>
-    <v-card-subtitle>{{ location }}</v-card-subtitle>
-    <v-row class="mx-1 mt-2">
+    <v-card-item>
+      <v-card-title class="my-0" style="text-wrap: wrap">
+        {{ names }}
+      </v-card-title>
+      <v-card-subtitle>{{ location }}</v-card-subtitle>
+    </v-card-item>
+    <v-row class="mx-3" dense>
       <v-col cols="6" class="data-label">Proceeded</v-col>
       <v-col> {{ proceeded }}</v-col>
     </v-row>
-    <v-row class="mx-1">
+    <v-row class="mx-3" dense>
       <v-col cols="6" class="data-label">Crown</v-col>
       <v-col>{{ crownName }}</v-col>
     </v-row>
-    <v-row class="mx-1 mb-1">
+    <v-row class="mx-3 pb-1" dense>
       <v-col cols="6" class="data-label">Case Age (days)</v-col>
       <v-col>{{ details.caseAgeDays }}</v-col>
     </v-row>


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[408](https://jira.justice.gov.bc.ca/browse/JASPER-408)**----    

## Reduce overall empty space of case-details

## How Has This Been Tested?

- [x] Ran `./manage` script

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Screenshot of changes
Criminal:
![image](https://github.com/user-attachments/assets/10df7925-bddd-4fd4-82de-36944f432a6d)

Civil:
![image](https://github.com/user-attachments/assets/43397667-0fcf-4035-bfc9-b097b44d5835)
