### PR TITLE
JASPER-548: Case Details: Civil: Document Filtering by Category

### DIFF
--- a/api/Infrastructure/Mappings/DocumentCategoryMapping.cs
+++ b/api/Infrastructure/Mappings/DocumentCategoryMapping.cs
@@ -1,4 +1,6 @@
-﻿using Mapster;
+﻿using System;
+using System.Collections.Generic;
+using Mapster;
 using PCSSCommon.Models;
 using Scv.Api.Models;
 using Scv.Db.Models;
@@ -7,16 +9,38 @@ namespace Scv.Api.Infrastructure.Mappings;
 
 public class DocumentCategoryMapping : IRegister
 {
+    // ROPs and PSRs are acronyms so we don't want to change their casing
+    private static readonly HashSet<string> CategoriesToSkip = new(
+    [
+        DocumentCategory.ROP,
+        DocumentCategory.PSR
+    ], StringComparer.OrdinalIgnoreCase);
+
     public void Register(TypeAdapterConfig config)
     {
         config.NewConfig<PcssConfiguration, DocumentCategoryDto>()
-            .Map(dest => dest.Name, src => src.Key);
+            .Map(dest => dest.Name, src => TransformName(src.Key));
 
         config.NewConfig<PcssConfiguration, DocumentCategory>()
-            .Map(dest => dest.Name, src => src.Key)
+            .Map(dest => dest.Name, src => TransformName(src.Key))
             .Map(dest => dest.ExternalId, src => src.PcssConfigurationId);
 
         config.NewConfig<DocumentCategory, DocumentCategory>()
             .Ignore(dest => dest.Id);
+    }
+
+    /// <summary>
+    /// Capitalize the first letter and make the rest lowercase unless it's in the skip list
+    /// </summary>
+    /// <param name="value">Category value </param>
+    /// <returns>Transformed value</returns>
+    private static string TransformName(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || CategoriesToSkip.Contains(value))
+        {
+            return value ?? string.Empty;
+        }
+
+        return char.ToUpper(value[0]) + value.Substring(1).ToLower();
     }
 }

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -1,18 +1,18 @@
 <template>
   <v-row>
     <v-col cols="6" />
-    <v-col cols="3" class="ml-auto" v-if="documentTypes.length > 1">
+    <v-col cols="3" class="ml-auto" v-if="documentCategories.length > 1">
       <v-select
-        v-model="selectedType"
+        v-model="selectedCategory"
         label="Documents"
         placeholder="All documents"
         hide-details
-        :items="documentTypes"
+        :items="documentCategories"
       >
         <template v-slot:item="{ props: itemProps, item }">
           <v-list-item
             v-bind="itemProps"
-            :title="item.title + ' (' + typeCount(item.raw) + ')'"
+            :title="item.title + ' (' + categoryCount(item.raw) + ')'"
           ></v-list-item>
         </template>
       </v-select>
@@ -148,7 +148,7 @@
   const enableViewTogether = computed<boolean>(
     () => selectedItems.value.filter((d) => d.imageId).length > 1
   );
-  const selectedType = ref<string>();
+  const selectedCategory = ref<string>();
   const isBinderLoading = ref(true);
   const rolesLoading = ref(false);
   const roles = ref<LookupCode[]>();
@@ -196,7 +196,7 @@
     ['judgeId']: commonStore.userInfo?.userId,
   };
 
-  const documentTypes = ref<any[]>([
+  const documentCategories = ref<any[]>([
     ...new Map(
       props.documents
         .filter((d) => d.category)
@@ -206,12 +206,12 @@
         ])
     ).values(),
   ]);
-  const filterByType = (item: civilDocumentType) =>
-    !selectedType.value ||
-    item.category?.toLowerCase() === selectedType.value?.toLowerCase();
+  const filterByCategory = (item: civilDocumentType) =>
+    !selectedCategory.value ||
+    item.category?.toLowerCase() === selectedCategory.value?.toLowerCase();
 
   const filteredDocuments = computed(() =>
-    props.documents.filter(filterByType)
+    props.documents.filter(filterByCategory)
   );
 
   const binderDocuments = computed(() => {
@@ -231,11 +231,11 @@
       .filter(
         (item): item is (typeof props.documents)[number] => item !== undefined
       )
-      .filter(filterByType);
+      .filter(filterByCategory);
     return filteredAndSorted;
   });
 
