### PR TITLE
JASPER-556: Dashboard: Addition of date navigation chevrons to move forward or backward

### DIFF
--- a/web/src/components/dashboard/CalendarToolbar.vue
+++ b/web/src/components/dashboard/CalendarToolbar.vue
@@ -15,6 +15,7 @@
       <div class="d-flex align-center">
         <v-icon
           class="previous cursor-pointer"
+          data-testid="previous"
           :icon="mdiChevronLeft"
           size="32"
           @click.stop="() => previous(calendarView)"
@@ -26,6 +27,7 @@
         <v-icon
           class="next cursor-pointer"
           :icon="mdiChevronRight"
+          data-testid="next"
           size="32"
           @click.stop="() => next(calendarView)"
           :disabled="isCalendarLoading"
@@ -51,16 +53,16 @@
             <div class="d-flex flex-row justify-center mt-3">
               <v-icon
                 :icon="mdiChevronLeft"
-                data-testid="previous-button"
-                @click.stop="() => previous('')"
+                data-testid="previous-year"
+                @click.stop="() => previous()"
                 :disabled="isCalendarLoading"
               />
               <span class="mx-3">{{ selectedYear }}</span>
               <v-icon
                 :disabled="isCalendarLoading"
                 :icon="mdiChevronRight"
-                @click.stop="() => next('')"
-                data-testid="next-button"
+                @click.stop="() => next()"
+                data-testid="next-year"
               />
             </div>
             <v-date-picker
@@ -162,14 +164,14 @@
     mdiChevronRight,
     mdiDotsHorizontal,
   } from '@mdi/js';
-  import { computed, ref, watch } from 'vue';
   import { DateTime } from 'luxon';
+  import { computed, ref } from 'vue';
 
   const selectedDate = defineModel<Date>('selectedDate');
   const isCourtCalendar = defineModel<boolean>('isCourtCalendar');
-  const calendarView = defineModel<string>('calendarView');
+  const calendarView = defineModel<CalendarViewEnum>('calendarView');
 
