### PR TITLE
jasper-746 add secret-fed list of emails for aws notifications.

### DIFF
--- a/infrastructure/cloud/environments/dev/managed-notifications.tf
+++ b/infrastructure/cloud/environments/dev/managed-notifications.tf
@@ -1,40 +1,9 @@
-locals {
-  aws_health_managed_notification_configuration_arns = toset([
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
-  ])
-}
+module "managed_notifications" {
+  source = "../../modules/ManagedNotifications"
 
-provider "aws" {
-  alias  = "notifications_hub"
-  region = var.region
-}
-
-resource "aws_notifications_notification_hub" "aws_health" {
-  provider                = aws.notifications_hub
-  notification_hub_region = var.region
-}
-
-resource "aws_notificationscontacts_email_contact" "aws_health" {
-  provider      = aws.notifications_hub
-  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
-  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
-  email_address = each.value
-}
-
-resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
-  provider = aws.notifications_hub
-  for_each = {
-    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
-    "${pair[0]}::${pair[1]}" => {
-      managed_notification_arn = pair[0]
-      email_contact_key        = pair[1]
-    }
-  }
-
-  managed_notification_arn = each.value.managed_notification_arn
-  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
-
-  depends_on = [aws_notifications_notification_hub.aws_health]
+  account_id               = data.aws_caller_identity.current.account_id
+  environment              = var.environment
+  notification_hub_region  = var.region
+  email_addresses          = tolist(toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses)))
+  managed_notification_sub_categories = ["Security", "Operations", "Issue"]
 }

--- a/infrastructure/cloud/environments/dev/managed-notifications.tf
+++ b/infrastructure/cloud/environments/dev/managed-notifications.tf
@@ -1,0 +1,40 @@
+locals {
+  aws_health_managed_notification_configuration_arns = toset([
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
+  ])
+}
+
+provider "aws" {
+  alias  = "notifications_hub"
+  region = var.region
+}
+
+resource "aws_notifications_notification_hub" "aws_health" {
+  provider                = aws.notifications_hub
+  notification_hub_region = var.region
+}
+
+resource "aws_notificationscontacts_email_contact" "aws_health" {
+  provider      = aws.notifications_hub
+  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
+  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
+  email_address = each.value
+}
+
+resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
+  provider = aws.notifications_hub
+  for_each = {
+    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
+    "${pair[0]}::${pair[1]}" => {
+      managed_notification_arn = pair[0]
+      email_contact_key        = pair[1]
+    }
+  }
+
+  managed_notification_arn = each.value.managed_notification_arn
+  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
+
+  depends_on = [aws_notifications_notification_hub.aws_health]
+}

--- a/infrastructure/cloud/environments/dev/providers.tf
+++ b/infrastructure/cloud/environments/dev/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0.0"
+      version = ">= 6.38.0, < 7.0.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/dev/providers.tf
+++ b/infrastructure/cloud/environments/dev/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.38.0, < 7.0.0"
+      version = "~> 6.38.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/lz-dev/managed-notifications.tf
+++ b/infrastructure/cloud/environments/lz-dev/managed-notifications.tf
@@ -1,18 +1,3 @@
-moved {
-  from = aws_notifications_notification_hub.aws_health
-  to   = module.managed_notifications.aws_notifications_notification_hub.aws_health
-}
-
-moved {
-  from = aws_notificationscontacts_email_contact.aws_health
-  to   = module.managed_notifications.aws_notificationscontacts_email_contact.aws_health
-}
-
-moved {
-  from = aws_notifications_managed_notification_additional_channel_association.aws_health_email_contacts
-  to   = module.managed_notifications.aws_notifications_managed_notification_additional_channel_association.aws_health_email_contacts
-}
-
 module "managed_notifications" {
   source = "../../modules/ManagedNotifications"
 

--- a/infrastructure/cloud/environments/lz-dev/managed-notifications.tf
+++ b/infrastructure/cloud/environments/lz-dev/managed-notifications.tf
@@ -1,0 +1,40 @@
+locals {
+  aws_health_managed_notification_configuration_arns = toset([
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
+  ])
+}
+
+provider "aws" {
+  alias  = "notifications_hub"
+  region = var.region
+}
+
+resource "aws_notifications_notification_hub" "aws_health" {
+  provider                = aws.notifications_hub
+  notification_hub_region = var.region
+}
+
+resource "aws_notificationscontacts_email_contact" "aws_health" {
+  provider      = aws.notifications_hub
+  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
+  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
+  email_address = each.value
+}
+
+resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
+  provider = aws.notifications_hub
+  for_each = {
+    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
+    "${pair[0]}::${pair[1]}" => {
+      managed_notification_arn = pair[0]
+      email_contact_key        = pair[1]
+    }
+  }
+
+  managed_notification_arn = each.value.managed_notification_arn
+  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
+
+  depends_on = [aws_notifications_notification_hub.aws_health]
+}

