### PR TITLE
JASPER 769: Batch document retrieval/merge requests

### DIFF
--- a/api/Documents/DocumentMerger.cs
+++ b/api/Documents/DocumentMerger.cs
@@ -12,6 +12,7 @@ namespace Scv.Api.Documents;
 
 public class DocumentMerger(IDocumentRetriever documentRetriever, ILogger<DocumentMerger> logger) : IDocumentMerger
 {
+    private const int RetrieveBatchSize = 10;
 
     /// <summary>
     /// Merges multiple PDF documents into a single PDF document in base64 format.
@@ -22,11 +23,7 @@ public class DocumentMerger(IDocumentRetriever documentRetriever, ILogger<Docume
     {
         using GdPictureDocumentConverter gdpictureConverter = new();
 
-        // Retrieve all document streams to merge
-        var retrieveTasks = documentRequests
-            .Select(documentRetriever.Retrieve);
-
-        var streamsToMerge = await Task.WhenAll(retrieveTasks);
+        var streamsToMerge = await RetrieveStreamsInBatches(documentRequests);
 
         try
         {
@@ -107,5 +104,39 @@ public class DocumentMerger(IDocumentRetriever documentRetriever, ILogger<Docume
 
             await Task.WhenAll(disposeTasks);
         }
+    }
+
+    private async Task<MemoryStream[]> RetrieveStreamsInBatches(PdfDocumentRequest[] documentRequests)
+    {
+        var streams = new MemoryStream[documentRequests.Length];
+
+        for (var batchStart = 0; batchStart < documentRequests.Length; batchStart += RetrieveBatchSize)
+        {
+            var batchCount = Math.Min(RetrieveBatchSize, documentRequests.Length - batchStart);
+
+            logger.LogInformation(
+                "Retrieving document batch starting at index {BatchStart} with {BatchCount} documents.",
+                batchStart,
+                batchCount);
+
+            var retrieveTasks = Enumerable
+                .Range(batchStart, batchCount)
+                .Select(index => RetrieveStream(index, documentRequests[index]));
+
+            var batchResults = await Task.WhenAll(retrieveTasks);
+
+            foreach (var (index, stream) in batchResults)
+            {
+                streams[index] = stream;
+            }
+        }
+
+        return streams;
+    }
+
+    private async Task<(int Index, MemoryStream Stream)> RetrieveStream(int index, PdfDocumentRequest documentRequest)
+    {
+        var stream = await documentRetriever.Retrieve(documentRequest);
+        return (index, stream);
     }
 }

--- a/api/Documents/DocumentMerger.cs
+++ b/api/Documents/DocumentMerger.cs
@@ -2,17 +2,25 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using GdPicture14;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Scv.Api.Models.Document;
 
 namespace Scv.Api.Documents;
 
-public class DocumentMerger(IDocumentRetriever documentRetriever, ILogger<DocumentMerger> logger) : IDocumentMerger
+public class DocumentMerger(
+    IDocumentRetriever documentRetriever,
+    ILogger<DocumentMerger> logger,
+    IConfiguration configuration) : IDocumentMerger
 {
-    private const int RetrieveBatchSize = 10;
+    private const int DefaultRetrieveBatchSize = 10;
+    private const string RetrieveBatchSizeKey = "DOCUMENT_RETRIEVAL_BATCH_SIZE";
+
+    private readonly IDocumentRetriever documentRetriever = documentRetriever;
+    private readonly ILogger<DocumentMerger> logger = logger;
+    private readonly IConfiguration configuration = configuration;
 
     /// <summary>
     /// Merges multiple PDF documents into a single PDF document in base64 format.
@@ -109,10 +117,14 @@ public class DocumentMerger(IDocumentRetriever documentRetriever, ILogger<Docume
     private async Task<MemoryStream[]> RetrieveStreamsInBatches(PdfDocumentRequest[] documentRequests)
     {
         var streams = new MemoryStream[documentRequests.Length];
-
-        for (var batchStart = 0; batchStart < documentRequests.Length; batchStart += RetrieveBatchSize)
+        var configuredValue = configuration.GetValue<string>(RetrieveBatchSizeKey);
+        var batchSize = int.TryParse(configuredValue, out var parsedBatchSize) && parsedBatchSize > 0
+            ? parsedBatchSize
+            : DefaultRetrieveBatchSize;
+        
+        for (var batchStart = 0; batchStart < documentRequests.Length; batchStart += batchSize)
         {
-            var batchCount = Math.Min(RetrieveBatchSize, documentRequests.Length - batchStart);
+            var batchCount = Math.Min(batchSize, documentRequests.Length - batchStart);
 
             logger.LogInformation(
                 "Retrieving document batch starting at index {BatchStart} with {BatchCount} documents.",

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -51,6 +51,7 @@ services:
       - DataProtectionKeyEncryptionKey=${DataProtectionKeyEncryptionKey}
       - DEFAULT_QUICK_LINKS=${DEFAULT_QUICK_LINKS}
       - DEFAULT_USERS=${DEFAULT_USERS}
+      - DOCUMENT_RETRIEVAL_BATCH_SIZE=${DOCUMENT_RETRIEVAL_BATCH_SIZE}
       - FileServicesClient__Password=${FileServicesClientPassword}
       - FileServicesClient__Url=${FileServicesClientUrl}
       - FileServicesClient__Username=${FileServicesClientUsername}

--- a/infrastructure/cloud/modules/SecretsManager/main.tf
+++ b/infrastructure/cloud/modules/SecretsManager/main.tf
@@ -238,7 +238,8 @@ resource "aws_secretsmanager_secret_version" "misc_secret_value" {
     allowedIpRanges                 = "",
     keyDocsBinderRefreshHours       = "",
     lazyCacheDefaultDurationSeconds = "",
-    supportAccount                  = ""
+    supportAccount                  = "",
+    documentRetrievalBatchSize      = ""
   })
   lifecycle {
     ignore_changes = [secret_string]

--- a/infrastructure/cloud/modules/SecretsManager/output.tf
+++ b/infrastructure/cloud/modules/SecretsManager/output.tf
@@ -58,6 +58,7 @@ output "api_secrets" {
     ["DARS__LogsheetUrl", "${aws_secretsmanager_secret.dars_secret.arn}:logsheetUrl::"],
     ["DatabaseConnectionString", "${aws_secretsmanager_secret.database_secret.arn}:dbConnectionString::"],
     ["DataProtectionKeyEncryptionKey", "${aws_secretsmanager_secret.misc_secret.arn}:dataProtectionKeyEncryptionKey::"],
+    ["DOCUMENT_RETRIEVAL_BATCH_SIZE", "${aws_secretsmanager_secret.misc_secret.arn}:documentRetrievalBatchSize::"],
     ["FileServicesClient__Username", "${aws_secretsmanager_secret.file_services_client_secret.arn}:username::"],
     ["FileServicesClient__Password", "${aws_secretsmanager_secret.file_services_client_secret.arn}:password::"],
     ["FileServicesClient__Url", "${aws_secretsmanager_secret.file_services_client_secret.arn}:baseUrl::"],

--- a/tests/api/Documents/DocumentMergerTests.cs
+++ b/tests/api/Documents/DocumentMergerTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Configuration;
 using Moq;
 using Scv.Api.Documents;
 using Scv.Api.Models.Document;
@@ -21,7 +22,8 @@ public class DocumentMergerTest : ServiceTestBase
     {
         var retrieverMock = new Mock<IDocumentRetriever>();
         var loggerMock = new Mock<ILogger<DocumentMerger>>();
-        var merger = new DocumentMerger(retrieverMock.Object, loggerMock.Object);
+        var configuration = new ConfigurationBuilder().Build();
+        var merger = new DocumentMerger(retrieverMock.Object, loggerMock.Object, configuration);
 
         var activeRequests = 0;
         var maxConcurrentRequests = 0;
@@ -62,7 +64,8 @@ public class DocumentMergerTest : ServiceTestBase
     {
         var retrieverMock = new Mock<IDocumentRetriever>();
         var loggerMock = new Mock<ILogger<DocumentMerger>>();
-        var merger = new DocumentMerger(retrieverMock.Object, loggerMock.Object);
+        var configuration = new ConfigurationBuilder().Build();
+        var merger = new DocumentMerger(retrieverMock.Object, loggerMock.Object, configuration);
         var docId = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("doc1"));
         var request = new PdfDocumentRequest
         {

--- a/tests/api/Documents/DocumentMergerTests.cs
+++ b/tests/api/Documents/DocumentMergerTests.cs
@@ -1,5 +1,8 @@
 using System;
+using System.IO;
+using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
 using Moq;
@@ -13,6 +16,47 @@ namespace tests.api.Documents;
 
 public class DocumentMergerTest : ServiceTestBase
 {
+    [Fact]
+    public async Task MergeDocuments_RetrievesDocumentsInBatches()
+    {
+        var retrieverMock = new Mock<IDocumentRetriever>();
+        var loggerMock = new Mock<ILogger<DocumentMerger>>();
+        var merger = new DocumentMerger(retrieverMock.Object, loggerMock.Object);
+
+        var activeRequests = 0;
+        var maxConcurrentRequests = 0;
+
+        retrieverMock
+            .Setup(x => x.Retrieve(It.IsAny<PdfDocumentRequest>()))
+            .Returns(async () =>
+            {
+                var current = Interlocked.Increment(ref activeRequests);
+                UpdateMaxConcurrentRequests(ref maxConcurrentRequests, current);
+
+                await Task.Delay(20);
+
+                Interlocked.Decrement(ref activeRequests);
+                return (MemoryStream)null;
+            });
+
+        var requests = Enumerable.Range(1, 25)
+            .Select(index => new PdfDocumentRequest
+            {
+                Type = DocumentType.File,
+                Data = new PdfDocumentRequestDetails
+                {
+                    DocumentId = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes($"doc{index}")),
+                    FileId = $"file{index}",
+                    CorrelationId = $"corr{index}"
+                }
+            })
+            .ToArray();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => merger.MergeDocuments(requests));
+
+        Assert.True(maxConcurrentRequests <= 10, $"Expected at most 10 concurrent requests but saw {maxConcurrentRequests}.");
+    }
+
     [Fact]
     public async Task MergeDocuments_ThrowsInvalidOperationException_WhenStreamUnreadable()
     {
@@ -34,5 +78,18 @@ public class DocumentMergerTest : ServiceTestBase
         {
             await merger.MergeDocuments([request]);
         });
+    }
+
+    private static void UpdateMaxConcurrentRequests(ref int maxConcurrentRequests, int current)
+    {
+        int observedMax;
+
+        do
+        {
+            observedMax = maxConcurrentRequests;
+            if (current <= observedMax)
+                return;
+        }
+        while (Interlocked.CompareExchange(ref maxConcurrentRequests, current, observedMax) != observedMax);
     }
 }


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[769](https://jira.justice.gov.bc.ca/browse/JASPER-769)**----    

## ➕ Batch document retrieval requests before merging 🔁
Send out a max of 10 document retrieval requests at a time, this way we prevent overloading the downstream system.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran `./manage` script
- [x] Unit tested 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   