-  const props = defineProps<{ isCalendarLoading: boolean }>();
+  defineProps<{ isCalendarLoading: boolean }>();
 
   const viewMode = ref<'months' | 'year' | 'month' | undefined>('months');
   const selectedYear = ref(
@@ -180,7 +182,6 @@
   const selectedMonth = ref(
     selectedDate.value ? selectedDate.value.getMonth() : new Date().getMonth()
   );
-  const isLocalDisabled = ref(true);
 
   const options = [
     { label: 'Month', value: CalendarViewEnum.MonthView, icon: MonthIcon },
@@ -208,8 +209,8 @@
     selectedDate.value = date;
   };
 
-  const changeDate = (offset: number, viewMode: CalendarViewEnum) => {
-    let newDateTime = DateTime.fromJSDate(selectedDate.value);
+  const changeDate = (offset: number, viewMode?: CalendarViewEnum) => {
+    let newDateTime = DateTime.fromJSDate(selectedDate.value!);
 
     switch (viewMode) {
       case CalendarViewEnum.WeekView:
@@ -229,8 +230,8 @@
     setDate(newDateTime.toJSDate());
   };
 
-  const previous = (viewMode: CalendarViewEnum) => changeDate(-1, viewMode);
-  const next = (viewMode: CalendarViewEnum) => changeDate(1, viewMode);
+  const previous = (viewMode?: CalendarViewEnum) => changeDate(-1, viewMode);
+  const next = (viewMode?: CalendarViewEnum) => changeDate(1, viewMode);
 
   const today = () => setDate(new Date());
 
@@ -257,17 +258,13 @@
   }
 
   :deep(.v-date-picker-months) {
-    height: 10rem;
+    height: inherit;
   }
 
   :deep(.v-date-picker-months__content) {
-    border-bottom-left-radius: 1.25rem;
-    border-bottom-right-radius: 1.25rem;
     box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.2);
     grid-template-columns: repeat(4, 1fr);
     grid-gap: 0;
-    padding-inline-start: 0;
-    padding-inline-end: 0;
   }
 
   :deep(.v-date-picker-months__content .v-btn) {
@@ -278,8 +275,9 @@
 
   :deep(.v-date-picker-months__content .v-btn:hover) {
     border-radius: 0px;
-    font-weight: bold;
     margin: 0.5rem;
+    color: var(--text-white-500);
+    background-color: var(--bg-blue-800) !important;
   }
 
   :deep(.v-date-picker-months__content .v-btn--active .v-btn__overlay) {
@@ -288,6 +286,7 @@
 
   :deep(.v-date-picker-months__content .v-btn--active) {
     border: 1px solid var(--border-blue-500);
+    background-color: var(--bg-blue-50) !important;
     border-radius: 0px;
     font-weight: bold;
   }
@@ -298,7 +297,6 @@
 
   .month-picker {
     box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.2);
-    border-radius: 1.25rem;
     background-color: var(--bg-white-500);
   }
 

--- a/web/src/components/dashboard/CalendarToolbar.vue
+++ b/web/src/components/dashboard/CalendarToolbar.vue
@@ -12,9 +12,25 @@
       </a>
     </div>
     <div class="d-flex align-center centered">
-      <h3 data-testid="title" class="m-0">
-        Schedule for {{ formatDateInstanceToMMMYYYY(selectedDate!) }}
-      </h3>
+      <div class="d-flex align-center">
+        <v-icon
+          class="previous cursor-pointer"
+          :icon="mdiChevronLeft"
+          size="32"
+          @click.stop="() => previous(calendarView)"
+          :disabled="isCalendarLoading"
+        />
+        <h3 data-testid="title" class="m-0">
+          Schedule for {{ formatDateInstanceToMMMYYYY(selectedDate!) }}
+        </h3>
+        <v-icon
+          class="next cursor-pointer"
+          :icon="mdiChevronRight"
+          size="32"
+          @click.stop="() => next(calendarView)"
+          :disabled="isCalendarLoading"
+        />
+      </div>
       <div class="d-flex align-center centered">
         <!-- Month picker for My Calendar -->
         <v-menu
@@ -24,19 +40,26 @@
           class="mr-3"
         >
           <template v-slot:activator="{ props }">
-            <v-icon :icon="mdiChevronDown" v-bind="props" class="mr-3" />
+            <v-icon
+              :icon="mdiChevronDown"
+              v-bind="props"
+              class="mr-3"
+              :disabled="isCalendarLoading"
+            />
           </template>
           <div class="d-flex flex-column month-picker">
             <div class="d-flex flex-row justify-center mt-3">
               <v-icon
                 :icon="mdiChevronLeft"
                 data-testid="previous-button"
-                @click.stop="previousYear"
+                @click.stop="() => previous('')"
+                :disabled="isCalendarLoading"
               />
               <span class="mx-3">{{ selectedYear }}</span>
               <v-icon
+                :disabled="isCalendarLoading"
                 :icon="mdiChevronRight"
-                @click.stop="nextYear"
+                @click.stop="() => next('')"
                 data-testid="next-button"
               />
             </div>
@@ -59,6 +82,7 @@
           label=""
           density="compact"
           v-model="selectedDate"
+          :disabled="isCalendarLoading"
         >
           <template v-slot:default="">
             <v-icon :icon="mdiCalendarMonthOutline" />
@@ -71,6 +95,7 @@
           data-testid="today-button"
           @click="today"
           density="comfortable"
+          :disabled="isCalendarLoading"
         ></v-btn-secondary>
         <!-- Calendar View Picker for Court Calendar -->
         <v-menu
@@ -80,7 +105,12 @@
           location="bottom end"
         >
           <template #activator="{ props }">
-            <v-btn v-bind="props" variant="outlined" density="default">
+            <v-btn
+              v-bind="props"
+              variant="outlined"
+              density="default"
+              :disabled="isCalendarLoading"
+            >
               <component
                 class="mr-2"
                 :is="currentOption?.icon"
@@ -132,11 +162,14 @@
     mdiChevronRight,
     mdiDotsHorizontal,
   } from '@mdi/js';
-  import { computed, ref } from 'vue';
+  import { computed, ref, watch } from 'vue';
+  import { DateTime } from 'luxon';
 
   const selectedDate = defineModel<Date>('selectedDate');
   const isCourtCalendar = defineModel<boolean>('isCourtCalendar');
   const calendarView = defineModel<string>('calendarView');
+
+  const props = defineProps<{ isCalendarLoading: boolean }>();
 
   const viewMode = ref<'months' | 'year' | 'month' | undefined>('months');
   const selectedYear = ref(
@@ -147,6 +180,7 @@
   const selectedMonth = ref(
     selectedDate.value ? selectedDate.value.getMonth() : new Date().getMonth()
   );
+  const isLocalDisabled = ref(true);
 
   const options = [
     { label: 'Month', value: CalendarViewEnum.MonthView, icon: MonthIcon },
@@ -165,30 +199,43 @@
     menuOpen.value = false;
   };
 
-  const updateViewMode = (mode) => {
-    viewMode.value = mode === 'year' ? 'year' : 'months';
+  const updateViewMode = (mode) =>
+    (viewMode.value = mode === 'year' ? 'year' : 'months');
+
+  const setDate = (date: Date) => {
+    selectedYear.value = date.getFullYear();
+    selectedMonth.value = date.getMonth();
+    selectedDate.value = date;
   };
 
-  const previousYear = () => {
-    selectedYear.value--;
-    selectedDate.value = new Date(selectedYear.value, selectedMonth.value, 1);
+  const changeDate = (offset: number, viewMode: CalendarViewEnum) => {
+    let newDateTime = DateTime.fromJSDate(selectedDate.value);
+
+    switch (viewMode) {
+      case CalendarViewEnum.WeekView:
+        newDateTime = newDateTime.plus({ weeks: offset });
+        break;
+      case CalendarViewEnum.TwoWeekView:
+        newDateTime = newDateTime.plus({ weeks: offset * 2 });
+        break;
+      case CalendarViewEnum.MonthView:
+        newDateTime = newDateTime.plus({ months: offset });
+        break;
+      default:
+        newDateTime = newDateTime.plus({ years: offset });
+        break;
+    }
+
+    setDate(newDateTime.toJSDate());
   };
 
-  const nextYear = () => {
-    selectedYear.value++;
-    selectedDate.value = new Date(selectedYear.value, selectedMonth.value, 1);
-  };
+  const previous = (viewMode: CalendarViewEnum) => changeDate(-1, viewMode);
+  const next = (viewMode: CalendarViewEnum) => changeDate(1, viewMode);
 
-  const updateMonth = (month) => {
-    selectedMonth.value = month;
-    selectedDate.value = new Date(selectedYear.value, month, 1);
-  };
+  const today = () => setDate(new Date());
 
-  const today = () => {
-    const currentDate = new Date();
-    selectedYear.value = currentDate.getFullYear();
-    selectedMonth.value = currentDate.getMonth();
-    selectedDate.value = currentDate;
+  const updateMonth = (month: number) => {
+    setDate(new Date(selectedYear.value, month, 1));
   };
 </script>
 <style scoped>
@@ -267,5 +314,10 @@
   .two-week-svg {
     width: 22px;
     height: 22px;
+  }
+
+  .previous:hover,
+  .next:hover {
+    opacity: 0.8;
   }
 </style>

--- a/web/src/components/dashboard/CourtToday.vue
+++ b/web/src/components/dashboard/CourtToday.vue
@@ -160,9 +160,7 @@
     text-decoration: none;
   }
 
-  .transparent-skeleton {
-    background-color: transparent;
-    --v-skeleton-loader-background: transparent;
-    box-shadow: none;
+  :deep(.transparent-skeleton) {
+    background: transparent !important;
   }
 </style>

--- a/web/src/components/dashboard/Dashboard.vue
+++ b/web/src/components/dashboard/Dashboard.vue
@@ -4,14 +4,21 @@
     v-model:selectedDate="selectedDate"
     v-model:isCourtCalendar="isCourtCalendar"
     v-model:calendarView="calendarView"
+    :isCalendarLoading="isCalendarLoading"
   />
   <CourtCalendar
     v-if="isCourtCalendar"
     v-model:selectedDate="selectedDate"
     v-model:calendarView="calendarView"
+    v-model:isCalendarLoading="isCalendarLoading"
     :judgeId="judgeId"
   />
-  <MyCalendar v-else :judgeId="judgeId" v-model:selectedDate="selectedDate" />
+  <MyCalendar
+    v-else
+    :judgeId="judgeId"
+    v-model:selectedDate="selectedDate"
+    v-model:isCalendarLoading="isCalendarLoading"
+  />
   <DashboardPanels class="my-5" :judgeId="judgeId" />
 </template>
 <script setup lang="ts">
@@ -29,6 +36,7 @@
   const isCourtCalendar = ref(false);
   const selectedDate = ref(new Date());
   const calendarView = ref(CalendarViewEnum.MonthView);
+  const isCalendarLoading = ref(true);
 
   watch(
     () => commonStore.userInfo?.judgeId,

--- a/web/src/components/dashboard/court-calendar/CourtCalendar.vue
+++ b/web/src/components/dashboard/court-calendar/CourtCalendar.vue
@@ -37,12 +37,12 @@
 
   const selectedDate = defineModel<Date>('selectedDate');
   const calendarView = defineModel<string>('calendarView');
+  const isCalendarLoading = defineModel<boolean>('isCalendarLoading');
 
   if (!selectedDate.value) {
     throw new Error('selectedDate is required');
   }
 
-  const isCalendarLoading = ref(true);
   const calendarRef = ref();
   const calendarData = ref<CalendarDay[]>([]);
   const presiders = ref<Presider[]>([]);

--- a/web/src/components/dashboard/my-calendar/MyCalendar.vue
+++ b/web/src/components/dashboard/my-calendar/MyCalendar.vue
@@ -54,12 +54,12 @@
   }>();
 
   const selectedDate = defineModel<Date>('selectedDate')!;
+  const isCalendarLoading = defineModel<boolean>('isCalendarLoading');
 
   if (!selectedDate.value) {
     throw new Error('selectedDate is required');
   }
 
-  const isCalendarLoading = ref(true);
   const calendarData = ref<CalendarDay[]>([]);
   const expandedDate = ref<string | null>(null);
   const calendarRef = ref();

--- a/web/tests/components/dashboard/court-calendar/CourtCalendar.test.ts
+++ b/web/tests/components/dashboard/court-calendar/CourtCalendar.test.ts
@@ -1,8 +1,9 @@
 import CourtCalendar from '@/components/dashboard/court-calendar/CourtCalendar.vue';
 import { DashboardService } from '@/services';
 import { CalendarViewEnum } from '@/types/common';
-import { flushPromises, mount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
 
 vi.mock('@/services');
 
@@ -22,8 +23,10 @@ describe('CourtCalendar.vue', () => {
   const mountComponent = () => {
     return mount(CourtCalendar, {
       props: {
+        judgeId: 1,
         selectedDate: new Date(),
         calendarView: CalendarViewEnum.TwoWeekView,
+        isCalendarLoading: true,
       },
       global: {
         provide: {
@@ -33,22 +36,23 @@ describe('CourtCalendar.vue', () => {
     });
   };
 
-  it('renders CourtCalendarToolbar and FullCalendar', async () => {
-    const wrapper = mountComponent();
-
-    await flushPromises();
-
-    expect(wrapper.find('.fc').exists()).toBeTruthy();
-  });
-
-  it('shows v-skeleton-loader briefly before FullCalendar', async () => {
-    const wrapper = mountComponent();
+  it('renders skeleton loader when isCalendarLoading is true while FullCalendar is hidden', async () => {
+    const wrapper: any = mountComponent();
 
     expect(wrapper.find('v-skeleton-loader').exists()).toBeTruthy();
+    expect(wrapper.find('.fc').exists()).toBeFalsy();
+  });
 
-    await flushPromises();
+  it('renders FullCalendar when isCalendarLoading is false while skeleton loader is hidden', async () => {
+    const wrapper: any = mountComponent();
 
-    expect(wrapper.find('.fc').exists()).toBeTruthy();
+    expect(wrapper.find('v-skeleton-loader').exists()).toBeTruthy();
+    expect(wrapper.find('.fc').exists()).toBeFalsy();
+
+    wrapper.vm.isCalendarLoading = false;
+    await nextTick();
+
     expect(wrapper.find('v-skeleton-loader').exists()).toBeFalsy();
+    expect(wrapper.find('.fc').exists()).toBeTruthy();
   });
 });

--- a/web/tests/components/dashboard/my-calendar/MyCalendar.test.ts
+++ b/web/tests/components/dashboard/my-calendar/MyCalendar.test.ts
@@ -1,7 +1,8 @@
 import MyCalendar from '@/components/dashboard/my-calendar/MyCalendar.vue';
 import { DashboardService } from '@/services';
-import { flushPromises, mount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
 
 vi.mock('@/services');
 
@@ -21,6 +22,7 @@ describe('MyCalendar.vue', () => {
       props: {
         judgeId: 1,
         selectedDate: new Date(),
+        isCalendarLoading: true,
       },
       global: {
         provide: {
@@ -30,22 +32,23 @@ describe('MyCalendar.vue', () => {
     });
   };
 
-  it('renders MyCalendarToolbar and FullCalendar', async () => {
-    const wrapper = mountComponent();
-
-    await flushPromises();
-
-    expect(wrapper.find('.fc').exists()).toBeTruthy();
-  });
-
-  it('shows v-skeleton-loader briefly before FullCalendar', async () => {
-    const wrapper = mountComponent();
+  it('renders skeleton loader when isCalendarLoading is true while FullCalendar is hidden', async () => {
+    const wrapper: any = mountComponent();
 
     expect(wrapper.find('v-skeleton-loader').exists()).toBeTruthy();
+    expect(wrapper.find('.fc').exists()).toBeFalsy();
+  });
 
-    await flushPromises();
+  it('renders FullCalendar when isCalendarLoading is false while skeleton loader is hidden', async () => {
+    const wrapper: any = mountComponent();
 
-    expect(wrapper.find('.fc').exists()).toBeTruthy();
+    expect(wrapper.find('v-skeleton-loader').exists()).toBeTruthy();
+    expect(wrapper.find('.fc').exists()).toBeFalsy();
+
+    wrapper.vm.isCalendarLoading = false;
+    await nextTick();
+
     expect(wrapper.find('v-skeleton-loader').exists()).toBeFalsy();
+    expect(wrapper.find('.fc').exists()).toBeTruthy();
   });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-556

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-556

## Description
Add `previous` and `next` buttons to both My Calendar and Court Calendar to make navigation easier. This previous and next feature is supported in all views (weekly, 2-week and monthly).

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Local testing

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screen Grab
https://github.com/user-attachments/assets/332fa386-bbe1-40dc-af66-df89c28b3118