### PR TITLE
JASPER-467: Case Details: Civil - Appearance of Aliases

### DIFF
--- a/api/Services/Files/CivilFilesService.cs
+++ b/api/Services/Files/CivilFilesService.cs
@@ -213,7 +213,10 @@ namespace Scv.Api.Services.Files
             detail.Appearances = appearances;
 
             ICollection<ClParty> courtListParties = [];
-            if ((detail.CourtClassCd == CivilFileDetailResponseCourtClassCd.C || detail.CourtClassCd == CivilFileDetailResponseCourtClassCd.F)
+            if ((detail.CourtClassCd == CivilFileDetailResponseCourtClassCd.C
+                || detail.CourtClassCd == CivilFileDetailResponseCourtClassCd.M
+                || detail.CourtClassCd == CivilFileDetailResponseCourtClassCd.L
+                || detail.CourtClassCd == CivilFileDetailResponseCourtClassCd.F)
                 && detail.Appearances != null
                 && detail.Appearances.ApprDetail.Count != 0)
             {
@@ -223,7 +226,7 @@ namespace Scv.Api.Services.Files
                 var latestApprearance = detail.Appearances.ApprDetail.OrderByDescending(a => a.AppearanceDt).FirstOrDefault();
                 if (latestApprearance != null)
                 {
-                    var agencyId = await _locationService.GetLocationAgencyIdentifier(detail.HomeLocationAgenId);
+                    var agencyId = await _locationService.GetLocationAgencyIdentifier(latestApprearance.CourtAgencyId);
                     var courtList = await _filesClient.FilesCourtlistAsync(
                         _requestAgencyIdentifierId,
                         _requestPartId,

--- a/web/src/components/case-details/civil/parties/Party.vue
+++ b/web/src/components/case-details/civil/parties/Party.vue
@@ -14,7 +14,7 @@
     </v-row>
     <v-row v-if="showAlias" class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Alias</v-col>
-      <v-col data-testid="alias">
+      <v-col>
         <LabelWithTooltip :values="aliases" />
       </v-col>
     </v-row>

--- a/web/src/components/case-details/civil/parties/Party.vue
+++ b/web/src/components/case-details/civil/parties/Party.vue
@@ -14,7 +14,7 @@
     </v-row>
     <v-row v-if="showAlias" class="mx-1 mt-0">
       <v-col cols="6" class="data-label">Alias</v-col>
-      <v-col>
+      <v-col data-testid="alias">
         <LabelWithTooltip :values="aliases" />
       </v-col>
     </v-row>
@@ -34,7 +34,7 @@
   import LabelWithTooltip from '@/components/shared/LabelWithTooltip.vue';
   import { partyType } from '@/types/civil/jsonTypes';
   import { CourtClassEnum } from '@/types/common';
-  import { formatToFullName } from '@/utils/utils';
+  import { formatToFullName, getEnumName } from '@/utils/utils';
   import { computed } from 'vue';
 
   const props = defineProps<{
@@ -43,15 +43,24 @@
   }>();
 
   // Alias is only visible for Small Claims
-  const showAlias = props.courtClassCd === CourtClassEnum[CourtClassEnum.C];
+  const smallClaims = [
+    getEnumName(CourtClassEnum, CourtClassEnum.C),
+    getEnumName(CourtClassEnum, CourtClassEnum.M),
+    getEnumName(CourtClassEnum, CourtClassEnum.L),
+  ];
+
+  const showAlias =
+    smallClaims.includes(props.courtClassCd) &&
+    props.party.aliases &&
+    props.party.aliases.length > 0;
   const counselNames =
     props.party.selfRepresentedYN === 'Y'
       ? ['Self-Represented']
-      : (props.party.counsel?.map((c) => c.fullNm) ?? []);
+      : (props.party.counsel?.map((c) => c.counselFullName) ?? []);
   const aliases =
     props.party.aliases?.map((a) =>
       a.surnameNm && a.firstGivenNm
-        ? `${a.surnameNm?.toUpperCase()}, ${a.firstGivenNm} ${a.secondGivenNm ?? ''} ${a.thirdGivenNm ?? ''}`
+        ? `${a.surnameNm?.toUpperCase()}, ${a.firstGivenNm} ${a.secondGivenNm ?? ''} ${a.thirdGivenNm ?? ''}`.trim()
         : a.organizationNm
     ) ?? [];
 

--- a/web/tests/components/case-details/civil/parties/Party.test.ts
+++ b/web/tests/components/case-details/civil/parties/Party.test.ts
@@ -1,5 +1,5 @@
 import Party from '@/components/case-details/civil/parties/Party.vue';
-import { partyType } from '@/types/civil/jsonTypes';
+import { partyAliasType, partyType } from '@/types/civil/jsonTypes';
 import { CourtClassEnum } from '@/types/common';
 import { faker } from '@faker-js/faker';
 import { shallowMount } from '@vue/test-utils';
@@ -25,7 +25,7 @@ describe('Party.vue', () => {
 
     expect(chip.classes()).toContain('text-uppercase');
     expect(chip.text()).toBe(`${mockParty.lastNm}, ${mockParty.givenNm}`);
-    expect(labelWithTooltip.length).toBe(2);
+    expect(labelWithTooltip.length).toBe(1);
   });
 
   it('renders Party component for Family case detail', () => {
@@ -68,5 +68,132 @@ describe('Party.vue', () => {
     const label = lastRow.findComponent({ name: 'LabelWithTooltip' });
 
     expect(label.attributes('values')).toBe('Self-Represented');
+  });
+
+  it('renders Party with alias data for Small Claims case', () => {
+    const aliasLastName = faker.person.lastName();
+    const aliasFirstName = faker.person.firstName();
+    const aliasSecondName = faker.person.firstName();
+    const aliasThirdName = faker.person.firstName();
+
+    const mockParty = {
+      givenNm: faker.person.firstName(),
+      lastNm: faker.person.lastName(),
+      aliases: [
+        {
+          surnameNm: aliasLastName,
+          firstGivenNm: aliasFirstName,
+          secondGivenNm: aliasSecondName,
+          thirdGivenNm: aliasThirdName,
+        } as partyAliasType,
+      ],
+    } as partyType;
+    const wrapper = shallowMount(Party, {
+      props: {
+        party: mockParty,
+        courtClassCd: CourtClassEnum[CourtClassEnum.C],
+      },
+    });
+
+    const chip = wrapper.find('v-chip');
+    const labelWithTooltip = wrapper.findAllComponents({
+      name: 'label-with-tooltip',
+    });
+    const alias = labelWithTooltip[0].attributes('values');
+
+    expect(chip.classes()).toContain('text-uppercase');
+    expect(chip.text()).toBe(`${mockParty.lastNm}, ${mockParty.givenNm}`);
+    expect(labelWithTooltip.length).toBe(2);
+    expect(alias).toBe(
+      `${aliasLastName.toUpperCase()}, ${aliasFirstName} ${aliasSecondName} ${aliasThirdName}`
+    );
+  });
+
+  it('renders Party with alias data for MVA case', () => {
+    const aliasLastName = faker.person.lastName();
+    const aliasFirstName = faker.person.firstName();
+
+    const mockParty = {
+      givenNm: faker.person.firstName(),
+      lastNm: faker.person.lastName(),
+      aliases: [
+        {
+          surnameNm: aliasLastName,
+          firstGivenNm: aliasFirstName,
+        } as partyAliasType,
+      ],
+    } as partyType;
+    const wrapper = shallowMount(Party, {
+      props: {
+        party: mockParty,
+        courtClassCd: CourtClassEnum[CourtClassEnum.M],
+      },
+    });
+
+    const chip = wrapper.find('v-chip');
+    const labelWithTooltip = wrapper.findAllComponents({
+      name: 'label-with-tooltip',
+    });
+    const alias = labelWithTooltip[0].attributes('values');
+
+    expect(chip.classes()).toContain('text-uppercase');
+    expect(chip.text()).toBe(`${mockParty.lastNm}, ${mockParty.givenNm}`);
+    expect(labelWithTooltip.length).toBe(2);
+    expect(alias).toBe(`${aliasLastName.toUpperCase()}, ${aliasFirstName}`);
+  });
+
+  it('renders Party with alias of an org name data for Legislated case', () => {
+    const aliasCompanyName = faker.company.name();
+
+    const mockParty = {
+      givenNm: faker.person.firstName(),
+      lastNm: faker.person.lastName(),
+      aliases: [
+        {
+          organizationNm: aliasCompanyName,
+        } as partyAliasType,
+      ],
+    } as partyType;
+    const wrapper = shallowMount(Party, {
+      props: {
+        party: mockParty,
+        courtClassCd: CourtClassEnum[CourtClassEnum.L],
+      },
+    });
+
+    const chip = wrapper.find('v-chip');
+    const labelWithTooltip = wrapper.findAllComponents({
+      name: 'label-with-tooltip',
+    });
+    const alias = labelWithTooltip[0].attributes('values');
+
+    expect(chip.classes()).toContain('text-uppercase');
+    expect(chip.text()).toBe(`${mockParty.lastNm}, ${mockParty.givenNm}`);
+    expect(labelWithTooltip.length).toBe(2);
+    expect(alias).toBe(aliasCompanyName);
+  });
+
+  it('renders Party without alias of an org name data for Legislated case', () => {
+    const aliasCompanyName = faker.company.name();
+
+    const mockParty = {
+      givenNm: faker.person.firstName(),
+      lastNm: faker.person.lastName(),
+    } as partyType;
+    const wrapper = shallowMount(Party, {
+      props: {
+        party: mockParty,
+        courtClassCd: CourtClassEnum[CourtClassEnum.L],
+      },
+    });
+
+    const chip = wrapper.find('v-chip');
+    const labelWithTooltip = wrapper.findAllComponents({
+      name: 'label-with-tooltip',
+    });
+
+    expect(chip.classes()).toContain('text-uppercase');
+    expect(chip.text()).toBe(`${mockParty.lastNm}, ${mockParty.givenNm}`);
+    expect(labelWithTooltip.length).toBe(1);
   });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-467

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-467

## Description
- Show Alias if available and for SC, MVA and Legislated court class only
- Update backend to include cases with MVA and Legislated court class when retrieving aliases via court list endpoint
- Use the appearance's court agency id when querying for court list

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Local

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screen Grab
https://github.com/user-attachments/assets/6a1a8cbd-1d0d-4cdc-8b5e-878c327cee60