### PR TITLE
JASPER 422: Hide Civil FileNumber qualifiers

### DIFF
--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -36,7 +36,12 @@
             :error-messages="searchErrorMessages"
           />
         </v-col>
-        <template v-if="searchCriteria.searchBy === 'fileNumber'">
+        <template
+          v-if="
+            searchCriteria.searchBy === 'fileNumber' &&
+            searchCriteria.isCriminal
+          "
+        >
           <v-col cols="1">
             <v-text-field
               label="Prefix"
@@ -84,7 +89,7 @@
             "
           />
         </v-col>
-        <v-col :cols="searchCriteria.searchBy === 'orgName' ? 2 : ''">
+        <v-col style="max-width: 20rem">
           <v-select
             v-model="selectedDivision"
             label="Division"
@@ -137,7 +142,7 @@
   import { LocationService } from '@/services/LocationService';
   import { LookupService } from '@/services/LookupService';
   import { useCourtFileSearchStore } from '@/stores';
-  import { KeyValueInfo, LookupCode, CourtClassEnum } from '@/types/common';
+  import { CourtClassEnum, KeyValueInfo, LookupCode } from '@/types/common';
   import {
     CourtFileSearchCriteria,
     FileDetail,
@@ -151,7 +156,7 @@
   const SEARCH_RESULT_LIMIT = 100;
 
   const courtFileSearchStore = useCourtFileSearchStore();
-  const defaultLocation = '';
+  const defaultLocation = undefined;
   let searchCriteria: CourtFileSearchCriteria = reactive({
     isCriminal: true,
     isFamily: false,
@@ -358,7 +363,7 @@
   };
 
   const loadClasses = () => {
-    searchCriteria.class = '';
+    searchCriteria.class = null;
     if (selectedDivision.value === 'isCriminal') {
       classOptions.value = classes.value.filter(
         (c) => c.longDesc === CRIMINAL_CODE

--- a/web/src/types/courtFileSearch/index.ts
+++ b/web/src/types/courtFileSearch/index.ts
@@ -1,6 +1,6 @@
 import { chargeType } from "../criminal/jsonTypes";
 
-// Intefaces
+// Interfaces
 export interface CourtFileSearchCriteria {
   isCriminal: boolean;
   isFamily: boolean;
@@ -14,7 +14,7 @@ export interface CourtFileSearchCriteria {
   givenName?: string;
   orgName?: string;
   class?: string;
-  fileHomeAgencyId: string;
+  fileHomeAgencyId?: string;
 }
 
 export interface CourtFileSearchResponse {


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[422](https://jira.justice.gov.bc.ca/browse/JASPER-422)**----    

## 🥷 Hide FileNumber qualifier search criteria when searching for civil cases 💼

## How Has This Been Tested?

- [ ] Ran `./manage` script
- [ ] Unit tested (this file is lacking unit tests in general)  

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules   