### PR TITLE
JASPER 731: Assign unique keys for duplicate civilDocumentId

### DIFF
--- a/web/src/components/case-details/civil/documents/AllDocuments.vue
+++ b/web/src/components/case-details/civil/documents/AllDocuments.vue
@@ -121,8 +121,7 @@
   const documentsWithRowKey = computed<RowCivilDocument[]>(() =>
     props.documents.map((doc, index) => ({
       ...doc,
-      __rowKey:
-        `${doc.civilDocumentId}|${doc.fileSeqNo}|${index}`,
+      __rowKey: `${doc.civilDocumentId}|${doc.fileSeqNo}|${index}`,
     }))
   );
 

--- a/web/src/components/case-details/civil/documents/AllDocuments.vue
+++ b/web/src/components/case-details/civil/documents/AllDocuments.vue
@@ -122,8 +122,7 @@
     props.documents.map((doc, index) => ({
       ...doc,
       __rowKey:
-        `${doc.civilDocumentId}|${doc.fileSeqNo}|${doc.lastAppearanceId}|` +
-        `${doc.lastAppearanceDt}|${index}`,
+        `${doc.civilDocumentId}|${doc.fileSeqNo}|${index}`,
     }))
   );
 

--- a/web/src/components/case-details/civil/documents/AllDocuments.vue
+++ b/web/src/components/case-details/civil/documents/AllDocuments.vue
@@ -34,10 +34,10 @@
     :model-value="selectedItems"
     @update:model-value="handleSelectedItemsChange"
     :headers="baseHeaders"
-    :items="documents"
+    :items="documentsWithRowKey"
     :sortBy
     return-object
-    item-value="civilDocumentId"
+    item-value="__rowKey"
     show-select
     class="my-3"
     height="800"
@@ -94,6 +94,7 @@
   import { DataTableHeader } from '@/types/shared';
   import { mdiNotebookOutline } from '@mdi/js';
   import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
+  import { computed } from 'vue';
 
   const props = defineProps<{
     selectedItems: civilDocumentType[];
@@ -114,7 +115,19 @@
       (e: 'update:selectedItems', value: civilDocumentType[]) => void
     >();
 
-  const handleSelectedItemsChange = (newItems) => {
+  type RowCivilDocument = civilDocumentType & { __rowKey: string };
+
+  // We need to create a unique row key for each document to ensure proper table drawing.
+  const documentsWithRowKey = computed<RowCivilDocument[]>(() =>
+    props.documents.map((doc, index) => ({
+      ...doc,
+      __rowKey:
+        `${doc.civilDocumentId}|${doc.fileSeqNo}|${doc.lastAppearanceId}|` +
+        `${doc.lastAppearanceDt}|${index}`,
+    }))
+  );
+
+  const handleSelectedItemsChange = (newItems: RowCivilDocument[]) => {
     emit('update:selectedItems', [...newItems]);
   };
 


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[731](https://jira.justice.gov.bc.ca/browse/JASPER-731)**----    

## ⤵️ Assign unique keys for each civil document 🛠️
We are getting documents back with duplicate `civilDocumentId`s. The rest of the info is pretty different which tells me it could be an issue on the JC side. It was causing the UI to break and act really strangely.
To get around this I've computed a unique key based off this value plus some extra more unique values.
I was able to confirm this fix by reusing some of the prod information locally.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran `./manage` script
- [ ] Unit tested 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   