### PR TITLE
JASPER 474: Copyable file-number and center tabs

### DIFF
--- a/web/public/styles/common.css
+++ b/web/public/styles/common.css
@@ -35,6 +35,15 @@ select {
 .small-claims-table-banner {
   background-color: var(--bg-purple-500) !important;
 }
+.criminal-label {
+  color: var(--bg-blue-500) !important;
+}
+.family-label {
+  color: var(--bg-green-500) !important;
+}
+.small-label {
+  color: var(--bg-purple-500) !important;
+}
 
 tbody tr:nth-of-type(odd) {
   background-color: var(--bg-black-50);

--- a/web/src/components/case-details/civil/CivilSummary.vue
+++ b/web/src/components/case-details/civil/CivilSummary.vue
@@ -48,7 +48,6 @@
   import SheriffCommentsDialog from './SheriffCommentsDialog.vue';
 
   const props = defineProps<{ details: civilFileDetailsType }>();
-  console.log(props.details);
   const showSheriffCommentsModal = ref(false);
 
   const division = props.details.courtClassDescription;

--- a/web/src/components/case-details/civil/CivilSummary.vue
+++ b/web/src/components/case-details/civil/CivilSummary.vue
@@ -1,5 +1,17 @@
 <template>
-  <h5 class="my-1">Case Details</h5>
+  <h5 class="my-1">
+    Case Details
+    <span
+      class="pl-3"
+      :class="
+        labelClasses[getCourtClassLabel(details.courtClassCd)] ||
+        'criminal-label'
+      "
+    >
+      {{ details.fileNumberTxt }}
+    </span>
+    <CopyToClipboard :text="details.fileNumberTxt" />
+  </h5>
   <v-card class="py-3" color="var(--bg-gray-500)" flat>
     <div class="ml-3 d-flex align-center">
       <DivisionBadge :division :activityClassDesc :courtClassCd />
@@ -26,13 +38,17 @@
   />
 </template>
 <script setup lang="ts">
+  import CopyToClipboard from '@/components/shared/CopyToClipboard.vue';
+  import { labelClasses } from '@/constants/labelClasses';
   import { civilFileDetailsType } from '@/types/civil/jsonTypes';
+  import { getCourtClassLabel } from '@/utils/utils';
   import { mdiPoliceBadgeOutline } from '@mdi/js';
   import { ref } from 'vue';
   import DivisionBadge from '../common/DivisionBadge.vue';
   import SheriffCommentsDialog from './SheriffCommentsDialog.vue';
 
   const props = defineProps<{ details: civilFileDetailsType }>();
+  console.log(props.details);
   const showSheriffCommentsModal = ref(false);
 
   const division = props.details.courtClassDescription;

--- a/web/src/components/case-details/common/CourtFilesSelector.vue
+++ b/web/src/components/case-details/common/CourtFilesSelector.vue
@@ -7,21 +7,21 @@
           <v-btn base-color="white">View all documents</v-btn>
         </v-col>
       </v-row>
-      <v-tabs v-model="activeTab">
+      <v-tabs v-model="activeTab" center-active>
         <template v-for="file in props.files" :key="file.key">
           <v-tab
             class="text-body-1 mb-0"
             selected-class="active-tab"
-            rounded="t-lg"
+            :rounded="fileNumber == file.key ? 't-lg' : false"
             :ripple="false"
             :to="file.key"
             hide-slider
             base-color="white"
             color="black"
+            border="e-md"
             @click="fileNumber = file.key"
-            >{{ file.value }}</v-tab
-          >
-          <v-divider class="ms-2" inset vertical thickness="2"></v-divider>
+            >{{ file.value }}
+          </v-tab>
         </template>
       </v-tabs>
     </v-container>
@@ -38,7 +38,6 @@
     courtClass: { type: String, default: null },
   });
   const activeTab = ref(() => fileNumber.value);
-
   const getBannerStyle = computed(() => getCourtClassStyle(props.courtClass));
 </script>
 

--- a/web/src/components/case-details/criminal/CriminalSummary.vue
+++ b/web/src/components/case-details/criminal/CriminalSummary.vue
@@ -1,5 +1,17 @@
 <template>
-  <h5 class="my-1">Case Details</h5>
+  <h5 class="my-1">
+    Case Details
+    <span
+      class="pl-3"
+      :class="
+        labelClasses[getCourtClassLabel(details.courtClassCd)] ||
+        'criminal-label'
+      "
+    >
+      {{ details.fileNumberTxt }}
+    </span>
+    <CopyToClipboard :text="details.fileNumberTxt" />
+  </h5>
   <v-card color="var(--bg-gray-500)" flat>
     <div class="mx-2 d-flex align-center pt-2">
       <DivisionBadge
