### PR TITLE
JASPER 350: Court-list criminal appearance expanded panel

### DIFF
--- a/api/Services/Files/CriminalFilesService.cs
+++ b/api/Services/Files/CriminalFilesService.cs
@@ -236,10 +236,21 @@ namespace Scv.Api.Services.Files
 
         #region Criminal Details
 
-        private List<CriminalDocument> GetInitiatingDocuments(ICollection<CfcDocument> documents)
+        private static List<CriminalDocument> GetInitiatingDocuments(ICollection<CfcDocument> documents)
         {
             return documents?.Where(doc => doc?.DocmClassification == "Initiating" && !string.IsNullOrEmpty(doc.ImageId))
-                .Select(a => new CriminalDocument { IssueDate = a.IssueDate, ImageId = a.ImageId }).ToList();
+                .Select(doc =>
+                    new CriminalDocument
+                    {
+                        IssueDate = doc.IssueDate,
+                        ImageId = doc.ImageId,
+                        DocmClassification = doc.DocmClassification,
+                        DocmDispositionDsc = doc.DocmDispositionDsc,
+                        DocmFormDsc = doc.DocmFormDsc,
+                        DocmFormId = doc.DocmFormId,
+                        DocmId = doc.DocmId,
+                        DocumentPageCount = doc.DocumentPageCount
+                    }).ToList();
         }
 
         private async Task<CriminalFileAppearances> PopulateDetailsAppearancesAsync(string fileId, FutureYN? future, HistoryYN? history)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,7 +34,7 @@
         "vue": "^3.5.17",
         "vue-month-picker": "^1.7.2",
         "vue-router": "^4.5.1",
-        "vuetify": "^3.8.6"
+        "vuetify": "3.7.6"
       },
       "devDependencies": {
         "@faker-js/faker": "^9.8.0",
@@ -6751,9 +6751,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.8.6.tgz",
-      "integrity": "sha512-WU7BrS0rKtewaU1e0SjJmUVc23k1Y9L5+aJdSmezAYlxYbHprlFVYeZZvwj1kA9xrPE8MGguvMQgePSxxD/l2w==",
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.6.tgz",
+      "integrity": "sha512-lol0Va5HtMIqZfjccSD5DLv5v31R/asJXzc6s7ULy51PHr1DjXxWylZejhq0kVpMGW64MiV1FmA/p8eYQfOWfQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.20 || >=14.13"
@@ -6764,9 +6764,9 @@
       },
       "peerDependencies": {
         "typescript": ">=4.7",
-        "vite-plugin-vuetify": ">=2.1.0",
-        "vue": "^3.5.0",
-        "webpack-plugin-vuetify": ">=3.1.0"
+        "vite-plugin-vuetify": ">=1.0.0",
+        "vue": "^3.3.0",
+        "webpack-plugin-vuetify": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/web/package.json
+++ b/web/package.json
@@ -47,7 +47,7 @@
     "vue": "^3.5.17",
     "vue-month-picker": "^1.7.2",
     "vue-router": "^4.5.1",
-    "vuetify": "^3.8.6"
+    "vuetify": "3.7.6"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.8.0",

--- a/web/src/components/case-details/common/AppearancesView.vue
+++ b/web/src/components/case-details/common/AppearancesView.vue
@@ -42,13 +42,9 @@
       show-expand
       variant="hover"
     >
-      <template
-        v-slot:item.data-table-expand="{
-          internalItem,
-          isExpanded,
-          toggleExpand,
-        }"
-      >
+    <template
+      v-slot:item.data-table-expand="{ internalItem, isExpanded, toggleExpand }"
+    >
         <v-icon
           color="primary"
           :icon="isExpanded(internalItem) ? mdiChevronUp : mdiChevronDown"

--- a/web/src/components/courtfilesearch/CourtFileSearchResult.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchResult.vue
@@ -13,11 +13,13 @@
       <h3 class="px-2 py-2">Search Results</h3>
     </v-banner>
     <v-skeleton-loader type="table" :loading="isSearching">
-      <v-data-table
+      <v-data-table-virtual
         v-model="selectedItems"
