### PR TITLE
Fix Court-list appearance details not showing all key-documents

### DIFF
--- a/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
+++ b/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
@@ -32,8 +32,8 @@ public class CriminalAppearanceDetail
     public ICollection<CriminalAppearanceMethod> AppearanceMethods { get; set; }
     public string EstimatedTimeHour { get; set; }
     public string EstimatedTimeMin { get; set; }
-    public List<CriminalDocument> InitiatingDocuments { get; set; }
-    public IEnumerable<CriminalDocument> KeyDocuments => KeyDocumentResolver.GetCriminalKeyDocuments(InitiatingDocuments);
+    public IEnumerable<CriminalDocument> Documents { get; set; }
+    public IEnumerable<CriminalDocument> KeyDocuments => KeyDocumentResolver.GetCriminalKeyDocuments(Documents);
     
     public CriminalFileDetailResponseCourtLevelCd CourtLevelCd { get; set; }
 }

--- a/api/Services/Files/CriminalFilesService.cs
+++ b/api/Services/Files/CriminalFilesService.cs
@@ -223,7 +223,7 @@ namespace Scv.Api.Services.Files
                 Adjudicator = await PopulateAppearanceDetailAdjudicator(appearanceFromAccused, attendanceMethods, appearanceMethods.AppearanceMethod),
                 JustinCounsel = await PopulateAppearanceDetailJustinCounsel(criminalParticipant, appearanceFromAccused, attendanceMethods, appearanceMethods.AppearanceMethod),
                 Charges = await PopulateCharges(appearanceCount.ApprCount),
-                InitiatingDocuments = GetInitiatingDocuments(accusedFile.Document),
+                Documents = await GetCriminalDocuments(accusedFile),
                 CourtLevelCd = detail.CourtLevelCd
             };
             return appearanceDetail;
@@ -234,23 +234,6 @@ namespace Scv.Api.Services.Files
         #region Helpers
 
         #region Criminal Details
