### PR TITLE
JASPER 470 - Nutrient Viewer Document Outline

### DIFF
--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -263,7 +263,6 @@
       documentData: DocumentData;
       memberName: string;
       documentName: string;
-      caseNumber: string;
     }[] = [];
     const source = isBinder ? selectedBinderItems : selectedItems;
     source.value
@@ -279,7 +278,6 @@
           documentData,
           memberName: '',
           documentName: item.documentTypeDescription + ' - ' + formatDateToDDMMMYYYY(item.filedDt),
-          caseNumber: documentData.fileNumberText || ''
         });
       });
     shared.openDocumentsPdfV2(documents);

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -261,6 +261,9 @@
     const documents: {
       documentType: DocumentRequestType;
       documentData: DocumentData;
+      memberName: string;
+      documentName: string;
+      caseNumber: string;
     }[] = [];
     const source = isBinder ? selectedBinderItems : selectedItems;
     source.value
@@ -271,7 +274,13 @@
             ? DocumentRequestType.CourtSummary
             : DocumentRequestType.File;
         const documentData = prepareCivilDocumentData(item);
-        documents.push({ documentType, documentData });
+        documents.push({
+          documentType,
+          documentData,
+          memberName: '',
+          documentName: item.documentTypeDescription,
+          caseNumber: documentData.fileNumberText || ''
+        });
       });
     shared.openDocumentsPdfV2(documents);
   };

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -278,7 +278,7 @@
           documentType,
           documentData,
           memberName: '',
-          documentName: item.documentTypeDescription,
+          documentName: item.documentTypeDescription + ' - ' + formatDateToDDMMMYYYY(item.filedDt),
           caseNumber: documentData.fileNumberText || ''
         });
       });

--- a/web/src/components/case-details/criminal/CriminalDocumentsView.vue
+++ b/web/src/components/case-details/criminal/CriminalDocumentsView.vue
@@ -91,9 +91,13 @@
             </span>
           </v-col>
         </v-row>
-        <v-row v-if="type === 'keyDocuments' && item.category === 'BAIL'" no-gutters>
+        <v-row
+          v-if="type === 'keyDocuments' && item.category === 'BAIL'"
+          no-gutters
+        >
           <v-col>
-            {{ item.docmDispositionDsc }} <span class="pl-2" /> {{ formatDateToDDMMMYYYY(item.issueDate) }}
+            {{ item.docmDispositionDsc }} <span class="pl-2" />
+            {{ formatDateToDDMMMYYYY(item.issueDate) }}
           </v-col>
         </v-row>
       </template>
@@ -123,7 +127,11 @@
     criminalParticipantType,
     documentType,
   } from '@/types/criminal/jsonTypes';
-  import { DocumentRequestType, DocumentData, CourtDocumentType } from '@/types/shared';
+  import {
+    CourtDocumentType,
+    DocumentData,
+    DocumentRequestType,
+  } from '@/types/shared';
   import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
   import { formatFromFullname } from '@/utils/utils';
   import { mdiFileDocumentMultipleOutline } from '@mdi/js';
@@ -277,13 +285,24 @@
     );
 
   const openMergedDocuments = () => {
-    const documents: { documentType: DocumentRequestType, documentData: DocumentData }[] = [];
+    const documents: {
+      documentType: DocumentRequestType;
+      documentData: DocumentData;
+      memberName: string;
+    }[] = [];
     selectedItems.value
       .filter((item) => item.imageId)
       .forEach((item) => {
-        const documentType = getCriminalDocumentType(item) === CourtDocumentType.Criminal ? DocumentRequestType.File : DocumentRequestType.ROP;
+        const documentType =
+          getCriminalDocumentType(item) === CourtDocumentType.Criminal
+            ? DocumentRequestType.File
+            : DocumentRequestType.ROP;
         const documentData = prepareCriminalDocumentData(item);
-        documents.push({ documentType, documentData });
+        documents.push({
+          documentType,
+          documentData,
+          memberName: item.fullName,
+        });
       });
 
     shared.openDocumentsPdfV2(documents);

--- a/web/src/components/case-details/criminal/CriminalDocumentsView.vue
+++ b/web/src/components/case-details/criminal/CriminalDocumentsView.vue
@@ -289,6 +289,7 @@
       documentType: DocumentRequestType;
       documentData: DocumentData;
       memberName: string;
+      documentName: string;
     }[] = [];
     selectedItems.value
       .filter((item) => item.imageId)
@@ -302,6 +303,7 @@
           documentType,
           documentData,
           memberName: item.fullName,
