### PR TITLE
JASPER 421: Only show file markers that are "set"

### DIFF
--- a/web/src/components/shared/FileMarkers.vue
+++ b/web/src/components/shared/FileMarkers.vue
@@ -34,7 +34,6 @@
     classOverride: string;
     markers: { marker: FileMarkerEnum; value: string; notes?: string[] }[];
   }>();
-  console.log(props.markers);
 
   const allMarkers = [
     { marker: FileMarkerEnum.ADJ, description: '' },

--- a/web/src/components/shared/FileMarkers.vue
+++ b/web/src/components/shared/FileMarkers.vue
@@ -1,13 +1,12 @@
 <template>
   <div>
     <v-chip
-      v-for="{ key, description, notes, value } in data"
+      v-for="{ key, description, notes } in data"
       :key
       rounded="lg"
       variant="outlined"
       size="small"
-      :class="[classOverride, explicit ? { selected: value } : {}]"
-      selected-class="selected"
+      :class="classOverride"
     >
       {{ key }}
       <v-tooltip
@@ -34,8 +33,8 @@
   const props = defineProps<{
     classOverride: string;
     markers: { marker: FileMarkerEnum; value: string; notes?: string[] }[];
-    explicit?: boolean; // If true, show all markers regardless of value
   }>();
+  console.log(props.markers);
 
   const allMarkers = [
     { marker: FileMarkerEnum.ADJ, description: '' },
@@ -49,27 +48,19 @@
     { marker: FileMarkerEnum.OTH, description: '' },
     { marker: FileMarkerEnum.W, description: 'Warrant Issued' },
   ];
-
   const data = props.markers
-    .filter((m) => props.explicit || m.value === 'Y')
-    .map((m) => {
-      const match = allMarkers.find((am) => am.marker === m.marker);
-      return {
-        ...match,
-        key: Object.entries(FileMarkerEnum).find(
-          ([, val]) => val === m.marker
-        )?.[0],
-        notes: m.notes,
-        value: m.value === 'Y',
-      };
-    });
+    .filter((m) => m.value === 'Y')
+    .map((m) => ({
+      key: Object.keys(FileMarkerEnum).find(
+        (k) => FileMarkerEnum[k as keyof typeof FileMarkerEnum] === m.marker
+      ),
+      notes: m.notes,
+      description: allMarkers[m.marker]?.description,
+    }));
 </script>
+
 <style scoped>
   .v-chip {
     cursor: default;
-  }
-  .selected {
-    background-color: #183a4a !important;
-    color: white !important;
   }
 </style>

--- a/web/src/components/shared/FileMarkers.vue
+++ b/web/src/components/shared/FileMarkers.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <v-chip
-      v-for="{ key, description, value, notes } in data"
+      v-for="{ key, description, notes, value } in data"
       :key
       rounded="lg"
       variant="outlined"
       size="small"
-      :class="[classOverride, { selected: value }]"
+      :class="[classOverride, explicit ? { selected: value } : {}]"
       selected-class="selected"
     >
       {{ key }}
@@ -34,6 +34,7 @@
   const props = defineProps<{
     classOverride: string;
     markers: { marker: FileMarkerEnum; value: string; notes?: string[] }[];
+    explicit?: boolean; // If true, show all markers regardless of value
   }>();
 
   const allMarkers = [
@@ -49,17 +50,19 @@
     { marker: FileMarkerEnum.W, description: 'Warrant Issued' },
   ];
 
-  const data = props.markers.map((m) => {
-    const match = allMarkers.find((am) => am.marker === m.marker);
-    return {
-      ...m,
-      ...match,
-      key: Object.entries(FileMarkerEnum).find(
-        ([, val]) => val === m.marker
-      )?.[0],
-      value: m.value === 'Y',
-    };
-  });
+  const data = props.markers
+    .filter((m) => props.explicit || m.value === 'Y')
+    .map((m) => {
+      const match = allMarkers.find((am) => am.marker === m.marker);
+      return {
+        ...match,
+        key: Object.entries(FileMarkerEnum).find(
+          ([, val]) => val === m.marker
+        )?.[0],
+        notes: m.notes,
+        value: m.value === 'Y',
+      };
+    });
 </script>
 <style scoped>
   .v-chip {

--- a/web/src/components/shared/FileMarkers.vue
+++ b/web/src/components/shared/FileMarkers.vue
@@ -61,5 +61,6 @@
 <style scoped>
   .v-chip {
     cursor: default;
+    padding: 2px;
   }
 </style>

--- a/web/tests/components/shared/FileMarkers.test.ts
+++ b/web/tests/components/shared/FileMarkers.test.ts
@@ -16,7 +16,7 @@ describe('FileMarkers.vue', () => {
     ],
   };
 
-  it('renders markers', async () => {
+  it('renders enabled markers', async () => {
     const wrapper = mount(FileMarkers, { props });
 
     await nextTick();

--- a/web/tests/components/shared/FileMarkers.test.ts
+++ b/web/tests/components/shared/FileMarkers.test.ts
@@ -22,10 +22,8 @@ describe('FileMarkers.vue', () => {
     await nextTick();
 
     const chips = wrapper.findAll('v-chip');
-    const selectedChips = wrapper.findAll('v-chip.selected');
 
-    expect(chips.length).toBe(4); // W, IC, DO, INT
-    expect(selectedChips.length).toBe(2); // W, INT
+    expect(chips.length).toBe(2); // W, DO
     expect(chips[0].classes()).toContain('pt-1');
   });
 
@@ -37,11 +35,11 @@ describe('FileMarkers.vue', () => {
     const tooltips = wrapper.findAll('v-tooltip');
     const descriptions = tooltips.map((tooltip) => tooltip.text());
 
-    expect(tooltips.length).toBe(4);
+    expect(tooltips.length).toBe(2); // W, DO
     expect(descriptions).toContain('Warrant Issued');
-    expect(descriptions).toContain('In Custody');
+    expect(descriptions).not.toContain('In Custody');
     expect(descriptions).toContain('Detention Order');
-    expect(descriptions).toContain('Interpreter Required');
+    expect(descriptions).not.toContain('Interpreter Required');
   });
 
   it('renders child divs when there are multiple notes', async () => {
@@ -54,7 +52,7 @@ describe('FileMarkers.vue', () => {
         markers: [
           {
             marker: FileMarkerEnum.ADJ,
-            value: '',
+            value: 'Y',
             notes: [fakeNote1, fakeNote2, fakeNote3],
           },
         ],


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[421](https://jira.justice.gov.bc.ca/browse/JASPER-421)**----    

## 📄 Adjust how file markers display 👁️
We no longer want to display file markers for an appearance when they are not enabled

## How Has This Been Tested?

- [x] Ran `./manage` script
- [x] Unit tested 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screengrab of changes
Court-list
![image](https://github.com/user-attachments/assets/81c7384f-f0f4-4f0b-a83e-e194db039194)
Case-details
![image](https://github.com/user-attachments/assets/8a3a6f36-e85d-4b86-b1aa-85a196b3e3c5)