+        show-select
         :group-by
         :items-per-page="maxItemsPerPage"
         :headers
+        :return-object="true"
         :items="searchResults"
         :item-value="idSelector"
       >
@@ -43,8 +45,7 @@
             </td>
           </tr>
         </template>
-        <template v-slot:bottom />
-      </v-data-table>
+      </v-data-table-virtual>
     </v-skeleton-loader>
     <action-bar :selected="selectedItems" @clicked="handleViewFilesClick">
       <v-btn
@@ -145,6 +146,15 @@
       title: 'Next appearance',
       key: 'nextApprDt',
       value: (item: FileDetail) => `${beautifyDate(item.nextApprDt)}`,
+      sortRaw: (a: FileDetail, b: FileDetail) => {
+        const aTime = a.nextApprDt
+          ? new Date(a.nextApprDt).getTime()
+          : Number.MIN_VALUE;
+        const bTime = b.nextApprDt
+          ? new Date(b.nextApprDt).getTime()
+          : Number.MIN_VALUE;
+        return aTime - bTime;
+      },
     },
     { title: 'OW', key: 'warrantyYN' },
     { title: 'IC', key: 'inCustodyYN' },

--- a/web/src/components/courtlist/CourtListCriminalDetails.vue
+++ b/web/src/components/courtlist/CourtListCriminalDetails.vue
@@ -63,8 +63,8 @@
     { title: 'COUNT', key: 'printSeqNo' },
     { title: 'CRIMINAL CODE', key: 'statuteSectionDsc' },
     { title: 'DESCRIPTION', key: 'statuteDsc' },
-    { title: 'LAST RESULTS', key: 'appearanceResultDesc' }, // double check if correct
-    { title: 'PLEA', key: 'printSeqNo' }, // ???
+    { title: 'LAST RESULTS', key: 'appearanceResultDesc' },
+    { title: 'PLEA', key: '' }, // Awaiting more info on clAppearanceCount 
     { title: 'FINDINGS', key: 'findingDsc' },
   ]);
 

--- a/web/src/components/courtlist/CourtListCriminalDetails.vue
+++ b/web/src/components/courtlist/CourtListCriminalDetails.vue
@@ -18,21 +18,6 @@
           </v-data-table-virtual>
         </v-card>
       </v-col>
-      <v-col>
-        <v-card title="Case Summary" variant="flat">
-          <v-card-text>
-            <v-row>
-              <v-col cols="6" class="data-label">No of appearances</v-col>
-            </v-row>
-            <v-row>
-              <v-col cols="6" class="data-label">Elections</v-col>
-            </v-row>
-            <v-row>
-              <v-col cols="6" class="data-label">Bail status</v-col>
-            </v-row>
-          </v-card-text>
-        </v-card>
-      </v-col>
     </v-row>
     <v-row>
       <v-col>
@@ -64,7 +49,6 @@
     fileId: string;
     appearanceId: string;
     partId: string;
-    seqNo: string;
   }>();
 
   const filesService = inject<FilesService>('filesService');

