### PR TITLE
Update Publish API GHA Working Directory

### DIFF
--- a/.github/workflows/publish-api.yml
+++ b/.github/workflows/publish-api.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - master
     paths:
-      - "api/**"
-      - "db/**"
+      - 'api/**'
+      - 'db/**'
 
   workflow_dispatch:
 
 env:
-  WORKING_DIRECTORY: ./api
+  WORKING_DIRECTORY: .
   IMAGE_NAME: api
   GITHUB_IMAGE_REPO: ghcr.io/bcgov/jasper
 


### PR DESCRIPTION
The publish api action is failing because of the recent update to the build api gha (https://github.com/bcgov/jasper/pull/511). This updates here should resolve the issue.