--- a/infrastructure/cloud/environments/lz-dev/managed-notifications.tf
+++ b/infrastructure/cloud/environments/lz-dev/managed-notifications.tf
@@ -1,9 +1,28 @@
+moved {
+  from = aws_notifications_notification_hub.aws_health
+  to   = module.managed_notifications.aws_notifications_notification_hub.aws_health
+}
+
+moved {
+  from = aws_notificationscontacts_email_contact.aws_health
+  to   = module.managed_notifications.aws_notificationscontacts_email_contact.aws_health
+}
+
+moved {
+  from = aws_notifications_managed_notification_additional_channel_association.aws_health_email_contacts
+  to   = module.managed_notifications.aws_notifications_managed_notification_additional_channel_association.aws_health_email_contacts
+}
+
 module "managed_notifications" {
   source = "../../modules/ManagedNotifications"
 
-  account_id                         = data.aws_caller_identity.current.account_id
-  environment                        = var.environment
-  notification_hub_region            = var.region
-  email_addresses                    = tolist(toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses)))
+  providers = {
+    aws = aws.notifications_hub
+  }
+
+  account_id                          = data.aws_caller_identity.current.account_id
+  environment                         = var.environment
+  notification_hub_region             = var.region
+  email_addresses                     = tolist(toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses)))
   managed_notification_sub_categories = ["Security", "Operations", "Issue"]
 }

--- a/infrastructure/cloud/environments/lz-dev/managed-notifications.tf
+++ b/infrastructure/cloud/environments/lz-dev/managed-notifications.tf
@@ -1,40 +1,9 @@
-locals {
-  aws_health_managed_notification_configuration_arns = toset([
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
-  ])
-}
+module "managed_notifications" {
+  source = "../../modules/ManagedNotifications"
 
-provider "aws" {
-  alias  = "notifications_hub"
-  region = var.region
-}
-
-resource "aws_notifications_notification_hub" "aws_health" {
-  provider                = aws.notifications_hub
-  notification_hub_region = var.region
-}
-
-resource "aws_notificationscontacts_email_contact" "aws_health" {
-  provider      = aws.notifications_hub
-  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
-  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
-  email_address = each.value
-}
-
-resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
-  provider = aws.notifications_hub
-  for_each = {
-    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
-    "${pair[0]}::${pair[1]}" => {
-      managed_notification_arn = pair[0]
-      email_contact_key        = pair[1]
-    }
-  }
-
-  managed_notification_arn = each.value.managed_notification_arn
-  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
-
-  depends_on = [aws_notifications_notification_hub.aws_health]
+  account_id                         = data.aws_caller_identity.current.account_id
+  environment                        = var.environment
+  notification_hub_region            = var.region
+  email_addresses                    = tolist(toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses)))
+  managed_notification_sub_categories = ["Security", "Operations", "Issue"]
 }

--- a/infrastructure/cloud/environments/lz-dev/providers.tf
+++ b/infrastructure/cloud/environments/lz-dev/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0.0"
+      version = ">= 6.38.0, < 7.0.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/lz-dev/providers.tf
+++ b/infrastructure/cloud/environments/lz-dev/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.38.0, < 7.0.0"
+      version = "~> 6.38.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/lz-dev/providers.tf
+++ b/infrastructure/cloud/environments/lz-dev/providers.tf
@@ -19,5 +19,6 @@ terraform {
 }
 
 provider "aws" {
+  alias  = "notifications_hub"
   region = var.region
 }