--- a/web/src/components/courtlist/CourtListCriminalDetails.vue
+++ b/web/src/components/courtlist/CourtListCriminalDetails.vue
@@ -1,0 +1,113 @@
+<template>
+  <v-skeleton-loader class="p-3" type="card" :loading="loading">
+    <v-row v-if="details.appearanceMethods?.length">
+      <v-col cols="6">
+        <v-card title="Appearance Methods" class="p-2" variant="flat">
+          <AppearanceMethods :appearanceMethod="details.appearanceMethods" />
+        </v-card>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        <v-card title="Key Documents" class="p-2" variant="flat">
+          <v-data-table-virtual
+            :items="details.initiatingDocuments"
+            :headers="documentHeaders"
+            density="compact"
+          >
+          </v-data-table-virtual>
+        </v-card>
+      </v-col>
+      <v-col>
+        <v-card title="Case Summary" variant="flat">
+          <v-card-text>
+            <v-row>
+              <v-col cols="6" class="data-label">No of appearances</v-col>
+            </v-row>
+            <v-row>
+              <v-col cols="6" class="data-label">Elections</v-col>
+            </v-row>
+            <v-row>
+              <v-col cols="6" class="data-label">Bail status</v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        <v-card title="Charges" variant="flat">
+          <v-data-table-virtual
+            :items="details.charges"
+            :headers="chargeHeaders"
+            style="background-color: rgba(248, 211, 119, 0.52)"
+            density="compact"
+          >
+          </v-data-table-virtual>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-skeleton-loader>
+</template>
+
+<script setup lang="ts">
+  import AppearanceMethods from '@/components/case-details/civil/appearances/AppearanceMethods.vue';
+  import { FilesService } from '@/services/FilesService';
+  import {
+    CriminalAppearanceDetails,
+    CriminalDocument,
+  } from '@/types/criminal/jsonTypes';
+  import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
+  import { inject, onMounted, ref } from 'vue';
+
+  const props = defineProps<{
+    fileId: string;
+    appearanceId: string;
+    partId: string;
+    seqNo: string;
+  }>();
+
+  const filesService = inject<FilesService>('filesService');
+  const details = ref<CriminalAppearanceDetails>(
+    {} as CriminalAppearanceDetails
+  );
+  const loading = ref(false);
+  if (!filesService) {
+    throw new Error('Files service is undefined.');
+  }
+  const chargeHeaders = ref([
+    { title: 'COUNT', key: 'printSeqNo' },
+    { title: 'CRIMINAL CODE', key: 'statuteSectionDsc' },
+    { title: 'DESCRIPTION', key: 'statuteDsc' },
+    { title: 'LAST RESULTS', key: 'appearanceResultDesc' }, // double check if correct
+    { title: 'PLEA', key: 'printSeqNo' }, // ???
+    { title: 'FINDINGS', key: 'findingDsc' },
+  ]);
+
+  const documentHeaders = ref([
+    {
+      title: 'DATE SWORN/FILED',
+      key: 'issueDate',
+      value: (item: CriminalDocument) => formatDateToDDMMMYYYY(item.issueDate),
+    },
+    { title: 'DOCUMENT TYPE', key: 'docmFormDsc' },
+    { title: 'CATEGORY', key: 'docmClassification' },
+    { title: 'PAGES', key: 'documentPageCount' },
+  ]);
+
+  onMounted(async () => {
+    loading.value = true;
+    details.value = await filesService.criminalAppearanceDetails(
+      props.fileId,
+      props.appearanceId,
+      props.partId
+    );
+    loading.value = false;
+  });
+</script>
+
+<style scoped>
+  .v-skeleton-loader {
+    display: block;
+  }
+</style>

--- a/web/src/components/courtlist/CourtListTable.vue
+++ b/web/src/components/courtlist/CourtListTable.vue
@@ -7,10 +7,32 @@
     :headers
     :search="search"
     :group-by
+    :return-object="false"
     item-value="appearanceId"
     items-per-page="100"
     class="pb-5"
   >
+    <template
+      v-slot:item.data-table-expand="{ internalItem, isExpanded, toggleExpand }"
+    >
+      <v-icon
+        color="primary"
+        :icon="isExpanded(internalItem) ? mdiChevronUp : mdiChevronDown"
+        @click="toggleExpand(internalItem)"
+      />
+    </template>
+    <template v-slot:expanded-row="{ columns, item }">
+      <tr class="expanded">
+        <td :colspan="columns.length">
+          <CourtListCriminalDetails
+            :fileId="item.justinNo"
+            :appearanceId="item.appearanceId"
+            :partId="item.profPartId"
+            :seqNo="item.appearanceSequenceNumber"
+          />
+        </td>
+      </tr>
+    </template>
     <template v-slot:group-header="{ item, columns, isGroupOpen, toggleGroup }">
       <tr>
         <td class="pa-0" style="height: 1rem" :colspan="columns.length">
@@ -108,15 +130,18 @@
 </template>
 
 <script setup lang="ts">
