### PR TITLE
Switch Hangfire Storage to Postgresql

### DIFF
--- a/api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/api/Infrastructure/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using GdPicture14;
 using Hangfire;
 using Hangfire.Mongo;
+using Hangfire.Mongo.UtcDateTime;
 using JCCommon.Clients.FileServices;
 using JCCommon.Clients.LocationServices;
 using JCCommon.Clients.LookupCodeServices;
@@ -223,7 +224,6 @@ namespace Scv.Api.Infrastructure
             services.AddHangfire((sp, config) =>
             {
                 var mongoClient = sp.GetRequiredService<IMongoClient>();
-                var dbName = configuration.GetValue<string>("HANGFIRE_DB") ?? "hangfire";
 
                 config
                     .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
@@ -233,8 +233,9 @@ namespace Scv.Api.Infrastructure
                     {
                         ByPassMigration = true,
                         CheckQueuedJobsStrategy = CheckQueuedJobsStrategy.TailNotificationsCollection,
-                        Prefix = "hangfire.mongo",
+                        Prefix = "hangfire",
                         CheckConnection = true,
+                        UtcDateTimeStrategies = [new AggregationUtcDateTimeStrategy()]
                     });
             });
             services.AddHangfireServer(options => options.ServerName = "Hangfire.Mongo");

--- a/api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/api/Infrastructure/ServiceCollectionExtensions.cs
@@ -4,8 +4,6 @@ using System.Reflection;
 using GdPicture14;
 using Hangfire;
 using Hangfire.Mongo;
-using Hangfire.Mongo.Migration.Strategies;
-using Hangfire.Mongo.Migration.Strategies.Backup;
 using JCCommon.Clients.FileServices;
 using JCCommon.Clients.LocationServices;
 using JCCommon.Clients.LookupCodeServices;
@@ -233,14 +231,10 @@ namespace Scv.Api.Infrastructure
                     .UseRecommendedSerializerSettings()
                     .UseMongoStorage(mongoClient, dbName, new MongoStorageOptions
                     {
-                        MigrationOptions = new MongoMigrationOptions
-                        {
-                            MigrationStrategy = new MigrateMongoMigrationStrategy(),
-                            BackupStrategy = new CollectionMongoBackupStrategy(),
-                        },
+                        ByPassMigration = true,
                         CheckQueuedJobsStrategy = CheckQueuedJobsStrategy.TailNotificationsCollection,
                         Prefix = "hangfire.mongo",
-                        CheckConnection = true
+                        CheckConnection = true,
                     });
             });
             services.AddHangfireServer(options => options.ServerName = "Hangfire.Mongo");

