### PR TITLE
JASPER 614: Show 'View Key-documents' for all criminal appearances

### DIFF
--- a/web/src/components/courtlist/CourtListTableActionBarGroup.vue
+++ b/web/src/components/courtlist/CourtListTableActionBarGroup.vue
@@ -20,7 +20,7 @@
             View case details
           </v-btn>
           <v-btn
-            v-if="courtClass == 'Criminal - Adult'"
+            v-if="isCourtClassLabelCriminal(courtClass)"
             size="large"
             class="mx-2"
             :prepend-icon="mdiFileDocumentMultipleOutline"
@@ -39,7 +39,7 @@
 <script setup lang="ts">
   import ActionBar from '@/components/shared/table/ActionBar.vue';
   import { CourtListAppearance } from '@/types/courtlist';
-  import { getCourtClassLabel } from '@/utils/utils';
+  import { getCourtClassLabel, isCourtClassLabelCriminal } from '@/utils/utils';
   import {
     mdiFileDocumentMultipleOutline,
     mdiFileDocumentOutline,

--- a/web/src/utils/utils.ts
+++ b/web/src/utils/utils.ts
@@ -300,6 +300,22 @@ export const getCourtClassLabel = (courtClassCd: string): string => {
 };
 
 /**
+ * Determines if the provided court class label corresponds to a criminal court class.
+ * @param courtClassLabel The court class label
+ * @returns Whether the court class is criminal
+ */
+export const isCourtClassLabelCriminal = (courtClassLabel: string): boolean => {
+  switch (courtClassLabel) {
+    case 'Criminal - Adult':
+    case 'Youth':
+    case 'Tickets':
+      return true;
+    default:
+      return false;
+  }
+};
+
+/**
  * Parses QueryString to string
  * @param value The query string param
  * @param fallback The fallback param when parsing fails

--- a/web/tests/utils/utils.test.ts
+++ b/web/tests/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { isPositiveInteger, parseQueryStringToString } from '@/utils/utils';
+import { isPositiveInteger, parseQueryStringToString, isCourtClassLabelCriminal } from '@/utils/utils';
 import { describe, expect, it } from 'vitest';
 
 describe('utils', () => {
@@ -56,6 +56,40 @@ describe('utils', () => {
 
       it('returns false for NaN', () => {
         expect(isPositiveInteger(NaN)).toBe(false);
+      });
+    });
+    
+    describe('isCourtClassLabelCriminal', () => {
+      it('returns true for "Criminal - Adult"', () => {
+        expect(isCourtClassLabelCriminal('Criminal - Adult')).toBe(true);
+      });
+
+      it('returns true for "Youth"', () => {
+        expect(isCourtClassLabelCriminal('Youth')).toBe(true);
+      });
+
+      it('returns true for "Tickets"', () => {
+        expect(isCourtClassLabelCriminal('Tickets')).toBe(true);
+      });
+
+      it('returns false for "Small Claims"', () => {
+        expect(isCourtClassLabelCriminal('Small Claims')).toBe(false);
+      });
+
+      it('returns false for "Family"', () => {
+        expect(isCourtClassLabelCriminal('Family')).toBe(false);
+      });
+
+      it('returns false for "Unknown"', () => {
+        expect(isCourtClassLabelCriminal('Unknown')).toBe(false);
+      });
+
+      it('returns false for empty string', () => {
+        expect(isCourtClassLabelCriminal('')).toBe(false);
+      });
+
+      it('returns false for unrelated label', () => {
+        expect(isCourtClassLabelCriminal('Civil')).toBe(false);
       });
     });
   });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[614](https://jira.justice.gov.bc.ca/browse/JASPER-614)**----    

## Fix issue where 'View key-documents' button was only appearing for Criminal-Adult appearances

Fixes # [614](https://jira.justice.gov.bc.ca/browse/JASPER-614)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tested
- [x] Ran `./manage` script

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   