-
-        private static List<CriminalDocument> GetInitiatingDocuments(ICollection<CfcDocument> documents)
-        {
-            return documents?.Where(doc => doc?.DocmClassification == "Initiating" && !string.IsNullOrEmpty(doc.ImageId))
-                .Select(doc =>
-                    new CriminalDocument
-                    {
-                        IssueDate = doc.IssueDate,
-                        ImageId = doc.ImageId,
-                        DocmClassification = doc.DocmClassification,
-                        DocmDispositionDsc = doc.DocmDispositionDsc,
-                        DocmFormDsc = doc.DocmFormDsc,
-                        DocmFormId = doc.DocmFormId,
-                        DocmId = doc.DocmId,
-                        DocumentPageCount = doc.DocumentPageCount
-                    }).ToList();
-        }
 
         private async Task<CriminalFileAppearances> PopulateDetailsAppearancesAsync(string fileId, FutureYN? future, HistoryYN? history)
         {

--- a/web/src/components/courtlist/CourtList.vue
+++ b/web/src/components/courtlist/CourtList.vue
@@ -162,20 +162,21 @@
 
     data.items.forEach((courtList: any) => {
       const courtRoomDetails = courtList.courtRoomDetails[0];
-      const adjudicatorDetails = courtRoomDetails.adjudicatorDetails[0];
-      if (adjudicatorDetails) {
-        const card = {} as CourtListCardInfo;
-        const appearances = courtList.appearances as CourtListAppearance[];
-        card.fileCount = courtList.casesTarget;
-        card.activity = courtList.activityDsc;
-        card.presider = adjudicatorDetails?.adjudicatorNm;
-        card.courtListRoom = courtRoomDetails.courtRoomCd;
-        card.courtListLocationID = courtList.locationId;
-        card.courtListLocation = courtList.locationNm;
-        card.amPM = adjudicatorDetails?.amPm;
-
-        cardTablePairings.value.push({ card, table: appearances });
+      if(!courtRoomDetails) {
+        return;
       }
+      const adjudicatorDetails = courtRoomDetails.adjudicatorDetails[0];
+      const card = {} as CourtListCardInfo;
+      const appearances = courtList.appearances as CourtListAppearance[];
+      card.fileCount = courtList.casesTarget;
+      card.activity = courtList.activityDsc;
+      card.presider = adjudicatorDetails?.adjudicatorNm;
+      card.courtListRoom = courtRoomDetails.courtRoomCd;
+      card.courtListLocationID = courtList.locationId;
+      card.courtListLocation = courtList.locationNm;
+      card.amPM = adjudicatorDetails?.amPm;
+
+      cardTablePairings.value.push({ card, table: appearances });
     });
   };
 

--- a/web/src/components/courtlist/CourtListCriminalDetails.vue
+++ b/web/src/components/courtlist/CourtListCriminalDetails.vue
@@ -11,16 +11,16 @@
       <v-col>
         <v-card title="Key Documents" variant="flat">
           <v-data-table-virtual
-            :items="details.initiatingDocuments"
+            :items="details.keyDocuments"
             :headers
             :sortBy
             density="compact"
           >
+            <template v-slot:item.docmClassification="{ item }">
+              {{ formatCategory(item) }}
+            </template>
             <template v-slot:item.docmFormDsc="{ item }">
-              <a
-                v-if="item.imageId"
-                href="javascript:void(0)"
-              >
+              <a v-if="item.imageId" href="javascript:void(0)">
                 {{ formatType(item) }}
               </a>
               <span v-else>
@@ -77,7 +77,7 @@
     { title: 'CRIMINAL CODE', key: 'statuteSectionDsc' },
     { title: 'DESCRIPTION', key: 'statuteDsc' },
     { title: 'LAST RESULTS', key: 'appearanceResultDesc' },
-    { title: 'PLEA', key: '' }, // Awaiting more info on clAppearanceCount 
+    { title: 'PLEA', key: '' }, // Awaiting more info on clAppearanceCount
     { title: 'FINDINGS', key: 'findingDsc' },
   ]);
 
@@ -113,9 +113,13 @@
     );
     loading.value = false;
   });
+  const formatCategory = (item: documentType) =>
+    item.category === 'rop' ? 'ROP' : item.category;
 
   const formatType = (item: documentType) =>
-    item.docmClassification === 'rop' ? 'Record of Proceedings' : item.docmFormDsc;
+    item.category === 'rop'
+      ? 'Record of Proceedings'
+      : item.documentTypeDescription;
 </script>
 
 <style scoped>

--- a/web/src/types/criminal/jsonTypes/index.ts
+++ b/web/src/types/criminal/jsonTypes/index.ts
@@ -343,7 +343,8 @@ export interface CriminalAppearanceDetails {
   appearanceMethods: CriminalAppearanceMethod[];
   estimatedTimeHour: string;
   estimatedTimeMin: string;
-  initiatingDocuments: CriminalDocument[];
+  documents: documentType[];
+  keyDocuments: documentType[];
   courtLevelCd: CriminalFileDetailResponseCourtLevelCd;
 }
 

--- a/web/tests/components/courtList/CourtListCriminalDetails.test.ts
+++ b/web/tests/components/courtList/CourtListCriminalDetails.test.ts
@@ -12,7 +12,7 @@ describe('CourtListCriminalDetails.vue', () => {
 
     const mockDetails = {
         appearanceMethods: [{ method: 'In Person' }],
-        initiatingDocuments: [
+        keyDocuments: [
             {
             issueDate: '2024-06-01',
             docmFormDsc: 'Form A',


### PR DESCRIPTION
 ## 🐞 Get all available court-list key-documents 🐞
We were mistakenly referencing "Initiating" documents instead of "All" documents when building out the list of key-documents.
Because of this we weren't getting the full list of available key documents.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran `./manage` script
- [x] Unit tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   