+  import CourtListCriminalDetails from '@/components/courtlist/CourtListCriminalDetails.vue';
   import CourtListTableActionBarGroup from '@/components/courtlist/CourtListTableActionBarGroup.vue';
   import FileMarkers from '@/components/shared/FileMarkers.vue';
   import TooltipIcon from '@/components/shared/TooltipIcon.vue';
   import { CourtClassEnum, DivisionEnum, FileMarkerEnum } from '@/types/common';
   import { CourtListAppearance, PcssCounsel } from '@/types/courtlist';
   import { hoursMinsFormatter } from '@/utils/dateUtils';
-  import { getEnumName, getCourtClassLabel } from '@/utils/utils';
+  import { getCourtClassLabel, getEnumName } from '@/utils/utils';
   import {
     mdiCheck,
+    mdiChevronDown,
+    mdiChevronUp,
     mdiCircleHalfFull,
     mdiFileDocumentEditOutline,
     mdiHomeOutline,
@@ -141,6 +166,11 @@
     },
   ]);
 
+  const props = defineProps<{
+    data: CourtListAppearance[];
+    search: string;
+  }>();
+
   const data = computed(() =>
     props.data.map((item) => ({
       ...item,
@@ -148,12 +178,10 @@
     }))
   );
 
-  const props = defineProps<{
-    data: CourtListAppearance[];
-    search: string;
-  }>();
-
   const headers = ref([
+    {
+      key: 'data-table-expand',
+    },
     { key: 'data-table-group' },
     {
       title: '#',

--- a/web/src/components/courtlist/CourtListTable.vue
+++ b/web/src/components/courtlist/CourtListTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-data-table
+  <v-data-table-virtual
     v-model="selected"
     must-sort
     :sort-by="sortBy"
@@ -7,8 +7,8 @@
     :headers
     :search="search"
     :group-by
-    :return-object="false"
-    item-value="appearanceId"
+    :return-object="true"
+    show-select
     items-per-page="100"
     class="pb-5"
   >
@@ -124,13 +124,11 @@
       <v-icon :icon="mdiNotebookEditOutline" size="large" />
       <v-icon :icon="mdiFileDocumentEditOutline" size="large" />
     </template>
-    <template v-slot:bottom />
-  </v-data-table>
+  </v-data-table-virtual>
   <CourtListTableActionBarGroup :selected />
 </template>
 
 <script setup lang="ts">
-  import CourtListCriminalDetails from '@/components/courtlist/CourtListCriminalDetails.vue';
   import CourtListTableActionBarGroup from '@/components/courtlist/CourtListTableActionBarGroup.vue';
   import FileMarkers from '@/components/shared/FileMarkers.vue';
   import TooltipIcon from '@/components/shared/TooltipIcon.vue';
@@ -179,9 +177,7 @@
   );
 
   const headers = ref([
-    {
-      key: 'data-table-expand',
-    },
+    { key: 'data-table-expand' },
     { key: 'data-table-group' },
     {
       title: '#',

--- a/web/src/services/FilesService.ts
+++ b/web/src/services/FilesService.ts
@@ -1,7 +1,7 @@
-import { CourtFileSearchResponse } from '@/types/courtFileSearch';
-import { HttpService } from './HttpService';
 import { CivilAppearanceDetails } from '@/types/civil/jsonTypes/index';
-import { CriminalAppearanceDetails } from '@/types/criminal/jsonTypes/index'
+import { CourtFileSearchResponse } from '@/types/courtFileSearch';
+import { CriminalAppearanceDetails } from '@/types/criminal/jsonTypes/index';
+import { HttpService } from './HttpService';
 
 export class FilesService {
   private httpService: HttpService;
@@ -26,16 +26,36 @@ export class FilesService {
       queryParams
     );
   }
-  
-  async civilAppearanceDetails(fileId: string, appearanceId: string): Promise<CivilAppearanceDetails> {
+
+  async civilAppearanceDetails(
+    fileId: string,
+    appearanceId: string
+  ): Promise<CivilAppearanceDetails> {
     return this.httpService.get<any>(
       `${this.baseUrl}/civil/${fileId}/appearance-detail/${appearanceId}`
     );
   }
 
-  async criminalAppearanceDetails(fileId: string, appearanceId: string, partId: string): Promise<CriminalAppearanceDetails> {
+  async criminalAppearanceDetails(
+    fileId: string,
+    appearanceId: string,
+    partId: string
+  ): Promise<CriminalAppearanceDetails> {
     return this.httpService.get<any>(
       `${this.baseUrl}/criminal/${fileId}/appearance-detail/${appearanceId}/${partId}`
     );
   }
+
+  // Coming soon...
+  // async PCSSCriminalAppearanceDetails(
+  //   fileId: string,
+  //   appearanceId: string,
+  //   partId: string,
+  //   seqNo: string
+  // ): Promise<CriminalAppearanceDetails> {
+  //   //?partId=127956.0102&profSeqNo=31
+  //   return this.httpService.get<any>(
+  //     `${this.baseUrl}/pcss/criminal/${fileId}/appearance-detail/${appearanceId}/?partId=${partId}&profSeqNo=${seqNo}`
+  //   );
+  // }
 }

--- a/web/tests/components/courtList/CourtListCriminalDetails.test.ts
+++ b/web/tests/components/courtList/CourtListCriminalDetails.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FilesService } from '@/services/FilesService';
+import { mount, flushPromises } from '@vue/test-utils';
+import CourtListCriminalDetails from 'CMP/courtlist/CourtListCriminalDetails.vue';
+import { nextTick } from 'vue';
+
+vi.mock('@/services/FilesService');
+
+describe('CourtListCriminalDetails.vue', () => {
+    let filesService: any;
+    let wrapper: ReturnType<typeof mount>;
+
+    const mockDetails = {
+        appearanceMethods: [{ method: 'In Person' }],
+        initiatingDocuments: [
+            {
+            issueDate: '2024-06-01',
+            docmFormDsc: 'Form A',
+            docmClassification: 'Type 1',
+            documentPageCount: 3,
+            },
+        ],
+        charges: [
+            {
+            printSeqNo: 1,
+            statuteSectionDsc: '123',
+            statuteDsc: 'Description',
+            appearanceResultDesc: 'Result',
+            findingDsc: 'Finding',
+            },
+        ],
+    };
+
+  beforeEach(async () => {
+    filesService = {
+      criminalAppearanceDetails: vi.fn().mockResolvedValue(mockDetails)
+    };
+    (FilesService as any).mockReturnValue(filesService);
+    
+    wrapper = mount(CourtListCriminalDetails, {
+      global: {
+        provide: {
+          filesService,
+        },
+      },
+      props: {
+        fileId: 'file1',
+        appearanceId: 'app1',
+        partId: 'part1',
+        seqNo: 'seq1',
+      },
+    });
+    await flushPromises();
+    await nextTick();
+  });
+
+  it('calls filesService.criminalAppearanceDetails on mount', () => {
+    expect(filesService.criminalAppearanceDetails).toHaveBeenCalledWith(
+      'file1',
+      'app1',
+      'part1'
+    );
+  });
+
+  it('renders AppearanceMethods when appearanceMethods exist', () => {
+    expect(wrapper.findComponent({name: 'AppearanceMethods'}).exists()).toBe(true);
+  });
+
+it('does not render AppearanceMethods when no appearanceMethods', () => {
+    mockDetails.appearanceMethods = [];
+        wrapper = mount(CourtListCriminalDetails, {
+      global: {
+        provide: {
+          filesService,
+        },
+      },
+      props: {
+        fileId: 'file1',
+        appearanceId: 'app1',
+        partId: 'part1',
+        seqNo: 'seq1',
+      },
+    });
+    expect(wrapper.findComponent({name: 'AppearanceMethods'}).exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----[350](https://jira.justice.gov.bc.ca/browse/JASPER-350)----    

## 👁️ Show criminal appearance details on court-list expand ⬇️
Get criminal appearance details on court-list row expand.
Currently there is a [bug ](https://github.com/vuetifyjs/vuetify/issues/21096)in Vuetify that can crash when `return-object` is true and trying to expand a row. Due to this I have downgraded the Vuetify version to one that does not have this bug.
This PR also allows the ordering of dates in court-file search


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Ran `./manage` script
- [x] Unit tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Screengrab of changes

https://github.com/user-attachments/assets/d2d53cb2-7fa1-4eb3-9745-5955ba7f9ced