--- a/api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/api/Infrastructure/ServiceCollectionExtensions.cs
@@ -212,7 +212,6 @@ namespace Scv.Api.Infrastructure
 
         public static IServiceCollection AddHangfire(this IServiceCollection services, IConfiguration configuration)
         {
-            // Remove checking when the "real" mongo db has been configured
             var connectionString = configuration.GetValue<string>("DatabaseConnectionString");
             if (string.IsNullOrEmpty(connectionString))
             {

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using ColeSoft.Extensions.Logging.Splunk;
 using FluentValidation;
 using Hangfire;
@@ -26,10 +30,6 @@ using Scv.Api.Infrastructure.Middleware;
 using Scv.Api.Jobs;
 using Scv.Api.Services.EF;
 using Scv.Db.Models;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
 
 namespace Scv.Api
 {
@@ -82,7 +82,7 @@ namespace Scv.Api
             services.AddMapster();
             services.AddNutrient();
             services.AddJasperDb(Configuration);
-            //services.AddHangfire(Configuration);
+            services.AddHangfire(Configuration);
 
             #region Cors
 
@@ -210,28 +210,28 @@ namespace Scv.Api
             app.UseAuthentication();
             app.UseAuthorization();
 
-            // var connectionString = Configuration.GetValue<string>("MONGODB_CONNECTION_STRING");
-            // var dbName = Configuration.GetValue<string>("MONGODB_NAME");
-            // if (!string.IsNullOrWhiteSpace(connectionString) && !string.IsNullOrWhiteSpace(dbName))
-            // {
-            //     app.UseHangfireDashboard("/hangfire", new DashboardOptions
-            //     {
-            //         Authorization = [new HangFireDashboardAuthorizationFilter()]
-            //     });
+            var connectionString = Configuration.GetValue<string>("MONGODB_CONNECTION_STRING");
+            var dbName = Configuration.GetValue<string>("MONGODB_NAME");
+            if (!string.IsNullOrWhiteSpace(connectionString) && !string.IsNullOrWhiteSpace(dbName))
+            {
+                app.UseHangfireDashboard("/hangfire", new DashboardOptions
+                {
+                    Authorization = [new HangFireDashboardAuthorizationFilter()]
+                });
 
-            //     #region Setup Jobs
-            //     using (var scope = app.ApplicationServices.CreateScope())
-            //     {
-            //         var provider = scope.ServiceProvider;
-            //         var allJobs = provider.GetServices<IRecurringJob>();
+                #region Setup Jobs
+                using (var scope = app.ApplicationServices.CreateScope())
+                {
+                    var provider = scope.ServiceProvider;
+                    var allJobs = provider.GetServices<IRecurringJob>();
 
-            //         foreach (var job in allJobs)
-            //         {
-            //             RecurringJobHelper.AddOrUpdate(job);
-            //         }
-            //     }
-            //     #endregion Setup Jobs
-            // }
+                    foreach (var job in allJobs)
+                    {
+                        RecurringJobHelper.AddOrUpdate(job);
+                    }
+                }
+                #endregion Setup Jobs
+            }
 
             app.UseEndpoints(endpoints =>
             {

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -210,9 +210,8 @@ namespace Scv.Api
             app.UseAuthentication();
             app.UseAuthorization();
 
-            var connectionString = Configuration.GetValue<string>("MONGODB_CONNECTION_STRING");
-            var dbName = Configuration.GetValue<string>("MONGODB_NAME");
-            if (!string.IsNullOrWhiteSpace(connectionString) && !string.IsNullOrWhiteSpace(dbName))
+            var connectionString = Configuration.GetValue<string>("DatabaseConnectionString");
+            if (!string.IsNullOrWhiteSpace(connectionString))
             {
                 app.UseHangfireDashboard("/hangfire", new DashboardOptions
                 {

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using ColeSoft.Extensions.Logging.Splunk;
 using FluentValidation;
@@ -15,8 +16,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.OpenApi.Models;
+using MongoDB.Driver;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -220,15 +223,16 @@ namespace Scv.Api
                 });
 
                 #region Setup Jobs
-                using (var scope = app.ApplicationServices.CreateScope())
-                {
-                    var provider = scope.ServiceProvider;
-                    var allJobs = provider.GetServices<IRecurringJob>();
+                using var scope = app.ApplicationServices.CreateScope();
+                var provider = scope.ServiceProvider;
+                var allJobs = provider.GetServices<IRecurringJob>();
+                var logger = provider.GetRequiredService<ILogger>();
 
-                    foreach (var job in allJobs)
-                    {
-                        RecurringJobHelper.AddOrUpdate(job);
-                    }
+                logger.LogInformation("Setting up {JobCount} recurring jobs", allJobs?.Count() ?? 0);
+
+                foreach (var job in allJobs)
+                {
+                    RecurringJobHelper.AddOrUpdate(job);
                 }
                 #endregion Setup Jobs
             }

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -225,7 +225,6 @@ namespace Scv.Api
 
                 foreach (var job in allJobs)
                 {
-                    Console.WriteLine($"Setting up {job.JobName}");
                     RecurringJobHelper.AddOrUpdate(job);
                 }
                 #endregion Setup Jobs

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using ColeSoft.Extensions.Logging.Splunk;
 using FluentValidation;
@@ -16,10 +15,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.OpenApi.Models;
-using MongoDB.Driver;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -226,12 +223,10 @@ namespace Scv.Api
                 using var scope = app.ApplicationServices.CreateScope();
                 var provider = scope.ServiceProvider;
                 var allJobs = provider.GetServices<IRecurringJob>();
-                var logger = provider.GetRequiredService<ILogger>();
-
-                logger.LogInformation("Setting up {JobCount} recurring jobs", allJobs?.Count() ?? 0);
 
                 foreach (var job in allJobs)
                 {
+                    Console.WriteLine($"Setting up {job.JobName}");
                     RecurringJobHelper.AddOrUpdate(job);
                 }
                 #endregion Setup Jobs

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -17,9 +17,9 @@
     <PackageReference Include="ColeSoft.Extensions.Logging.Splunk" Version="1.0.72" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="Hangfire" Version="1.8.21" />
-    <PackageReference Include="Hangfire.Mongo" Version="1.12.0" />
     <PackageReference Include="GdPicture.API" Version="14.3.14" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.20.12" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
     <PackageReference Include="NSwag.Generation.AspNetCore" Version="14.5.0" />

--- a/docker/api/Dockerfile.dev
+++ b/docker/api/Dockerfile.dev
@@ -7,8 +7,4 @@ ENV DOTNET_STARTUP_PROJECT='./api/api.csproj'
 ENV DOTNET_USE_POLLING_FILE_WATCHER 1
 
 # Download and install the AWS CA bundle
-RUN apt-get update && apt-get --no-install-recommends install -y curl ca-certificates \
-    && curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /usr/local/share/ca-certificates/aws-rds.crt \
-    && update-ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l /vsdbg
+RUN curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l /vsdbg

--- a/docker/api/Dockerfile.dev
+++ b/docker/api/Dockerfile.dev
@@ -6,5 +6,4 @@ ENV CORS_DOMAIN='http://localhost:8080'
 ENV DOTNET_STARTUP_PROJECT='./api/api.csproj'
 ENV DOTNET_USE_POLLING_FILE_WATCHER 1
 
-# Download and install the AWS CA bundle
 RUN curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l /vsdbg

--- a/docker/api/Dockerfile.dev
+++ b/docker/api/Dockerfile.dev
@@ -6,4 +6,9 @@ ENV CORS_DOMAIN='http://localhost:8080'
 ENV DOTNET_STARTUP_PROJECT='./api/api.csproj'
 ENV DOTNET_USE_POLLING_FILE_WATCHER 1
 
-RUN curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l /vsdbg
+# Download and install the AWS CA bundle
+RUN apt-get update && apt-get --no-install-recommends install -y curl ca-certificates \
+    && curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /usr/local/share/ca-certificates/aws-rds.crt \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l /vsdbg


### PR DESCRIPTION
When I first added Hangfire to JASPER, I set it up to use MongoDb for storage. When I configured JASPER to connect to AWS DocumentDb last sprint, I commented out Hangfire because it was throwing an error during initialization . I revisited it this sprint since we need it for the job that will save the Reserved Judgements data and as expected, the same initialization error showed up again. I managed to find a workaround but new keeps on coming up so I thought that it would be better to utilize the Postgres database we already have for the tables `scv` originally uses.

AWS DocumentDb is a 'cut-down' version of MongoDb and Hangfire depends on some features (e.g. such as creating of indices on initialization, using $$NOW no figure the UTC time). I made the necessary updates and deployed this branch in DEV and Hangfire is confirmed up and running.

## Screen Shots
<img width="1049" height="609" alt="image" src="https://github.com/user-attachments/assets/635605ed-5796-4b92-85c9-3695e29926f6" />

<img width="1117" height="320" alt="image" src="https://github.com/user-attachments/assets/0d70d0b4-a329-4962-b586-fa99e2afd563" />