### PR TITLE
JASPER 582: Include case-number in document tab title

### DIFF
--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -83,7 +83,7 @@ export default {
       this.openRequestedTab(url, fileName, correlationId);
     } else {
       const newWindow = window.open(url);
-      this.replaceWindowFileName(newWindow, fileName);
+      this.replaceWindowTitle(newWindow, fileName);
     }
   },
   openDocumentsPdfV2(
@@ -128,9 +128,9 @@ export default {
         documentName: doc.documentName,
       });
     });
-    const tabName = Array.from(new Set(documents.map(d => d.groupKeyOne))).join(', ');
+    const caseNumbers = Array.from(new Set(documents.map(d => d.groupKeyOne))).join(', ');
     const newWindow = window.open('/pdf-viewer', 'pdf-viewer');
-    this.replaceWindowFileName(newWindow, tabName);
+    this.replaceWindowTitle(newWindow, caseNumbers);
   },
 
   generateFileName(
@@ -186,24 +186,24 @@ export default {
           splunkLog(endMsg);
         }
       };
-      this.replaceWindowFileName(windowObjectReference, fileName);
+      this.replaceWindowTitle(windowObjectReference, fileName);
     }
   },
 
-  replaceWindowFileName(newWindow: Window | null, fileName: string) {
+  replaceWindowTitle(newWindow: Window | null, title: string) {
     if(newWindow === null) {
       return null;
     }
     try {
       newWindow.addEventListener('load', function () {
         setTimeout(function () {
-          newWindow.document.title = fileName;
+          newWindow.document.title = title;
         }, 1000);
         setTimeout(function () {
-          newWindow.document.title = fileName;
+          newWindow.document.title = title;
         }, 3000);
         setTimeout(function () {
-          newWindow.document.title = fileName;
+          newWindow.document.title = title;
         }, 5000);
       });
     } catch (e) {


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[582](https://jira.justice.gov.bc.ca/browse/JASPER-582)**----    

## 🔢 Include case-number in document file tab 🎯
The title of the tab gets set by the `title` metadata of the downstream pdf.
We can override this by waiting a certain amount of time after the window loads and rewrite the tab ourselves.
The code introduced here was inspired PCSS's solution to the issue.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Ran `./manage` script

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screengrab of changes
Nutrient view:
<img width="480" height="204" alt="image" src="https://github.com/user-attachments/assets/63ff375e-b798-4db8-b188-88c98ee94130" />

Individual document view:
<img width="382" height="120" alt="image" src="https://github.com/user-attachments/assets/18c1e31e-a9bb-4c17-84e4-4f97062af25f" />

