### PR TITLE
JASPER 424: Sentence-order - Remove 10 item table limit

### DIFF
--- a/web/src/components/case-details/criminal/sentence-order-details/SentenceOrderDetailsTable.vue
+++ b/web/src/components/case-details/criminal/sentence-order-details/SentenceOrderDetailsTable.vue
@@ -1,13 +1,12 @@
 <template>
-  <v-data-table
+  <v-data-table-virtual
     :headers
     :group-by
     :items="data"
-    no-data-text="No sentences"
     :show-select="false"
-    hide-default-footer
-    hide-pagination
     :sort-by="sortBy"
+    no-data-text="No sentences"
+    height="800"
   >
     <template v-slot:group-header="{ item, columns, isGroupOpen, toggleGroup }">
       <tr>
@@ -86,7 +85,7 @@
         </td>
       </tr>
     </template>
-  </v-data-table>
+  </v-data-table-virtual>
 </template>
 <script setup lang="ts">
   import { criminalParticipantType } from '@/types/criminal/jsonTypes';


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[424](https://jira.justice.gov.bc.ca/browse/JASPER-424)**----    

## Description
We were using the default max-row amount for `v-data-tabel`, which is 10.
I have updated this table to a `v-data-table-virtual` which has a much larger limit and is more performant when not using data that needs to be manipulated in any way.
Also set a max-height for the table to stay in line with the other tables on the other tabs.

Fixes # [424](https://jira.justice.gov.bc.ca/browse/JASPER-424)  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   