+          documentName: documentData.documentDescription || ''
         });
       });
 

--- a/web/src/components/courtlist/CourtList.vue
+++ b/web/src/components/courtlist/CourtList.vue
@@ -202,6 +202,7 @@
       string,
       {
         locationId: number;
+        locationName: string;
         date: string;
         division: string;
         class: string;
@@ -212,23 +213,24 @@
       element.table.forEach((data) => {
         const obj = {
           locationId: element.card.courtListLocationID,
+          locationName: element.card.courtListLocation,
           date: data.appearanceDt,
           division: data.courtDivisionCd,
           class: data.courtClassCd,
           courtRoom: data.courtRoomCd,
         };
 
-        const key = `${obj.locationId}|${obj.date}|${obj.division}|${obj.class}|${obj.courtRoom}`;
+        const key = `${obj.locationId}|${obj.locationName}|${obj.date}|${obj.division}|${obj.class}|${obj.courtRoom}`;
         uniqueMap.set(key, obj);
       });
     });
-    const documents: {
+    const documents: Array<{
       documentType: DocumentRequestType;
-      documentData: DocumentData;
+      documentData: Record<string, any>;
       memberName: string;
-      documentName: string;
+      documentName: any;
       caseNumber: string;
-    }[] = [];
+    }> = [];
     uniqueMap.forEach((value) => {
       let documentData: Record<string, any> = {
         courtDivisionCd: value.division,
@@ -247,8 +249,8 @@
         documentType: DocumentRequestType.Report,
         documentData,
         memberName: value.courtRoom,
-        documentName: value.division,
-        caseNumber: value.locationId.toString()
+        documentName: documentData.reportType,
+        caseNumber: value.locationName,
       });
     });
     shared.openDocumentsPdfV2(documents);

--- a/web/src/components/courtlist/CourtList.vue
+++ b/web/src/components/courtlist/CourtList.vue
@@ -61,7 +61,7 @@
   import { usePDFViewerStore } from '@/stores';
   import { DivisionEnum } from '@/types/common';
   import { CourtListAppearance, CourtListCardInfo } from '@/types/courtlist';
-  import { DocumentData, DocumentRequestType } from '@/types/shared';
+  import { DocumentRequestType } from '@/types/shared';
   import {
     formatDateInstanceToDDMMMYYYY,
     parseDDMMMYYYYToDate,

--- a/web/src/components/courtlist/CourtList.vue
+++ b/web/src/components/courtlist/CourtList.vue
@@ -249,7 +249,7 @@
         documentType: DocumentRequestType.Report,
         documentData,
         memberName: value.courtRoom,
-        documentName: documentData.reportType,
+        documentName: documentData.reportType || documentData.date,
         caseNumber: value.locationName,
       });
     });