@@ -33,7 +45,10 @@
   </v-card>
 </template>
 <script setup lang="ts">
+  import CopyToClipboard from '@/components/shared/CopyToClipboard.vue';
+  import { labelClasses } from '@/constants/labelClasses';
   import { criminalFileDetailsType } from '@/types/criminal/jsonTypes';
+  import { getCourtClassLabel } from '@/utils/utils';
   import { computed, ref } from 'vue';
   import DivisionBadge from '../common/DivisionBadge.vue';
 

--- a/web/src/components/civil/CivilCaseDetails.vue
+++ b/web/src/components/civil/CivilCaseDetails.vue
@@ -196,12 +196,12 @@
 
       onMounted(() => {
         loading.value = true;
-        civilFileStore.civilFileInformation.fileNumber = getSingleValue(
-          route.params.fileNumber
-        );
+        const routFileNumber = getSingleValue(route.params.fileNumber);
+        civilFileStore.civilFileInformation.fileNumber = routFileNumber;
         civilFileStore.updateCivilFile(civilFileStore.civilFileInformation);
         getFileDetails();
         navigateToSection(route.params.section);
+        fileNumber.value = routFileNumber;
         loading.value = false;
       });
 

--- a/web/src/components/civil/CivilCaseDetails.vue
+++ b/web/src/components/civil/CivilCaseDetails.vue
@@ -196,12 +196,12 @@
 
       onMounted(() => {
         loading.value = true;
-        const routFileNumber = getSingleValue(route.params.fileNumber);
-        civilFileStore.civilFileInformation.fileNumber = routFileNumber;
+        const routeFileNumber = getSingleValue(route.params.fileNumber);
+        civilFileStore.civilFileInformation.fileNumber = routeFileNumber;
         civilFileStore.updateCivilFile(civilFileStore.civilFileInformation);
         getFileDetails();
         navigateToSection(route.params.section);
-        fileNumber.value = routFileNumber;
+        fileNumber.value = routeFileNumber;
         loading.value = false;
       });
 

--- a/web/src/components/courtfilesearch/CourtFileSearchResult.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchResult.vue
@@ -54,7 +54,7 @@
         </template>
       </v-data-table-virtual>
     </v-skeleton-loader>
-    <action-bar :selected="selectedItems" @clicked="handleViewFilesClick">
+    <ActionBar :selected="selectedItems" @clicked="handleViewFilesClick">
       <v-btn
         size="large"
         class="mx-2"
@@ -64,7 +64,7 @@
       >
         View case details
       </v-btn>
-    </action-bar>
+    </ActionBar>
   </div>
 </template>
 

--- a/web/src/components/courtfilesearch/CourtFileSearchView.vue
+++ b/web/src/components/courtfilesearch/CourtFileSearchView.vue
@@ -277,6 +277,7 @@
       [selectedDivision.value]: true,
     });
     searchResults.value.length = 0;
