### PR TITLE
JASPER-475: Court File Search/Court List: Locations not aligned with PCSS

### DIFF
--- a/api/Models/Location/Location.cs
+++ b/api/Models/Location/Location.cs
@@ -8,6 +8,7 @@ public class Location
 {
     private const string BASE_URL = "https://provincialcourt.bc.ca/court-locations/";
     private static readonly string[] invalidWords = ["Law", "Courts", "Court", "Provincial"];
+    private static readonly string[] courtTypes = ["Provincial Court", "Law Courts", "Provincial Courts"];
 
     public string Name { get; set; }
     public string ShortName { get; set; }
@@ -31,7 +32,8 @@ public class Location
         : this(name, code, locationId, active, courtRooms)
     {
         AgencyIdentifierCd = agencyIdentifierCd;
-        ShortName = shortName;
+        // When short name is not available, use the location name and make it a short name
+        ShortName = string.IsNullOrWhiteSpace(shortName) ? GenerateShortName(name) : shortName;
     }
 
     public static Location Create(string name, string code, string locationId, bool? active, ICollection<CourtRoom> courtRooms)
@@ -64,5 +66,17 @@ public class Location
         locationName = string.Join("-", filteredWords);
 
         return new Uri(BASE_URL + locationName.ToLower());
+    }
+
+    private static string GenerateShortName(string name)
+    {
+        string result = name;
+
+        foreach (var phrase in courtTypes)
+        {
+            result = result.Replace(phrase, "", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return string.Join(" ", result.Split(' ', StringSplitOptions.RemoveEmptyEntries));
     }
 }

--- a/api/Models/Location/Locations.cs
+++ b/api/Models/Location/Locations.cs
@@ -65,7 +65,7 @@ public class Locations : IList<Location>
                 return Location.Create(jc, match);
             })
             .Where(loc => loc.Active.GetValueOrDefault())
-            .OrderBy(loc => loc.Name)
+            .OrderBy(loc => loc.ShortName)
             .ToList();
 
         return [.. locations];

--- a/tests/api/Models/Location/LocationTests.cs
+++ b/tests/api/Models/Location/LocationTests.cs
@@ -89,10 +89,27 @@ public class LocationTest
     }
 
     [Fact]
-    public void Create_ShouldReturnLocation_WhenPcssLocationHasShortName()
+    public void Create_ShouldReturnLocation_WithCorrectShortNameWhenPcssShortNameIsNotAvailable()
     {
         var jcLocation = LocationModel.Create("Vancouver Law Courts", "123", "456", true, default);
         var pcssLocation = LocationModel.Create("Vancouver", "123", "789", true, default);
+
+        var result = LocationModel.Create(jcLocation, pcssLocation);
+
+        Assert.NotNull(result);
+        Assert.Equal("Vancouver Law Courts", result.Name);
+        Assert.Equal("456", result.Code);
+        Assert.NotNull(result.LocationId);
+        Assert.True(result.Active);
+        Assert.Equal(jcLocation.CourtRooms, result.CourtRooms);
+        Assert.Equal("Vancouver", result.ShortName);
+    }
+
+    [Fact]
+    public void Create_ShouldReturnLocation_WhenPcssLocationHasShortName()
+    {
+        var jcLocation = LocationModel.Create("Vancouver Law Courts", "123", "456", true, default);
+        var pcssLocation = LocationModel.Create("222-Main", "123", "789", true, default);
 
         var result = LocationModel.Create(jcLocation, pcssLocation);
 

--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -79,8 +79,8 @@
         <v-col :cols="searchCriteria.searchBy === 'orgName' ? 3 : 2">
           <v-select
             v-model="searchCriteria.fileHomeAgencyId"
-            :items="courtRooms"
-            item-title="name"
+            :items="sortedLocations"
+            item-title="shortName"
             item-value="code"
             label="Location"
             :required="true"
@@ -268,6 +268,12 @@
       isLookupDataMounted.value = true;
     }
   };
+
+  const sortedLocations = computed(() => {
+    return [...courtRooms.value].sort((a, b) => {
+      return a.shortName.localeCompare(b.shortName);
+    });
+  });
 
   const handleDivisionChange = () => {
     Object.assign(searchCriteria, {

--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -79,7 +79,7 @@
         <v-col :cols="searchCriteria.searchBy === 'orgName' ? 3 : 2">
           <v-select
             v-model="searchCriteria.fileHomeAgencyId"
-            :items="sortedLocations"
+            :items="courtRooms"
             item-title="shortName"
             item-value="code"
             label="Location"
@@ -268,12 +268,6 @@
       isLookupDataMounted.value = true;
     }
   };
-
-  const sortedLocations = computed(() => {
-    return [...courtRooms.value].sort((a, b) => {
-      return a.shortName.localeCompare(b.shortName);
-    });
-  });
 
   const handleDivisionChange = () => {
     Object.assign(searchCriteria, {

--- a/web/src/components/courtlist/CourtListSearch.vue
+++ b/web/src/components/courtlist/CourtListSearch.vue
@@ -11,7 +11,7 @@
                 @update:modelValue="selectedCourtRoom = ''"
                 :items="locationsAndCourtRooms"
                 return-object
-                item-title="name"
+                item-title="shortName"
                 item-value="locationId"
                 label="Location"
                 :loading="!isLocationDataMounted"

--- a/web/src/types/courtlist/index.ts
+++ b/web/src/types/courtlist/index.ts
@@ -3,6 +3,7 @@ import { courtListType } from '../courtlist/jsonTypes';
 
 export interface LocationInfo {
   name: string;
+  shortName: string;
   code: string;
   locationId: string;
   active?: boolean;


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-475

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-475

## Description
- Update `Location` model to generate a short name which removes string like "Provincial Courts", "Provicial Court" or "Law Courts".
- Apply location sorting by short name
- Update location dropdown in Court File Search and Court List to show the location's short name.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Local testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screen Grabs