-  const typeCount = (type: any): number =>
+  const categoryCount = (type: any): number =>
     props.documents.filter((doc) => doc.category === type.value).length;
 
   onMounted(async () => {
@@ -319,7 +319,10 @@
       return;
     }
     currentBinder.value.documents = currentBinder.value?.documents.filter(
-      (d) => !selectedBinderItems.value.find((item) => item === d.documentId)
+      (d) =>
+        !selectedBinderItems.value.find(
+          (item) => item.civilDocumentId === d.documentId
+        )
     );
     selectedBinderItems.value = [];
     await saveBinder();

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -198,15 +198,17 @@
 
   const documentTypes = ref<any[]>([
     ...new Map(
-      props.documents.map((doc) => [
-        doc.documentTypeCd,
-        { title: doc.documentTypeDescription, value: doc.documentTypeCd },
-      ])
+      props.documents
+        .filter((d) => d.category)
+        .map((doc) => [
+          doc.category,
+          { title: doc.category, value: doc.category },
+        ])
     ).values(),
   ]);
   const filterByType = (item: civilDocumentType) =>
     !selectedType.value ||
-    item.documentTypeCd?.toLowerCase() === selectedType.value?.toLowerCase();
+    item.category?.toLowerCase() === selectedType.value?.toLowerCase();
 
   const filteredDocuments = computed(() =>
     props.documents.filter(filterByType)
@@ -234,7 +236,7 @@
   });
 
   const typeCount = (type: any): number =>
-    props.documents.filter((doc) => doc.documentTypeCd === type.value).length;
+    props.documents.filter((doc) => doc.category === type.value).length;
 
   onMounted(async () => {
     try {

--- a/web/src/components/case-details/civil/appearances/ScheduledDocuments.vue
+++ b/web/src/components/case-details/civil/appearances/ScheduledDocuments.vue
@@ -13,7 +13,7 @@
     <template v-slot:item.issue="{ item }">
       <LabelWithTooltip
         v-if="item.issue?.length > 0"
-        :values="item.issue.map((issue) => issue.issueTypeDesc)"
+        :values="item.issue.map((issue) => issue.issueDsc)"
         :location="Anchor.Top"
       />
     </template>
@@ -32,7 +32,7 @@
 
   const headers = [
     { title: 'SEQ', key: 'fileSeqNo' },
-    { title: 'DOCUMENT TYPE', key: 'category' },
+    { title: 'DOCUMENT TYPE', key: 'documentTypeDescription' },
     { title: 'ACT', key: 'activity' },
     {
       title: 'DATE FILED',

--- a/web/src/components/case-details/civil/documents/AllDocuments.vue
+++ b/web/src/components/case-details/civil/documents/AllDocuments.vue
@@ -66,7 +66,7 @@
     <template v-slot:item.issue="{ item }">
       <LabelWithTooltip
         v-if="item.issue?.length > 0"
-        :values="item.issue.map((issue) => issue.issueTypeDesc)"
+        :values="item.issue.map((issue) => issue.issueDsc)"
         :location="Anchor.Top"
       />
     </template>

--- a/web/src/components/case-details/civil/documents/JudicialBinder.vue
+++ b/web/src/components/case-details/civil/documents/JudicialBinder.vue
@@ -29,10 +29,7 @@
       </template>
     </v-alert>
     <div class="d-flex justify-end my-3">
-      <v-btn-secondary 
-        class="mr-3"
-        text="View Binder"
-        @click="viewBinder" />
+      <v-btn-secondary class="mr-3" text="View Binder" @click="viewBinder" />
       <ConfirmButton
         buttonText="Delete Judicial Binder"
         infoText="Are you sure you want to delete your Judicial Binder? This will not delete any documents."
@@ -130,7 +127,7 @@
                   <!-- Issues column -->
                   <LabelWithTooltip
                     v-if="element.issue?.length > 0"
-                    :values="element.issue.map((issue) => issue.issueTypeDesc)"
+                    :values="element.issue.map((issue) => issue.issueDsc)"
                     :location="Anchor.Top"
                   />
                 </td>

--- a/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
+++ b/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
@@ -35,7 +35,7 @@ describe('CivilDocumentsView.vue', () => {
   const mockDocuments = [
     {
       civilDocumentId: '1',
-      documentTypeCd: 'CSR',
+      category: 'CSR',
       documentTypeDescription: 'Civil Document 1',
       filedDt: '2023-01-01',
       filedBy: [{ roleTypeCode: 'Role1' }],
@@ -46,7 +46,7 @@ describe('CivilDocumentsView.vue', () => {
     },
     {
       civilDocumentId: '2',
-      documentTypeCd: 'DOC',
+      category: 'ROP',
       documentTypeDescription: 'Civil Document 2',
       filedDt: '2023-02-01',
       filedBy: [{ roleTypeCode: 'Role2' }],
@@ -81,7 +81,7 @@ describe('CivilDocumentsView.vue', () => {
   });
 
   it('filters documents by selected type', async () => {
-    wrapper.vm.selectedType = 'CSR';
+    wrapper.vm.selectedCategory = 'CSR';
 
     expect(wrapper.vm.filteredDocuments).toEqual([mockDocuments[0]]);
   });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-548

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-548

## Description
- Fixes the Documents dropdown to use Categories instead of Document Types
- Updates Court List Scheduled Documents to show Document Type intead of Category
- Format the category name to show the first letter as capital while the rest are lower case. ROPs and CRSs is skipped.
- Some fixes to small bugs (value in Issue column, removing a document from binder via ActionBar)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Local testing

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [x]  Any dependent changes have been merged and published in downstream modules   

## Screen Grab

https://github.com/user-attachments/assets/0ba4f728-e53a-486d-85ac-6777cfcfbd16

