### PR TITLE
Fix directory where dotnet test command executes

### DIFF
--- a/.github/workflows/actions/build-api/action.yml
+++ b/.github/workflows/actions/build-api/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - run: dotnet format --verify-no-changes --severity info
       shell: bash
-      working-directory: ${{ inputs.working_directory }}
+      working-directory: ${{ inputs.working_directory }}/api
       continue-on-error: true
 
     - run: dotnet restore
@@ -29,8 +29,8 @@ runs:
 
     - run: dotnet build --configuration Release --no-restore
       shell: bash
-      working-directory: ${{ inputs.working_directory }}
+      working-directory: ${{ inputs.working_directory }}/api
 
     - run: dotnet test --no-restore --verbosity normal
       shell: bash
-      working-directory: ${{ inputs.working_directory }}/../tests
+      working-directory: ${{ inputs.working_directory }}/tests

--- a/.github/workflows/build-and-test-api.yml
+++ b/.github/workflows/build-and-test-api.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - master
     paths:
-      - "api/**"
-      - "db/**"
+      - 'api/**'
+      - 'db/**'
 
   workflow_dispatch:
 
 env:
-  WORKING_DIRECTORY: ./api
+  WORKING_DIRECTORY: .
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This should run the `dotnet test` command in the right directory where `tests.csproj` lives.

<img width="790" height="206" alt="image" src="https://github.com/user-attachments/assets/ca29a23b-ad44-4474-aba2-7e6c959db12c" />
