### PR TITLE
Fix Judge Selector not Loading in PROD

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -15,7 +15,12 @@
           <v-spacer></v-spacer>
           <div class="d-flex align-center">
             <JudgeSelector
-              v-if="selectedTab === 'dashboard' || selectedTab === 'court-list'"
+              v-if="
+                (selectedTab === 'dashboard' || selectedTab === 'court-list') &&
+                judges &&
+                judges?.length > 0
+              "
+              :judges="judges"
             />
             <v-btn
               class="ma-2"
@@ -37,12 +42,14 @@
 
 <script setup lang="ts">
   import { mdiAccountCircle } from '@mdi/js';
-  import { ref, watch } from 'vue';
+  import { inject, onMounted, ref, watch } from 'vue';
   import { useRoute } from 'vue-router';
   import JudgeSelector from './components/shared/JudgeSelector.vue';
   import ProfileOffCanvas from './components/shared/ProfileOffCanvas.vue';
   import Snackbar from './components/shared/Snackbar.vue';
+  import { DashboardService } from './services';
   import { useThemeStore } from './stores/ThemeStore';
+  import { PersonSearchItem } from './types';
 
   const themeStore = useThemeStore();
   const theme = ref(themeStore.state);
@@ -50,6 +57,12 @@
 
   const route = useRoute();
   const selectedTab = ref('/dashboard');
+  const userService = inject<DashboardService>('dashboardService');
+  const judges = ref<PersonSearchItem[]>([]);
+
+  onMounted(async () => {
+    judges.value = (await userService?.getJudges()) ?? [];
+  });
 
   watch(
     () => route.path,

--- a/web/src/components/shared/JudgeSelector.vue
+++ b/web/src/components/shared/JudgeSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex align-center" v-if="judges && judges.length > 0">
+  <div class="d-flex align-center">
     <span class="mr-2">You are viewing data for:</span>
     <v-select
       v-model="selectedJudgeId"
@@ -8,8 +8,6 @@
       item-value="personId"
       density="compact"
       hide-details
-      :loading="isLoading"
-      :disabled="isLoading"
       style="min-width: 200px"
       label="Select a Judge"
       clearable
@@ -18,26 +16,19 @@
   </div>
 </template>
 <script setup lang="ts">
-  import { DashboardService } from '@/services';
   import { useCommonStore } from '@/stores';
   import { PersonSearchItem } from '@/types';
   import { UserInfo } from '@/types/common';
-  import { inject, onMounted, ref, watch } from 'vue';
+  import { defineProps, ref, watch } from 'vue';
 
-  const judges = ref<PersonSearchItem[]>();
-  const userService = inject<DashboardService>('dashboardService');
-  const isLoading = ref(true);
+  defineProps<{
+    judges: PersonSearchItem[];
+  }>();
+
   const commonStore = useCommonStore();
-  const selectedJudgeId = ref<number | null>(null);
-  const isDataLoaded = ref(false);
-
-  onMounted(async () => {
-    isLoading.value = true;
-    const result = await userService?.getJudges();
-    judges.value = result;
-    selectedJudgeId.value = commonStore.userInfo?.judgeId ?? null;
-    isLoading.value = false;
-  });
+  const selectedJudgeId = ref<number | null>(
+    commonStore.userInfo?.judgeId ?? null
+  );
 
   watch(selectedJudgeId, (newVal) => {
     if (!newVal) {


### PR DESCRIPTION
When `JudgeSelector` is mounted, an API called is triggered to get the list of judges. Upon investigation, the `JudgeSelector` component is mounting twice due to its placement inside `v-tabs`. Since [`v-tabs`](https://vuetifyjs.com/en/components/tabs/#usage) wraps its slot content in a `v-slide-group`, non v-tab children gets duplicated. Thus, duplicate API calls.

The fix is to move the loading of judges on the parent component (`App.vue`) to ensure data is only retrieved once.

**Screen Grab**

https://github.com/user-attachments/assets/ec4399a3-e1ba-4da1-9037-2315d844d365



