### PR TITLE
JASPER 585: View court-list appearance details documents

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,8 +8,8 @@
     <link rel="stylesheet" type="text/css" href="/styles/common.css" />
     <link rel="icon" href="/images/jasper-favicon.svg" />
     <script
-      src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.0.0/nutrient-viewer.js"
-      integrity="sha384-JTC1mFN3kso24q8w7XCow7YpXGaqinW0IUd0BqkwLTJNTyaE2y3L1g0UsXqHoCgj"
+      src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.6.0/nutrient-viewer.js"
+      integrity="sha384-FpJgFoh5tdCRqaLprEfCHbS/pCRVdCC1DiDS0EYAZah8IPPqYtVbi5Fx2VG8R4o2"
       crossorigin="anonymous"
     ></script>
     <title>

--- a/web/src/components/case-details/civil/appearances/ScheduledDocuments.vue
+++ b/web/src/components/case-details/civil/appearances/ScheduledDocuments.vue
@@ -5,6 +5,14 @@
     :items="documents"
     item-value="appearanceId"
   >
+    <template v-slot:item.documentTypeDescription="{ item }">
+      <a v-if="item.imageId" href="javascript:void(0)" @click="openDocument(item)">
+        {{ item.documentTypeDescription }}
+      </a>
+      <span v-else>
+        {{ item.documentTypeDescription }}
+      </span>
+    </template>
     <template v-slot:item.activity="{ item }">
       <div v-for="info in item.documentSupport" :key="info.actCd">
         {{ info.actCd }}
@@ -22,12 +30,20 @@
 
 <script setup lang="ts">
   import LabelWithTooltip from '@/components/shared/LabelWithTooltip.vue';
+  import shared from '@/components/shared';
   import { civilDocumentType } from '@/types/civil/jsonTypes/index';
+  import { beautifyDate } from '@/filters';
   import { Anchor } from '@/types/common';
   import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
+  import { CourtDocumentType, DocumentData } from '@/types/shared';
+  import { useCommonStore } from '@/stores';
 