--- a/infrastructure/cloud/environments/lz-prod/managed-notifications.tf
+++ b/infrastructure/cloud/environments/lz-prod/managed-notifications.tf
@@ -1,0 +1,40 @@
+locals {
+  aws_health_managed_notification_configuration_arns = toset([
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue",
+  ])
+}
+
+provider "aws" {
+  alias  = "notifications_hub"
+  region = var.region
+}
+
+resource "aws_notifications_notification_hub" "aws_health" {
+  provider                = aws.notifications_hub
+  notification_hub_region = var.region
+}
+
+resource "aws_notificationscontacts_email_contact" "aws_health" {
+  provider      = aws.notifications_hub
+  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
+  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
+  email_address = each.value
+}
+
+resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
+  provider = aws.notifications_hub
+  for_each = {
+    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
+    "${pair[0]}::${pair[1]}" => {
+      managed_notification_arn = pair[0]
+      email_contact_key        = pair[1]
+    }
+  }
+
+  managed_notification_arn = each.value.managed_notification_arn
+  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
+
+  depends_on = [aws_notifications_notification_hub.aws_health]
+}

--- a/infrastructure/cloud/environments/lz-prod/managed-notifications.tf
+++ b/infrastructure/cloud/environments/lz-prod/managed-notifications.tf
@@ -1,40 +1,9 @@
-locals {
-  aws_health_managed_notification_configuration_arns = toset([
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue",
-  ])
-}
+module "managed_notifications" {
+  source = "../../modules/ManagedNotifications"
 
-provider "aws" {
-  alias  = "notifications_hub"
-  region = var.region
-}
-
-resource "aws_notifications_notification_hub" "aws_health" {
-  provider                = aws.notifications_hub
-  notification_hub_region = var.region
-}
-
-resource "aws_notificationscontacts_email_contact" "aws_health" {
-  provider      = aws.notifications_hub
-  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
-  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
-  email_address = each.value
-}
-
-resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
-  provider = aws.notifications_hub
-  for_each = {
-    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
-    "${pair[0]}::${pair[1]}" => {
-      managed_notification_arn = pair[0]
-      email_contact_key        = pair[1]
-    }
-  }
-
-  managed_notification_arn = each.value.managed_notification_arn
-  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
-
-  depends_on = [aws_notifications_notification_hub.aws_health]
+  account_id                         = data.aws_caller_identity.current.account_id
+  environment                        = var.environment
+  notification_hub_region            = var.region
+  email_addresses                    = tolist(toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses)))
+  managed_notification_sub_categories = ["Security", "Operations", "Issue"]
 }

--- a/infrastructure/cloud/environments/lz-prod/providers.tf
+++ b/infrastructure/cloud/environments/lz-prod/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0.0"
+      version = ">= 6.38.0, < 7.0.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/lz-prod/providers.tf
+++ b/infrastructure/cloud/environments/lz-prod/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.38.0, < 7.0.0"
+      version = "~> 6.38.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/lz-test/managed-notifications.tf
+++ b/infrastructure/cloud/environments/lz-test/managed-notifications.tf
@@ -1,0 +1,40 @@
+locals {
+  aws_health_managed_notification_configuration_arns = toset([
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
+  ])
+}
+
+provider "aws" {
+  alias  = "notifications_hub"
+  region = var.region
+}
+
+resource "aws_notifications_notification_hub" "aws_health" {
+  provider                = aws.notifications_hub
+  notification_hub_region = var.region
+}
+
+resource "aws_notificationscontacts_email_contact" "aws_health" {
+  provider      = aws.notifications_hub
+  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
+  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
+  email_address = each.value
+}
+
+resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
+  provider = aws.notifications_hub
+  for_each = {
+    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
+    "${pair[0]}::${pair[1]}" => {
+      managed_notification_arn = pair[0]
+      email_contact_key        = pair[1]
+    }
+  }
+
+  managed_notification_arn = each.value.managed_notification_arn
+  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
+
+  depends_on = [aws_notifications_notification_hub.aws_health]
+}