--- a/web/src/components/courtlist/CourtList.vue
+++ b/web/src/components/courtlist/CourtList.vue
@@ -225,6 +225,9 @@
     const documents: {
       documentType: DocumentRequestType;
       documentData: DocumentData;
+      memberName: string;
+      documentName: string;
+      caseNumber: string;
     }[] = [];
     uniqueMap.forEach((value) => {
       let documentData: Record<string, any> = {
@@ -234,7 +237,6 @@
         locationId: value.locationId,
         roomCode: value.courtRoom,
       };
-
       if (value.division === DivisionEnum.R) {
         documentData.reportType = reportType;
       } else if (value.division === DivisionEnum.I) {
@@ -244,6 +246,9 @@
       documents.push({
         documentType: DocumentRequestType.Report,
         documentData,
+        memberName: value.courtRoom,
+        documentName: value.division,
+        caseNumber: value.locationId.toString()
       });
     });
     shared.openDocumentsPdfV2(documents);

--- a/web/src/components/documents/DocumentUtils.ts
+++ b/web/src/components/documents/DocumentUtils.ts
@@ -43,7 +43,7 @@ export const prepareCivilDocumentData = (data) => {
     documentDescription: data.documentTypeCd,
     documentId: data.civilDocumentId,
     fileId: civilFileStore.civilFileInformation.fileNumber,
-    fileNumberText: data.documentTypeDescription,
+    fileNumberText: civilFileStore.civilFileInformation.detailsData.fileNumberTxt,
     courtClass: civilFileStore.civilFileInformation.detailsData.courtClassCd,
     courtLevel: civilFileStore.civilFileInformation.detailsData.courtLevelCd,
     location:

--- a/web/src/components/documents/NutrientContainer.vue
+++ b/web/src/components/documents/NutrientContainer.vue
@@ -59,7 +59,7 @@
     );
     loading.value = false;
 
-    var instance = await NutrientViewer.load({
+    let instance = await NutrientViewer.load({
       ...configuration,
       document: `data:application/pdf;base64,${documentResponse.base64Pdf}`,
     });

--- a/web/src/components/documents/NutrientContainer.vue
+++ b/web/src/components/documents/NutrientContainer.vue
@@ -11,9 +11,14 @@
 </template>
 
 <script setup lang="ts">
+  import {
+    GeneratePdfRequest,
+    GeneratePdfResponse,
+  } from '@/components/documents/models/GeneratePdf';
   import { FilesService } from '@/services/FilesService';
   import { usePDFViewerStore } from '@/stores';
   import { inject, onMounted, onUnmounted, ref } from 'vue';
+  //import NutrientViewer from '@/components/documents/NutrientViewer'; // Adjust path as needed
 
   const pdfStore = usePDFViewerStore();
   const filesService = inject<FilesService>('filesService');
@@ -33,7 +38,7 @@
     loading.value = true;
     emptyStore.value = false;
 
-    if (!pdfStore.documents.length) {
+    if (!pdfStore.documentRequests.length && !pdfStore.storeDocs.length) {
       loading.value = false;
       emptyStore.value = true;
       return;
@@ -42,15 +47,132 @@
   };
 
   const loadMultiple = async () => {
-    const documentResponse = await filesService.generatePdf(pdfStore.documents);
+    // const documentResponse = await filesService.generatePdf(pdfStore.documentRequests);
+    // Flatten all document objects into a single array
+    const groupedDocs = pdfStore.groupedDocuments;
+    const allDocs: GeneratePdfRequest[] = [];
+    Object.values(groupedDocs).forEach((userGroup: any) => {
+      Object.values(userGroup).forEach((docs) => {
+        allDocs.push(...(docs as any[]));
+      });
+    });
+    console.log('All Docs:', allDocs);
+
+    // Singular call to generatePdf with allDocs
+    const documentResponse = await filesService.generatePdf(allDocs);
     loading.value = false;
 
-    await NutrientViewer.load({
+    var instance = await NutrientViewer.load({
       ...configuration,
       document: `data:application/pdf;base64,${documentResponse.base64Pdf}`,
     });
-    // Todo - Render outline from page ranges
+    configureOutline(instance, documentResponse);
   };
+
+  //   {
+  //     "279899-1": {
+  //         "John Johnson": [
+  //             {
+  //                 "type": 0,
+  //                 "data": {
+  //                 }
+  //             },
+  //             {
+  //                 "type": 0,
+  //                 "data": {
+  //                 }
+  //             }
+  //         ]
+  //     }
+  // }
+  const configureOutline = (
+    instance: any,
+    documentResponse: GeneratePdfResponse
+  ) => {
+    // var indexCount = 0;
+    // const outline = NutrientViewer.Immutable.List(
+    //   Object.entries(pdfStore.groupedDocuments).map(
+    //     ([groupKey, userGroup]: [string, Record<string, GeneratePdfRequest[]>]) =>
+    //       new NutrientViewer.OutlineElement({
+    //         isExpanded: true,
+    //         title: groupKey,
+    //         children: NutrientViewer.Immutable.List(
+    //           Object.entries(userGroup).map(
+    //             ([name, docs]: [string, GeneratePdfRequest[]]) =>
+    //               new NutrientViewer.OutlineElement({
+    //                 isExpanded: true,
+    //                 title: name,
+    //                 children: NutrientViewer.Immutable.List(
+    //                   (docs as GeneratePdfRequest[]).map(
+    //                     (doc) =>
+    //                       new NutrientViewer.OutlineElement({
+    //                         isExpanded: true,
+    //                         title: `Document ${doc.data.documentId}`,
+    //                         action: new NutrientViewer.Actions.GoToAction({
+    //                           pageIndex:
+    //                             documentResponse.pageRanges?.[indexCount++]
+    //                               ?.start ?? 0,
+    //                         }),
+    //                       })
+    //                   )
+    //                 ),
+    //               })
+    //           )
+    //         ),
+    //       })
+    //   )
+    //);
+    
+    const indexRef = { current: 0 };
+    const outline = NutrientViewer.Immutable.List(
+      Object.entries(pdfStore.groupedDocuments).map(([groupKey, userGroup]) =>
+        makeGroupElement(groupKey, userGroup, indexRef, documentResponse)
+      )
+    );
+    instance.setDocumentOutline(outline);
+  };
+
+  function makeDocElement(doc: GeneratePdfRequest, index: number, documentResponse: any) {
+    return new NutrientViewer.OutlineElement({
+      isExpanded: true,
+      title: `Document ${doc.data.documentId}`,
+      action: new NutrientViewer.Actions.GoToAction({
+        pageIndex: documentResponse.pageRanges?.[index]?.start ?? 0,
+      }),
+    });
+  }
+
+  function makeUserElement(
+    name: string,
+    docs: GeneratePdfRequest[],
+    indexRef: { current: number },
+    documentResponse: any
+  ) {
+    return new NutrientViewer.OutlineElement({
+      isExpanded: true,
+      title: name,
+      children: NutrientViewer.Immutable.List(
+        docs.map(doc => makeDocElement(doc, indexRef.current++, documentResponse))
+      ),
+    });
+  }
+
+  function makeGroupElement(
+    groupKey: string,
+    userGroup: Record<string, GeneratePdfRequest[]>,
+    indexRef: { current: number },
+    documentResponse: any
+  ) {
+    return new NutrientViewer.OutlineElement({
+      isExpanded: true,
+      title: groupKey,
+      children: NutrientViewer.Immutable.List(
+        Object.entries(userGroup).map(([name, docs]) =>
+          makeUserElement(name, docs, indexRef, documentResponse)
+        )
+      ),
+    });
+  }
 
   onMounted(() => {
     loadNutrient();

--- a/web/src/components/documents/NutrientContainer.vue
+++ b/web/src/components/documents/NutrientContainer.vue
@@ -48,11 +48,13 @@
   const loadMultiple = async () => {
     const groupedDocs = pdfStore.groupedDocuments;
     const allDocs: StoreDocument[] = [];
-    Object.values(groupedDocs).forEach((userGroup: any) => {
-      Object.values(userGroup).forEach((docs) => {
-        allDocs.push(...(docs as StoreDocument[]));
-      });
-    });
+    Object.values(groupedDocs).forEach(
+      (userGroup: Record<string, StoreDocument[]>) => {
+        Object.values(userGroup).forEach((docs) => {
+          allDocs.push(...(docs as StoreDocument[]));
+        });
+      }
+    );
 
     documentResponse = await filesService.generatePdf(
       allDocs.map((doc) => doc.request)

--- a/web/src/components/documents/NutrientContainer.vue
+++ b/web/src/components/documents/NutrientContainer.vue
@@ -11,16 +11,11 @@
 </template>
 
 <script setup lang="ts">
-  import { getCriminalDocumentType } from '@/components/documents/DocumentUtils';
-  import {
-    GeneratePdfRequest,
-    GeneratePdfResponse,
-  } from '@/components/documents/models/GeneratePdf';
+  import { GeneratePdfResponse } from '@/components/documents/models/GeneratePdf';
   import { FilesService } from '@/services/FilesService';
   import { usePDFViewerStore } from '@/stores';
   import { StoreDocument } from '@/stores/PDFViewerStore';
   import { inject, onMounted, onUnmounted, ref } from 'vue';
-  import { CourtDocumentType } from '@/types/shared';
 
   const pdfStore = usePDFViewerStore();
   const filesService = inject<FilesService>('filesService');
@@ -42,7 +37,7 @@
     loading.value = true;
     emptyStore.value = false;
 
-    if (!pdfStore.documentRequests.length && !pdfStore.storeDocs.length) {
+    if (!pdfStore.documents.length) {
       loading.value = false;
       emptyStore.value = true;
       return;
@@ -59,7 +54,9 @@
       });
     });
 
-    documentResponse = await filesService.generatePdf(allDocs.map(doc => doc.request));
+    documentResponse = await filesService.generatePdf(
+      allDocs.map((doc) => doc.request)
+    );
     loading.value = false;
 
     var instance = await NutrientViewer.load({
@@ -69,9 +66,7 @@
     configureOutline(instance);
   };
 
-  const configureOutline = (
-    instance: any,
-  ) => {
+  const configureOutline = (instance: any) => {
     const outline = NutrientViewer.Immutable.List(
       Object.entries(pdfStore.groupedDocuments).map(([groupKey, userGroup]) =>
         makeCaseElement(groupKey, userGroup)
@@ -82,7 +77,7 @@
 
   const makeCaseElement = (
     groupKey: string,
-    userGroup: Record<string, StoreDocument[]>,
+    userGroup: Record<string, StoreDocument[]>
   ) => {
     return new NutrientViewer.OutlineElement({
       title: groupKey,
@@ -92,32 +87,25 @@
         )
       ),
     });
-  }
+  };
 
-  const makeMemberElement = (
-    memberName: string,
-    docs: StoreDocument[],
-  ) => {
+  const makeMemberElement = (memberName: string, docs: StoreDocument[]) => {
     return new NutrientViewer.OutlineElement({
       title: memberName,
       children: NutrientViewer.Immutable.List(
-        docs.map((doc) =>
-          makeDocElement(doc)
-        )
+        docs.map((doc) => makeDocElement(doc))
       ),
     });
-  }
+  };
 
-  const makeDocElement = (
-    doc: StoreDocument
-  ) => {
+  const makeDocElement = (doc: StoreDocument) => {
     return new NutrientViewer.OutlineElement({
       title: doc.documentName,
       action: new NutrientViewer.Actions.GoToAction({
-        pageIndex: documentResponse?.pageRanges?.[pageIndex++]?.start
+        pageIndex: documentResponse?.pageRanges?.[pageIndex++]?.start,
       }),
     });
-  }
+  };
 
   onMounted(() => {
     loadNutrient();

--- a/web/src/components/documents/models/GeneratePdf.ts
+++ b/web/src/components/documents/models/GeneratePdf.ts
@@ -2,7 +2,12 @@ import { DocumentRequestType } from "@/types/shared";
 
 export interface GeneratePdfResponse {
   base64Pdf: string;
-  pageRanges: Array<[number, number]>;
+  pageRanges: Array<PageRange>;
+}
+export interface PageRange
+{
+    start: number,
+    end: number
 }
 
 export type GeneratePdfRequest = {

--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -96,7 +96,7 @@ export default {
     
     const pdfStore = usePDFViewerStore();
     pdfStore.clearDocuments();
-    documents.map((doc) => {
+    documents.forEach((doc) => {
       pdfStore.addDocument({
         request: {
           type: doc.documentType,

--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -62,6 +62,8 @@ export default {
         }&CorrelationId=${correlationId}`;
     }
   },
+  // Eventually will be deprecated in favor of opening even
+  // single documents in the nutrient-viewer
   openDocumentsPdf(
     documentType: CourtDocumentType,
     documentData: DocumentData
@@ -95,7 +97,7 @@ export default {
     const pdfStore = usePDFViewerStore();
     pdfStore.clearDocuments();
     documents.map((doc) => {
-      pdfStore.addStoreDocument({
+      pdfStore.addDocument({
         request: {
           type: doc.documentType,
           data: {
@@ -117,7 +119,7 @@ export default {
             reportType: doc.documentData.reportType || '',
           },
         },
-        caseNumber: doc.caseNumber || doc.documentData.fileNumberText,
+        caseNumber: doc.caseNumber || doc.documentData.fileNumberText || 'Case',
         memberName: doc.memberName,
         documentName: doc.documentName,
       });

--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -12,14 +12,14 @@ export default {
     const base64 = btoa(inputText);
     return base64.replace(/[+/=]/g, (char) => {
       switch (char) {
-      case '+':
-        return '-';
-      case '/':
-        return '_';
-      case '=':
-        return '';
-      default:
-        return char;
+        case '+':
+          return '-';
+        case '/':
+          return '_';
+        case '=':
+          return '';
+        default:
+          return char;
       }
     });
   },
@@ -40,28 +40,26 @@ export default {
     switch (documentType) {
       case CourtDocumentType.CSR:
         return `${import.meta.env.BASE_URL}api/files/civil/court-summary-report/${
-            documentData.appearanceId
-          }/${encodeURIComponent(fileName)}?vcCivilFileId=${
-            documentData.fileId
-          }`
+          documentData.appearanceId
+        }/${encodeURIComponent(fileName)}?vcCivilFileId=${documentData.fileId}`;
       case CourtDocumentType.ROP:
         return `${
           import.meta.env.BASE_URL
-          }api/files/criminal/record-of-proceedings/${
-            documentData.partId
-          }/${encodeURIComponent(fileName)}?profSequenceNumber=${
-            documentData.profSeqNo
-          }&courtLevelCode=${documentData.courtLevel}&courtClassCode=${
-            documentData.courtClass
-          }`
+        }api/files/criminal/record-of-proceedings/${
+          documentData.partId
+        }/${encodeURIComponent(fileName)}?profSequenceNumber=${
+          documentData.profSeqNo
+        }&courtLevelCode=${documentData.courtLevel}&courtClassCode=${
+          documentData.courtClass
+        }`;
       default:
-          return `${
-            import.meta.env.BASE_URL
-          }api/files/document/${documentId}/${encodeURIComponent(
-            fileName
-          )}?isCriminal=${isCriminal}&fileId=${
-            documentData.fileId
-          }&CorrelationId=${correlationId}`;
+        return `${
+          import.meta.env.BASE_URL
+        }api/files/document/${documentId}/${encodeURIComponent(
+          fileName
+        )}?isCriminal=${isCriminal}&fileId=${
+          documentData.fileId
+        }&CorrelationId=${correlationId}`;
     }
   },
   openDocumentsPdf(
@@ -69,46 +67,61 @@ export default {
     documentData: DocumentData
   ): void {
     const correlationId = uuidv4();
-    const url = this.renderDocumentUrl(documentType, documentData, correlationId);
-    if(documentType !== CourtDocumentType.ROP && documentType !== CourtDocumentType.CSR) {
+    const url = this.renderDocumentUrl(
+      documentType,
+      documentData,
+      correlationId
+    );
+    if (
+      documentType !== CourtDocumentType.ROP &&
+      documentType !== CourtDocumentType.CSR
+    ) {
       this.openRequestedTab(url, correlationId);
-    }else{
+    } else {
       window.open(url);
     }
   },
   openDocumentsPdfV2(
-    documents: {
-      documentType: DocumentRequestType, 
-      documentData: DocumentData
+    documents?: {
+      documentType: DocumentRequestType;
+      documentData: DocumentData;
+      memberName: string;
+      documentName: string;
+      caseNumber?: string;
     }[]
   ): void {
     if (!documents || documents.length === 0) return;
-
+    
     const pdfStore = usePDFViewerStore();
-
-    pdfStore.addDocuments(
-      documents.map(({documentType, documentData}) => ({
-        type: documentType,
-        data: {
-          partId: documentData.partId || '',
-          profSeqNo: documentData.profSeqNo || '',
-          courtLevelCd: documentData.courtLevel || '',
-          courtClassCd: documentData.courtClass || '',
-          appearanceId: documentData.appearanceId || '',
-          documentId: documentData.documentId
-            ? this.convertToBase64Url(documentData.documentId)
-            : documentData.documentId || '',
-          fileId: documentData.fileId || '',
-          isCriminal: documentData.isCriminal || false,
-          correlationId: uuidv4(),
-          courtDivisionCd: documentData.courtDivisionCd || '',
-          date: documentData.date,
-          locationId: documentData.locationId,
-          roomCode: documentData.roomCode || '',
-          reportType: documentData.reportType || '',
+    pdfStore.clearDocuments();
+    documents.map((doc) => {
+      pdfStore.addStoreDocument({
+        request: {
+          type: doc.documentType,
+          data: {
+            partId: doc.documentData.partId || '',
+            profSeqNo: doc.documentData.profSeqNo || '',
+            courtLevelCd: doc.documentData.courtLevel || '',
+            courtClassCd: doc.documentData.courtClass || '',
+            appearanceId: doc.documentData.appearanceId || '',
+            documentId: doc.documentData.documentId
+              ? this.convertToBase64Url(doc.documentData.documentId)
+              : doc.documentData.documentId || '',
+            fileId: doc.documentData.fileId || '',
+            isCriminal: doc.documentData.isCriminal || false,
+            correlationId: uuidv4(),
+            courtDivisionCd: doc.documentData.courtDivisionCd || '',
+            date: doc.documentData.date,
+            locationId: doc.documentData.locationId,
+            roomCode: doc.documentData.roomCode || '',
+            reportType: doc.documentData.reportType || '',
+          },
         },
-      }))
-    );
+        caseNumber: doc.caseNumber || doc.documentData.fileNumberText,
+        memberName: doc.memberName,
+        documentName: doc.documentName,
+      });
+    });
     window.open('/pdf-viewer', 'pdf-viewer');
   },
   generateFileName(

--- a/web/src/stores/PDFViewerStore.ts
+++ b/web/src/stores/PDFViewerStore.ts
@@ -1,20 +1,61 @@
-import { defineStore } from 'pinia';
 import { GeneratePdfRequest } from '@/components/documents/models/GeneratePdf';
+import { defineStore } from 'pinia';
 
 export const usePDFViewerStore = defineStore('PDFViewerStore', {
   persist: true,
   state: () => ({
     documents: [] as GeneratePdfRequest[],
+    storeDocuments: [] as StoreDocument[],
+    groupedDocuments: {} as Record<
+      string,
+      Record<string, GeneratePdfRequest[]>
+    >,
   }),
   getters: {
     documentRequests: (state) => state.documents,
+    storeDocs: (state) => state.storeDocuments,
   },
   actions: {
-    addDocuments(documents: GeneratePdfRequest[]): void {
+    addDocuments(
+      documents: GeneratePdfRequest[],
+      caseNumber: string,
+      userId: string
+    ): void {
+      if (caseNumber) {
+      }
       this.documents = [...documents];
+    },
+    addStoreDocument(document: StoreDocument): void {
+      // if (!this.storeDocs.length) {
+      //   this.storeDocs.push(document);
+      //   return;
+      // }
+      this.storeDocs.push(document);
+
+      if (document.caseNumber) {
+        // Group documents by caseNumber, then by userId
+        const grouped = this.storeDocs.reduce(
+          (acc, doc) => {
+            if (!acc[doc.caseNumber]) acc[doc.caseNumber] = {};
+            if (!acc[doc.caseNumber][doc.userId])
+              acc[doc.caseNumber][doc.userId] = [];
+            acc[doc.caseNumber][doc.userId].push(doc.request);
+            return acc;
+          },
+          {} as Record<string, Record<string, GeneratePdfRequest[]>>
+        );
+        this.groupedDocuments = grouped;
+      }
     },
     clearDocuments(): void {
       this.documents.length = 0;
+      this.storeDocs.length = 0;
     },
   },
 });
+
+export type StoreDocument = {
+  request: GeneratePdfRequest;
+  caseNumber: string;
+  userId: string;
+};

--- a/web/src/stores/PDFViewerStore.ts
+++ b/web/src/stores/PDFViewerStore.ts
@@ -8,7 +8,7 @@ export const usePDFViewerStore = defineStore('PDFViewerStore', {
     storeDocuments: [] as StoreDocument[],
     groupedDocuments: {} as Record<
       string,
-      Record<string, GeneratePdfRequest[]>
+      Record<string, StoreDocument[]>
     >,
   }),
   getters: {
@@ -17,32 +17,24 @@ export const usePDFViewerStore = defineStore('PDFViewerStore', {
   },
   actions: {
     addDocuments(
-      documents: GeneratePdfRequest[],
-      caseNumber: string,
-      userId: string
+      documents: StoreDocument[]
     ): void {
-      if (caseNumber) {
-      }
-      this.documents = [...documents];
+      this.storeDocuments = [...documents];
     },
     addStoreDocument(document: StoreDocument): void {
-      // if (!this.storeDocs.length) {
-      //   this.storeDocs.push(document);
-      //   return;
-      // }
       this.storeDocs.push(document);
 
       if (document.caseNumber) {
-        // Group documents by caseNumber, then by userId
+        // Group documents by caseNumber, then by memberName
         const grouped = this.storeDocs.reduce(
           (acc, doc) => {
             if (!acc[doc.caseNumber]) acc[doc.caseNumber] = {};
-            if (!acc[doc.caseNumber][doc.userId])
-              acc[doc.caseNumber][doc.userId] = [];
-            acc[doc.caseNumber][doc.userId].push(doc.request);
+            if (!acc[doc.caseNumber][doc.memberName])
+              acc[doc.caseNumber][doc.memberName] = [];
+            acc[doc.caseNumber][doc.memberName].push(doc);
             return acc;
           },
-          {} as Record<string, Record<string, GeneratePdfRequest[]>>
+          {} as Record<string, Record<string, StoreDocument[]>>
         );
         this.groupedDocuments = grouped;
       }
@@ -57,5 +49,6 @@ export const usePDFViewerStore = defineStore('PDFViewerStore', {
 export type StoreDocument = {
   request: GeneratePdfRequest;
   caseNumber: string;
-  userId: string;
+  memberName: string;
+  documentName: string;
 };

--- a/web/src/stores/PDFViewerStore.ts
+++ b/web/src/stores/PDFViewerStore.ts
@@ -4,29 +4,22 @@ import { defineStore } from 'pinia';
 export const usePDFViewerStore = defineStore('PDFViewerStore', {
   persist: true,
   state: () => ({
-    documents: [] as GeneratePdfRequest[],
-    storeDocuments: [] as StoreDocument[],
+    storedDocuments: [] as StoreDocument[],
     groupedDocuments: {} as Record<
       string,
       Record<string, StoreDocument[]>
     >,
   }),
   getters: {
-    documentRequests: (state) => state.documents,
-    storeDocs: (state) => state.storeDocuments,
+    documents: (state) => state.storedDocuments,
   },
   actions: {
-    addDocuments(
-      documents: StoreDocument[]
-    ): void {
-      this.storeDocuments = [...documents];
-    },
-    addStoreDocument(document: StoreDocument): void {
-      this.storeDocs.push(document);
+    addDocument(document: StoreDocument): void {
+      this.storedDocuments.push(document);
 
       if (document.caseNumber) {
         // Group documents by caseNumber, then by memberName
-        const grouped = this.storeDocs.reduce(
+        const grouped = this.documents.reduce(
           (acc, doc) => {
             if (!acc[doc.caseNumber]) acc[doc.caseNumber] = {};
             if (!acc[doc.caseNumber][doc.memberName])
@@ -40,8 +33,8 @@ export const usePDFViewerStore = defineStore('PDFViewerStore', {
       }
     },
     clearDocuments(): void {
-      this.documents.length = 0;
-      this.storeDocs.length = 0;
+      this.storedDocuments.length = 0;
+      this.groupedDocuments = {};
     },
   },
 });

--- a/web/tests/components/documents/DocumentUtils.test.ts
+++ b/web/tests/components/documents/DocumentUtils.test.ts
@@ -18,8 +18,15 @@ const mockCriminalFileStore = {
   },
 };
 
+const mockCivilFileStore = {
+  civilFileInformation: {
+    detailsData: {}
+  }
+};
+
 vi.mock('@/stores', () => ({
   useCriminalFileStore: () => mockCriminalFileStore,
+  useCivilFileStore : () => mockCivilFileStore,
 }));
 
 describe('DocumentUtils', () => {
@@ -60,6 +67,14 @@ describe('DocumentUtils', () => {
       };
       const result = DocumentUtils.prepareCriminalDocumentData(data);
       expect(result.documentDescription).toBe('Other Type');
+    });
+
+    it('should prepare use civilDocumentId when no civil appearanceId', () => {
+      const data = {
+        civilDocumentId: 'civ-1',
+      };
+      const result = DocumentUtils.prepareCivilDocumentData(data);
+      expect(result.appearanceId).toBe('civ-1');
     });
   });
 

--- a/web/tests/components/documents/NutrientContainer.test.ts
+++ b/web/tests/components/documents/NutrientContainer.test.ts
@@ -5,6 +5,34 @@ import { setActivePinia, createPinia } from 'pinia'
 import { FilesService } from '@/services/FilesService';
 
 const mockDocuments = [{ test: "1" }, { test: "2" }, { test: "3" }];
+const mockGroupedDocuments = {
+    "20111101-1": {
+        "John Johnson": [
+            {
+                "request": {
+                    "type": 0,
+                    "data": {
+                    }
+                },
+                "caseNumber": "123",
+                "memberName": "John Johnson",
+                "documentName": "Information"
+            }
+        ],
+        "Elmer Fudd": [
+            {
+                "request": {
+                    "type": 0,
+                    "data": {
+                    }
+                },
+                "caseNumber": "123",
+                "memberName": "Elmer Fudd",
+                "documentName": "Information"
+            }
+        ]
+    }
+};
 const mockLoad = vi.fn().mockImplementation(() => ({setDocumentOutline: vi.fn().mockImplementation(() => ({}))}));
 const mockUnload = vi.fn();
 let filesService: any;
@@ -18,6 +46,9 @@ vi.mock('@/stores/PDFViewerStore', () => {
     usePDFViewerStore: vi.fn(() => ({
       get documents() {
         return mockDocuments;
+      },
+      get groupedDocuments() {
+        return mockGroupedDocuments;
       },
       clearDocuments: vi.fn(),
     })),


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[470](https://jira.justice.gov.bc.ca/browse/JASPER-470)**----    

## ✨ Nutrient FE Document Outline 🎯
This PR adds the FE capability to create and display the document outlines
The outline API is only exposed in the FE Nutrient SDK. This means it is entirely the FE's responsibility. The BE is only responsible for receiving pdf generation requests and squashing them all down into one document.
This is phase 1 of the outlines. More changes will come, but phase 1 needs to be done in time for the 2nd.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tested
- [x] Ran `./manage` script

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Screengrab of changes
<img width="693" height="738" alt="image" src="https://github.com/user-attachments/assets/3c552f4b-c604-4ce6-850e-30cc4e964e76" />
