### PR TITLE
Migrate from devcontainers-contrib to devcontainers-extra

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     "ghcr.io/devcontainers/features/aws-cli:1": {},
     "ghcr.io/devcontainers/features/terraform:1": {},
     "ghcr.io/devcontainers/features/docker-from-docker:1.5.0": {},
-    "ghcr.io/devcontainers-contrib/features/aws-cdk:2": {},
+    "ghcr.io/devcontainers-extra/features/aws-cdk:2": {},
     "ghcr.io/dhoeric/features/tfsec:1": {}
   },
   "customizations": {


### PR DESCRIPTION
Yesterday, I encountered an issue (could not resolve manifest for aws-cdk) when loading JASPER in devcontainer. As per my research, `devcontainers-contrib` is no longer advisable to be used and should be replaced by `devcontainers-extra`.

More info can be found here: https://github.com/devcontainers-extra/features/issues/123#issuecomment-2933883193