--- a/infrastructure/cloud/environments/lz-test/managed-notifications.tf
+++ b/infrastructure/cloud/environments/lz-test/managed-notifications.tf
@@ -1,40 +1,9 @@
-locals {
-  aws_health_managed_notification_configuration_arns = toset([
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
-  ])
-}
+module "managed_notifications" {
+  source = "../../modules/ManagedNotifications"
 
-provider "aws" {
-  alias  = "notifications_hub"
-  region = var.region
-}
-
-resource "aws_notifications_notification_hub" "aws_health" {
-  provider                = aws.notifications_hub
-  notification_hub_region = var.region
-}
-
-resource "aws_notificationscontacts_email_contact" "aws_health" {
-  provider      = aws.notifications_hub
-  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
-  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
-  email_address = each.value
-}
-
-resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
-  provider = aws.notifications_hub
-  for_each = {
-    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
-    "${pair[0]}::${pair[1]}" => {
-      managed_notification_arn = pair[0]
-      email_contact_key        = pair[1]
-    }
-  }
-
-  managed_notification_arn = each.value.managed_notification_arn
-  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
-
-  depends_on = [aws_notifications_notification_hub.aws_health]
+  account_id                         = data.aws_caller_identity.current.account_id
+  environment                        = var.environment
+  notification_hub_region            = var.region
+  email_addresses                    = tolist(toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses)))
+  managed_notification_sub_categories = ["Security", "Operations", "Issue"]
 }

--- a/infrastructure/cloud/environments/lz-test/providers.tf
+++ b/infrastructure/cloud/environments/lz-test/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0.0"
+      version = ">= 6.38.0, < 7.0.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/lz-test/providers.tf
+++ b/infrastructure/cloud/environments/lz-test/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.38.0, < 7.0.0"
+      version = "~> 6.38.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/prod/managed-notifications.tf
+++ b/infrastructure/cloud/environments/prod/managed-notifications.tf
@@ -1,0 +1,40 @@
+locals {
+  aws_health_managed_notification_configuration_arns = toset([
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
+  ])
+}
+
+provider "aws" {
+  alias  = "notifications_hub"
+  region = var.region
+}
+
+resource "aws_notifications_notification_hub" "aws_health" {
+  provider                = aws.notifications_hub
+  notification_hub_region = var.region
+}
+
+resource "aws_notificationscontacts_email_contact" "aws_health" {
+  provider      = aws.notifications_hub
+  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
+  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
+  email_address = each.value
+}
+
+resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
+  provider = aws.notifications_hub
+  for_each = {
+    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
+    "${pair[0]}::${pair[1]}" => {
+      managed_notification_arn = pair[0]
+      email_contact_key        = pair[1]
+    }
+  }
+
+  managed_notification_arn = each.value.managed_notification_arn
+  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
+
+  depends_on = [aws_notifications_notification_hub.aws_health]
+}

--- a/infrastructure/cloud/environments/prod/managed-notifications.tf
+++ b/infrastructure/cloud/environments/prod/managed-notifications.tf
@@ -1,40 +1,9 @@
-locals {
-  aws_health_managed_notification_configuration_arns = toset([
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
-  ])
-}
+module "managed_notifications" {
+  source = "../../modules/ManagedNotifications"
 
-provider "aws" {
-  alias  = "notifications_hub"
-  region = var.region
-}
-
-resource "aws_notifications_notification_hub" "aws_health" {
-  provider                = aws.notifications_hub
-  notification_hub_region = var.region
-}
-
-resource "aws_notificationscontacts_email_contact" "aws_health" {
-  provider      = aws.notifications_hub
-  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
-  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
-  email_address = each.value
-}
-
-resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
-  provider = aws.notifications_hub
-  for_each = {
-    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
-    "${pair[0]}::${pair[1]}" => {
-      managed_notification_arn = pair[0]
-      email_contact_key        = pair[1]
-    }
-  }
-
-  managed_notification_arn = each.value.managed_notification_arn
-  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
-
-  depends_on = [aws_notifications_notification_hub.aws_health]
+  account_id                         = data.aws_caller_identity.current.account_id
+  environment                        = var.environment
+  notification_hub_region            = var.region
+  email_addresses                    = tolist(toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses)))
+  managed_notification_sub_categories = ["Security", "Operations", "Issue"]
 }