+    selectedFiles.value = [];
   };
 
   const handleSubmit = async () => {

--- a/web/src/components/criminal/CriminalCaseDetails.vue
+++ b/web/src/components/criminal/CriminalCaseDetails.vue
@@ -218,13 +218,13 @@
 
       onMounted(() => {
         loading.value = true;
-        const routFileNumber = getSingleValue(route.params.fileNumber);
-        criminalFileStore.criminalFileInformation.fileNumber = routFileNumber;
+        const routeFileNumber = getSingleValue(route.params.fileNumber);
+        criminalFileStore.criminalFileInformation.fileNumber = routeFileNumber;
         criminalFileStore.updateCriminalFile(
           criminalFileStore.criminalFileInformation
         );
         getFileDetails();
-        fileNumber.value = routFileNumber;
+        fileNumber.value = routeFileNumber;
         loading.value = false;
       });
 

--- a/web/src/components/criminal/CriminalCaseDetails.vue
+++ b/web/src/components/criminal/CriminalCaseDetails.vue
@@ -218,13 +218,13 @@
 
       onMounted(() => {
         loading.value = true;
-        criminalFileStore.criminalFileInformation.fileNumber = getSingleValue(
-          route.params.fileNumber
-        );
+        const routFileNumber = getSingleValue(route.params.fileNumber);
+        criminalFileStore.criminalFileInformation.fileNumber = routFileNumber;
         criminalFileStore.updateCriminalFile(
           criminalFileStore.criminalFileInformation
         );
         getFileDetails();
+        fileNumber.value = routFileNumber;
         loading.value = false;
       });
 

--- a/web/src/components/shared/CopyToClipboard.vue
+++ b/web/src/components/shared/CopyToClipboard.vue
@@ -1,0 +1,45 @@
+<template>
+  <v-tooltip
+    v-model="showTooltip"
+    :open-on-hover="false"
+    close-on-back
+    close-on-content-click
+    open-on-click
+    location="right"
+    close-delay="1000"
+  >
+    <template v-slot:activator="{ props }">
+      <v-btn
+        v-bind="props"
+        size="small"
+        class="ma-2"
+        :icon="mdiContentCopy"
+        @click="copyToClipBoard(text)"
+      >
+      </v-btn>
+    </template>
+    <span>✅Copied!</span>
+  </v-tooltip>
+</template>
+
+<script setup lang="ts">
+  import { mdiContentCopy } from '@mdi/js';
+  import { ref, watch } from 'vue';
+
+  defineProps<{
+    text: string;
+  }>();
+  const showTooltip = ref(false);
+
+  watch(showTooltip, (val) => {
+    if (val) {
+      setTimeout(() => {
+        showTooltip.value = false;
+      }, 1000);
+    }
+  });
+
+  const copyToClipBoard = (textToCopy: string) => {
+    navigator.clipboard.writeText(textToCopy);
+  };
+</script>

--- a/web/src/constants/labelClasses.ts
+++ b/web/src/constants/labelClasses.ts
@@ -1,0 +1,4 @@
+export const labelClasses = {
+  Family: 'family-label',
+  'Small Claims': 'small-claims-label',
+};

--- a/web/tests/components/case-details/criminal/CriminalSummary.test.ts
+++ b/web/tests/components/case-details/criminal/CriminalSummary.test.ts
@@ -3,7 +3,7 @@ import {
   banType,
   criminalAppearancesType,
   criminalFileDetailsType,
-  crownType,
+  crownType
 } from '@/types/criminal/jsonTypes';
 import { mount } from '@vue/test-utils';
 import CriminalSummary from 'CMP/case-details/criminal/CriminalSummary.vue';
@@ -33,6 +33,7 @@ const createParticipant = (givenNm: string, lastNm: string) => ({
   counselRelatedRepTypeCd: '',
   counselEnteredDt: '',
   designatedCounselYN: '',
+  ageNotice: [],
   additionalProperties: {} as AdditionalProperties,
   additionalProp1: {},
   additionalProp2: {},
@@ -96,7 +97,7 @@ describe('CriminalSummary.vue', () => {
       props: { details },
     });
 
-    expect(wrapper.find('h5').text()).toBe('Case Details');
+    expect(wrapper.find('h5').text()).toContain('Case Details');
     expect(wrapper.findComponent({ name: 'DivisionBadge' }).exists()).toBe(
       true
     );
@@ -130,7 +131,7 @@ describe('CriminalSummary.vue', () => {
       props: { details },
     });
 
-    expect(wrapper.find('span').text()).toBe('BAN');
+    expect(wrapper.findAll('span')[2].text()).toBe('BAN');
   });
 
   it.each([

--- a/web/tests/components/shared/CopyToClipboard.test.ts
+++ b/web/tests/components/shared/CopyToClipboard.test.ts
@@ -1,0 +1,34 @@
+import { mount, VueWrapper } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import CopyToClipboard from 'CMP/shared/CopyToClipboard.vue'
+
+describe('CopyToClipboard.vue', () => {
+  let wrapper: VueWrapper<any>;
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true
+    })
+    wrapper = mount(CopyToClipboard, {
+      props: { text: 'Hello, clipboard!' }
+    })
+  })
+
+  it('does not show tooltip by default', () => {
+    expect(wrapper.vm.showTooltip).toBe(false);
+  })
+
+  it('hides tooltip after delay', async () => {
+    vi.useFakeTimers();
+    wrapper.vm.showTooltip = true;
+    await nextTick();
+    expect(wrapper.vm.showTooltip).toBe(true);
+    vi.advanceTimersByTime(1000);
+    await nextTick();
+    expect(wrapper.vm.showTooltip).toBe(false);
+    vi.useRealTimers();
+  })
+})


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[474](https://jira.justice.gov.bc.ca/browse/JASPER-474)**----    

## 📋Copy to clipboard component and keep selector tabs centered 🎨
-Added a component that is comprised of an icon, when on click copies the desired text to the users clipboard. Upon click notifies the user this copy action took place.
-Force the file selector tabs to be centered
-Fixed an issue where clearing the court-file-search division filter did not clear out selected table items
-Fixed an issue where file number was not being properly utilized in case-details tabs


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Ran `./manage` script
- [x] Unit tested  

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Screengrab of changes

https://github.com/user-attachments/assets/f6ee91ea-a5e8-465b-a7d7-3504325e1435


