### PR TITLE
Updates to Openshift Jobs to Access LZ secrets in Vault

### DIFF
--- a/openshift/sync-secrets.dc.yaml
+++ b/openshift/sync-secrets.dc.yaml
@@ -45,6 +45,7 @@ objects:
           activeDeadlineSeconds: 600
           parallelism: 1
           completions: 1
+          ttlSecondsAfterFinished: 259200 # Deletes pod after 3 days
           template:
             metadata:
               labels:
@@ -58,9 +59,9 @@ objects:
                 vault.hashicorp.com/auth-path: auth/k8s-emerald
                 vault.hashicorp.com/namespace: platform-services
                 vault.hashicorp.com/role: ${LICENSE_PLATE}-${VAULT_ROLE}
-                vault.hashicorp.com/agent-inject-secret-values: jasper-secret-${ENVIRONMENT}
+                vault.hashicorp.com/agent-inject-secret-values: jasper-secret-${AWS_SECRET_PREFIX}${ENVIRONMENT}
                 vault.hashicorp.com/agent-inject-template-values: |
-                  {{- with secret "${LICENSE_PLATE}-${VAULT_ROLE}/jasper-secret-${ENVIRONMENT}" -}}
+                  {{- with secret "${LICENSE_PLATE}-${VAULT_ROLE}/jasper-secret-${AWS_SECRET_PREFIX}${ENVIRONMENT}" -}}
                   {{ .Data.data | toUnescapedJSON }}
                   {{- end -}}
                 vault.hashicorp.com/agent-pre-populate-only: "true"
@@ -139,8 +140,8 @@ parameters:
 
   - name: AWS_SECRET_PREFIX
     description: AWS secret prefix to handle new landing zone environment
-    required: true
-    value: "lz-"
+    required: false
+    value: ""
 
   - name: CRON_SCHEDULE
     description: Cronjob Schedule

--- a/openshift/update-aws-creds.dc.yaml
+++ b/openshift/update-aws-creds.dc.yaml
@@ -75,6 +75,7 @@ objects:
           activeDeadlineSeconds: 600
           parallelism: 1
           completions: 1
+          ttlSecondsAfterFinished: 259200 # Deletes pod after 3 days
           template:
             metadata:
               labels:


### PR DESCRIPTION
Update job to delete pods older than 3 days and used `AWS_SECRET_PREFIX` to access appropriate lz- secrets in Vault.