--- a/infrastructure/cloud/environments/prod/providers.tf
+++ b/infrastructure/cloud/environments/prod/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0.0"
+      version = ">= 6.38.0, < 7.0.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/prod/providers.tf
+++ b/infrastructure/cloud/environments/prod/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.38.0, < 7.0.0"
+      version = "~> 6.38.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/test/managed-notifications.tf
+++ b/infrastructure/cloud/environments/test/managed-notifications.tf
@@ -1,0 +1,40 @@
+locals {
+  aws_health_managed_notification_configuration_arns = toset([
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
+    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
+  ])
+}
+
+provider "aws" {
+  alias  = "notifications_hub"
+  region = var.region
+}
+
+resource "aws_notifications_notification_hub" "aws_health" {
+  provider                = aws.notifications_hub
+  notification_hub_region = var.region
+}
+
+resource "aws_notificationscontacts_email_contact" "aws_health" {
+  provider      = aws.notifications_hub
+  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
+  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
+  email_address = each.value
+}
+
+resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
+  provider = aws.notifications_hub
+  for_each = {
+    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
+    "${pair[0]}::${pair[1]}" => {
+      managed_notification_arn = pair[0]
+      email_contact_key        = pair[1]
+    }
+  }
+
+  managed_notification_arn = each.value.managed_notification_arn
+  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
+
+  depends_on = [aws_notifications_notification_hub.aws_health]
+}

--- a/infrastructure/cloud/environments/test/managed-notifications.tf
+++ b/infrastructure/cloud/environments/test/managed-notifications.tf
@@ -1,40 +1,9 @@
-locals {
-  aws_health_managed_notification_configuration_arns = toset([
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Security",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Operations",
-    "arn:aws:notifications::${data.aws_caller_identity.current.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/Issue"
-  ])
-}
+module "managed_notifications" {
+  source = "../../modules/ManagedNotifications"
 
-provider "aws" {
-  alias  = "notifications_hub"
-  region = var.region
-}
-
-resource "aws_notifications_notification_hub" "aws_health" {
-  provider                = aws.notifications_hub
-  notification_hub_region = var.region
-}
-
-resource "aws_notificationscontacts_email_contact" "aws_health" {
-  provider      = aws.notifications_hub
-  for_each      = toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses))
-  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
-  email_address = each.value
-}
-
-resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
-  provider = aws.notifications_hub
-  for_each = {
-    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
-    "${pair[0]}::${pair[1]}" => {
-      managed_notification_arn = pair[0]
-      email_contact_key        = pair[1]
-    }
-  }
-
-  managed_notification_arn = each.value.managed_notification_arn
-  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
-
-  depends_on = [aws_notifications_notification_hub.aws_health]
+  account_id                         = data.aws_caller_identity.current.account_id
+  environment                        = var.environment
+  notification_hub_region            = var.region
+  email_addresses                    = tolist(toset(nonsensitive(module.secrets_manager.managed_notifications_email_addresses)))
+  managed_notification_sub_categories = ["Security", "Operations", "Issue"]
 }

