### PR TITLE
JASPER 465: Open Judicial-Binder in Nutrient

### DIFF
--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -53,6 +53,15 @@
     <v-btn
       size="large"
       class="mx-2"
+      :prepend-icon="mdiFileDocumentMultipleOutline"
+      style="letter-spacing: 0.001rem"
+      @click="openMergedDocuments(true)"
+    >
+      View together
+    </v-btn>
+    <v-btn
+      size="large"
+      class="mx-2"
       :prepend-icon="mdiNotebookRemoveOutline"
       style="letter-spacing: 0.001rem"
       @click="removeSelectedJudicialDocuments()"
@@ -106,7 +115,7 @@
     CourtDocumentType,
     DataTableHeader,
     DocumentData,
-    DocumentRequestType
+    DocumentRequestType,
   } from '@/types/shared';
   import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
   import { getCourtClassStyle, getRoles } from '@/utils/utils';
@@ -248,12 +257,19 @@
 
   // Todo, parts of these binder operation methods should be moved to a
   // shared binder space, that way the code is not repeated
-  const openMergedDocuments = () => {
-    const documents: { documentType: DocumentRequestType, documentData: DocumentData }[] = [];
-    selectedItems.value
+  const openMergedDocuments = (isBinder = false) => {
+    const documents: {
+      documentType: DocumentRequestType;
+      documentData: DocumentData;
+    }[] = [];
+    const source = isBinder ? selectedBinderItems : selectedItems;
+    source.value
       .filter((item) => item.imageId)
       .forEach((item) => {
-        const documentType = getCivilDocumentType(item) === CourtDocumentType.CSR ? DocumentRequestType.CourtSummary : DocumentRequestType.File;
+        const documentType =
+          getCivilDocumentType(item) === CourtDocumentType.CSR
+            ? DocumentRequestType.CourtSummary
+            : DocumentRequestType.File;
         const documentData = prepareCivilDocumentData(item);
         documents.push({ documentType, documentData });
       });

--- a/web/src/components/case-details/civil/documents/JudicialBinder.vue
+++ b/web/src/components/case-details/civil/documents/JudicialBinder.vue
@@ -79,7 +79,7 @@
                 <td>
                   <v-checkbox-btn
                     v-model="selectedBinderItems"
-                    :value="element.civilDocumentId"
+                    :value="element"
                     :input-value="selectedBinderItems?.includes(element)"
                   />
                 </td>

--- a/web/src/components/civil/CivilCaseDetails.vue
+++ b/web/src/components/civil/CivilCaseDetails.vue
@@ -200,7 +200,6 @@
         const routeFileNumber = getSingleValue(route.params.fileNumber);
         civilFileStore.civilFileInformation.fileNumber = routeFileNumber;
         civilFileStore.updateCivilFile(civilFileStore.civilFileInformation);
-        getFileDetails();
         navigateToSection(route.params.section);
         fileNumber.value = routeFileNumber;
         loading.value = false;

--- a/web/src/components/criminal/CriminalCaseDetails.vue
+++ b/web/src/components/criminal/CriminalCaseDetails.vue
@@ -223,7 +223,6 @@
         criminalFileStore.updateCriminalFile(
           criminalFileStore.criminalFileInformation
         );
-        getFileDetails();
         fileNumber.value = routeFileNumber;
         loading.value = false;
       });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[456](https://jira.justice.gov.bc.ca/browse/JASPER-456)**----    

## Ability to view multiple judicial binder documents in Nutrient

feat: open judicial docs in nutrient
fix: remove duplicate case-details call on page load

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Ran `./manage` script
- [ ] Unit tested 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Screengrab of changes
<img width="536" height="200" alt="image" src="https://github.com/user-attachments/assets/c96609bf-8345-4dae-aa24-90d6ca399150" />