-  defineProps<{
+  const props = defineProps<{
     documents: civilDocumentType[];
+    fileId: string;
+    fileNumberTxt: string;
+    courtLevel: string;
+    agencyId: string;
   }>();
 
   const headers = [
@@ -45,6 +61,26 @@
     { title: 'RESULTS', key: 'runtime' },
     { title: 'ISSUES', key: 'issue' },
   ];
+  const commonStore = useCommonStore();
+
+  const openDocument = (document: civilDocumentType) => {
+    const locationName = commonStore.courtRoomsAndLocations.filter(
+        (location) => location.agencyIdentifierCd == props.agencyId)[0]?.name;
+      const isCsr = document.category?.toLowerCase() === 'csr';
+      const documentData: DocumentData = {
+        dateFiled: beautifyDate(document.DateGranted),
+        documentId: document.civilDocumentId,
+        documentDescription: document.documentTypeDescription,
+        fileId: props.fileId,
+        fileNumberText: props.fileNumberTxt,
+        courtLevel: props.courtLevel,
+        partId: document.partId,
+        profSeqNo: document.fileSeqNo,
+        location: locationName,
+        isCriminal: false,
+      };
+    shared.openDocumentsPdf(isCsr ? CourtDocumentType.CSR : CourtDocumentType.Civil, documentData);
+  };
 </script>
 
 <style scoped>

--- a/web/src/components/civil/CivilAppearanceDetails.vue
+++ b/web/src/components/civil/CivilAppearanceDetails.vue
@@ -18,7 +18,12 @@
         :loading="loading"
       >
         <v-tabs-window-item value="documents">
-          <ScheduledDocuments :documents="details.document" />
+          <ScheduledDocuments 
+            :documents="details.document" 
+            :fileId 
+            :fileNumberTxt="details.fileNumberTxt" 
+            :courtLevel="details.courtLevelCd" 
+            :agencyId="details.agencyId" />
         </v-tabs-window-item>
         <v-tabs-window-item value="binder"> Binder </v-tabs-window-item>
 

--- a/web/src/components/courtlist/CourtListTable.vue
+++ b/web/src/components/courtlist/CourtListTable.vue
@@ -29,6 +29,7 @@
             :fileId="item.justinNo"
             :appearanceId="item.appearanceId"
             :partId="item.profPartId"
+            :courtClass="item.courtClassCd"
           />
           <CivilAppearanceDetails
             v-else

--- a/web/tests/components/case-details/civil/appearances/ScheduledDocuments.test.ts
+++ b/web/tests/components/case-details/civil/appearances/ScheduledDocuments.test.ts
@@ -1,0 +1,106 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ScheduledDocuments from 'CMP/case-details/civil/appearances/ScheduledDocuments.vue';
+
+const mockDocuments = [
+    {
+        appearanceId: '1',
+        fileSeqNo: 1,
+        documentTypeDescription: 'Affidavit',
+        imageId: 'img1',
+        documentSupport: [{ actCd: 'ACT1' }, { actCd: 'ACT2' }],
+        filedDt: '2024-06-01',
+        filedByName: 'John Doe',
+        runtime: 'Completed',
+        issue: [{ issueDsc: 'Issue 1' }],
+        category: 'civil',
+        DateGranted: '2024-06-01',
+        civilDocumentId: 'doc1',
+        partId: 'part1',
+    },
+    {
+        appearanceId: '2',
+        fileSeqNo: 2,
+        documentTypeDescription: 'Order',
+        imageId: null,
+        documentSupport: [],
+        filedDt: '2024-06-02',
+        filedByName: 'Jane Smith',
+        runtime: 'Pending',
+        issue: [],
+        category: 'csr',
+        DateGranted: '2024-06-02',
+        civilDocumentId: 'doc2',
+        partId: 'part2',
+    },
+];
+
+vi.mock('@/components/shared', () => ({
+    default: {
+        openDocumentsPdf: vi.fn(),
+    },
+    openDocumentsPdf: vi.fn(),
+}));
+
+vi.mock('@/stores', () => ({
+    useCommonStore: () => ({
+        courtRoomsAndLocations: [
+            { agencyIdentifierCd: 'AG1', name: 'Courtroom 1' },
+            { agencyIdentifierCd: 'AG2', name: 'Courtroom 2' },
+        ],
+    }),
+}));
+
+vi.mock('@/filters', () => ({
+    beautifyDate: (date: string) => `Beautified: ${date}`,
+}));
+
+vi.mock('@/utils/dateUtils', () => ({
+    formatDateToDDMMMYYYY: (date: string) => `Formatted: ${date}`,
+}));
+
+describe('ScheduledDocuments.vue', () => {
+    let wrapper: ReturnType<typeof mount>;
+    const mountComponent = (documents = mockDocuments) => {
+        return mount(ScheduledDocuments, {
+            props: {
+                documents,
+                fileId: 'file123',
+                fileNumberTxt: 'FN123',
+                courtLevel: 'Provincial',
+                agencyId: 'AG1',
+            },
+            global: {
+                stubs: {
+                    LabelWithTooltip: {
+                        template: '<div class="label-tooltip"></div>',
+                        props: ['values', 'location'],
+                    },
+                    'v-data-table-virtual': {
+                        template: `<div>
+                            <slot name="item.documentTypeDescription" :item="items && items[0] ? items[0] : {}"></slot>
+                        </div>`,
+                        props: ['headers', 'items', 'itemValue'],
+                    },
+                },
+            },
+        });
+    };
+
+    beforeEach(() => {
+        wrapper = mountComponent(mockDocuments);
+    });
+
+    it('renders document type as link if imageId exists', () => {
+        const links = wrapper.findAll('a');
+        expect(links.length).toBeGreaterThan(0);
+        expect(links[0].text()).toContain('Affidavit');
+    });
+
+    it('does not render document type as link if no imageId exists', () => {
+        mockDocuments[0].imageId = null;
+        wrapper = mountComponent(mockDocuments);
+        const links = wrapper.findAll('a');
+        expect(links.length).toBe(0);
+    });
+});

--- a/web/tests/components/civil/CivilAppearanceDetails.test.ts
+++ b/web/tests/components/civil/CivilAppearanceDetails.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import CivilAppearanceDetails from 'CMP/civil/CivilAppearanceDetails.vue';
 import { FilesService } from '@/services/FilesService';
+import { setActivePinia, createPinia } from 'pinia'
 
 vi.mock('@/services/FilesService');
+
+beforeEach(() => {
+    setActivePinia(createPinia());
+});
 
 describe('CivilAppearanceDetails.vue', () => {
   let wrapper: any;

--- a/web/tests/components/courtList/CourtListCriminalDetails.test.ts
+++ b/web/tests/components/courtList/CourtListCriminalDetails.test.ts
@@ -3,8 +3,13 @@ import { FilesService } from '@/services/FilesService';
 import { mount, flushPromises } from '@vue/test-utils';
 import CourtListCriminalDetails from 'CMP/courtlist/CourtListCriminalDetails.vue';
 import { nextTick } from 'vue';
+import { setActivePinia, createPinia } from 'pinia'
 
 vi.mock('@/services/FilesService');
+
+beforeEach(() => {
+    setActivePinia(createPinia());
+});
 
 describe('CourtListCriminalDetails.vue', () => {
     let filesService: any;


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[585](https://jira.justice.gov.bc.ca/browse/JASPER-585)**----    

## ✨ Ability to view court-list documents 📄
Can now view individual documents in court-list appearance details
Updated nutrient-web viewer version

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tested
- [x] Ran `./manage` script

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Screengrab of changes