### PR TITLE
Fix Infinite Load in Dashboard

### DIFF
--- a/web/src/components/dashboard/Dashboard.vue
+++ b/web/src/components/dashboard/Dashboard.vue
@@ -356,8 +356,13 @@
 
   onMounted(async () => {
     isLoading.value = true;
-    await Promise.all([loadLocations(), loadCalendarData()]);
-    isLoading.value = false;
+    try {
+      await Promise.all([loadLocations(), loadCalendarData()]);
+    } catch (error) {
+      console.error('Retrieving data failed.', error);
+    } finally {
+      isLoading.value = false;
+    }
   });
 
   watch(selectedDate, async (newVal) => {


### PR DESCRIPTION
This fixes the infinite loading when api for retrieving calendar data fails. The calendar would still show but with blank data making the user experience better.