--- a/infrastructure/cloud/environments/test/providers.tf
+++ b/infrastructure/cloud/environments/test/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0.0"
+      version = ">= 6.38.0, < 7.0.0"
     }
 
     tls = {

--- a/infrastructure/cloud/environments/test/providers.tf
+++ b/infrastructure/cloud/environments/test/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.38.0, < 7.0.0"
+      version = "~> 6.38.0"
     }
 
     tls = {

--- a/infrastructure/cloud/modules/ManagedNotifications/main.tf
+++ b/infrastructure/cloud/modules/ManagedNotifications/main.tf
@@ -1,0 +1,31 @@
+locals {
+  aws_health_managed_notification_configuration_arns = toset([
+    for sub_category in var.managed_notification_sub_categories :
+    "arn:aws:notifications::${var.account_id}:managed-notification-configuration/category/AWS-Health/sub-category/${sub_category}"
+  ])
+}
+
+resource "aws_notifications_notification_hub" "aws_health" {
+  notification_hub_region = var.notification_hub_region
+}
+
+resource "aws_notificationscontacts_email_contact" "aws_health" {
+  for_each      = toset(var.email_addresses)
+  name          = "health-${var.environment}-${substr(sha1(each.value), 0, 12)}"
+  email_address = each.value
+}
+
+resource "aws_notifications_managed_notification_additional_channel_association" "aws_health_email_contacts" {
+  for_each = {
+    for pair in setproduct(local.aws_health_managed_notification_configuration_arns, keys(aws_notificationscontacts_email_contact.aws_health)) :
+    "${pair[0]}::${pair[1]}" => {
+      managed_notification_arn = pair[0]
+      email_contact_key        = pair[1]
+    }
+  }
+
+  managed_notification_arn = each.value.managed_notification_arn
+  channel_arn              = aws_notificationscontacts_email_contact.aws_health[each.value.email_contact_key].arn
+
+  depends_on = [aws_notifications_notification_hub.aws_health]
+}

--- a/infrastructure/cloud/modules/ManagedNotifications/variables.tf
+++ b/infrastructure/cloud/modules/ManagedNotifications/variables.tf
@@ -1,0 +1,20 @@
+variable "account_id" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "notification_hub_region" {
+  type = string
+}
+
+variable "email_addresses" {
+  type = list(string)
+}
+
+variable "managed_notification_sub_categories" {
+  type    = list(string)
+  default = ["Security", "Operations", "Issue"]
+}

--- a/infrastructure/cloud/modules/SecretsManager/main.tf
+++ b/infrastructure/cloud/modules/SecretsManager/main.tf
@@ -239,7 +239,8 @@ resource "aws_secretsmanager_secret_version" "misc_secret_value" {
     keyDocsBinderRefreshHours       = "",
     lazyCacheDefaultDurationSeconds = "",
     supportAccount                  = "",
-    documentRetrievalBatchSize      = ""
+    documentRetrievalBatchSize      = "",
+    awsNotifEmails                  = []
   })
   lifecycle {
     ignore_changes = [secret_string]

--- a/infrastructure/cloud/modules/SecretsManager/output.tf
+++ b/infrastructure/cloud/modules/SecretsManager/output.tf
@@ -149,6 +149,16 @@ output "default_users" {
   value = jsonencode(jsondecode(data.aws_secretsmanager_secret_version.current_db_secret_value.secret_string)["defaultUsers"])
 }
 
+output "managed_notifications_email_addresses" {
+  value = try(
+    tolist(jsondecode(data.aws_secretsmanager_secret_version.current_misc_secret_value.secret_string).awsNotifEmails),
+    tolist(jsondecode(try(jsondecode(data.aws_secretsmanager_secret_version.current_misc_secret_value.secret_string).awsNotifEmails, "[]"))),
+    compact([try(tostring(jsondecode(data.aws_secretsmanager_secret_version.current_misc_secret_value.secret_string).awsNotifEmails), "")]),
+    []
+  )
+  sensitive = true
+}
+
 output "lambda_secrets" {
   value = {
     mtls                 = aws_secretsmanager_secret.mtls_cert_secret.name


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**746**----    

## Issue ticket number and link  
Jasper 746

## Description

Register key emails for AWS security, user, and health notifications to proactively be warned of outages and other major events.

Fixes # (issue)  

## Type of change

- [x] This change requires a documentation update    



## How Has This Been Tested?

- Validated publish infra job adds target emails to AWS health notification subscriptions pages.

**Test Configuration**:
If applicable

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Documentation References  

Put any doc references here