### PR TITLE
Use new claim to easily map the current user to PCSS user

### DIFF
--- a/api/Helpers/ClaimsTypes.cs
+++ b/api/Helpers/ClaimsTypes.cs
@@ -20,6 +20,7 @@ namespace Scv.Api.Helpers
         public const string JudgeId = nameof(CustomClaimTypes) + nameof(JudgeId);
         public const string JudgeHomeLocationId = nameof(CustomClaimTypes) + nameof(JudgeHomeLocationId);
         public const string UserGuid = "idir_user_guid";
+        public const string ExternalJudgeId = "pcss_judge_id";
 
         public static readonly List<string> UsedKeycloakClaimTypes =
         [
@@ -29,7 +30,8 @@ namespace Scv.Api.Helpers
             "preferred_username",
             "groups",
             ClaimTypes.Email,
-            UserGuid
+            UserGuid,
+            ExternalJudgeId
         ];
     }
 }

--- a/api/Helpers/Extensions/ClaimsPrincipalExtensions.cs
+++ b/api/Helpers/Extensions/ClaimsPrincipalExtensions.cs
@@ -124,7 +124,10 @@ namespace Scv.Api.Helpers.Extensions
         public static bool CanViewOthersSchedule(this ClaimsPrincipal claimsPrincipal)
             => claimsPrincipal.HasClaim(c => c.Type == CustomClaimTypes.Groups && c.Value == "jasper-view-others-schedule");
 
-        public static string UserGuid(this ClaimsPrincipal claimsPrincipal) =>
-            claimsPrincipal.FindFirstValue(CustomClaimTypes.UserGuid);
+        public static string UserGuid(this ClaimsPrincipal claimsPrincipal)
+            => claimsPrincipal.FindFirstValue(CustomClaimTypes.UserGuid);
+
+        public static string ExternalJudgeId(this ClaimsPrincipal claimsPrincipal)
+            => claimsPrincipal.FindFirstValue(CustomClaimTypes.ExternalJudgeId);
     }
 }

--- a/api/Infrastructure/Authentication/AuthenticationServiceCollectionExtension.cs
+++ b/api/Infrastructure/Authentication/AuthenticationServiceCollectionExtension.cs
@@ -255,12 +255,29 @@ namespace Scv.Api.Infrastructure.Authentication
             var judgeId = configuration.GetNonEmptyValue("PCSS:JudgeId");
             var homeLocationId = configuration.GetNonEmptyValue("PCSS:JudgeHomeLocationId");
 
+            // Default the user to his own external Judge Id.
+            if (!string.IsNullOrWhiteSpace(context.Principal.ExternalJudgeId()))
+            {
+                var dashboardService = context.HttpContext.RequestServices.GetRequiredService<IDashboardService>();
+                var judges = await dashboardService.GetJudges();
+
+                // Find out the judge home location from list of judges
+                int.TryParse(context.Principal.ExternalJudgeId(), out int pcssJudgeId);
+
+                var judge = judges.FirstOrDefault(j => j.PersonId == pcssJudgeId);
+                if (judge != null)
+                {
+                    judgeId = pcssJudgeId.ToString();
+                    homeLocationId = judge.HomeLocationId.ToString();
+                }
+            }
+
             // Remove checking when the "real" mongo db has been configured
             var connectionString = configuration.GetValue<string>("MONGODB_CONNECTION_STRING");
             if (string.IsNullOrWhiteSpace(connectionString))
             {
                 // Defaults the logged in user to the default judge.
-                logger.LogInformation("Acting as Judge Id - {JudgeId}.", judgeId);
+                logger.LogInformation("Acting as Judge Id - {JudgeId} with Home Location Id - {HomeLocationId}.", judgeId, homeLocationId);
                 claims.Add(new Claim(CustomClaimTypes.JudgeId, judgeId));
                 claims.Add(new Claim(CustomClaimTypes.JudgeHomeLocationId, homeLocationId));
                 return;
@@ -327,7 +344,7 @@ namespace Scv.Api.Infrastructure.Authentication
             finally
             {
                 // Add the final value of judgeId and homeLocationId as claims of the current user
-                logger.LogInformation("Acting as Judge Id - {JudgeId}.", judgeId);
+                logger.LogInformation("Acting as Judge Id - {JudgeId} with Home Location Id - {HomeLocationId}.", judgeId, homeLocationId);
                 claims.Add(new Claim(CustomClaimTypes.JudgeId, judgeId));
                 claims.Add(new Claim(CustomClaimTypes.JudgeHomeLocationId, homeLocationId));
             }

--- a/api/Infrastructure/Authentication/AuthenticationServiceCollectionExtension.cs
+++ b/api/Infrastructure/Authentication/AuthenticationServiceCollectionExtension.cs
@@ -262,12 +262,12 @@ namespace Scv.Api.Infrastructure.Authentication
                 var judges = await dashboardService.GetJudges();
 
                 // Find out the judge home location from list of judges
-                int.TryParse(context.Principal.ExternalJudgeId(), out int pcssJudgeId);
+                int.TryParse(context.Principal.ExternalJudgeId(), out int externalJudgeId);
 
-                var judge = judges.FirstOrDefault(j => j.PersonId == pcssJudgeId);
+                var judge = judges.FirstOrDefault(j => j.PersonId == externalJudgeId);
                 if (judge != null)
                 {
-                    judgeId = pcssJudgeId.ToString();
+                    judgeId = externalJudgeId.ToString();
                     homeLocationId = judge.HomeLocationId.ToString();
                 }
             }


### PR DESCRIPTION
This update uses the `pcss_judge_id` value to be able to load users PCSS data. If the claim is not populated, the default user will be loaded.