### PR TITLE
Ensure that failing DARS search requests also properly trigger the JA…

### DIFF
--- a/web/src/services/HttpService.ts
+++ b/web/src/services/HttpService.ts
@@ -77,6 +77,12 @@ export class HttpService implements IHttpService {
   private handleError(error: any) {
     console.error(error);
 
+    const status = error?.response?.status;
+
+    if (status === 401) {
+      redirectHandlerService.handleUnauthorized(globalThis.location.href);
+    }
+
     if (error.config?.skipErrorHandler) {
       // Component handles the error
       return Promise.reject(
@@ -85,13 +91,11 @@ export class HttpService implements IHttpService {
     }
 
     // todo: check for a 403 and handle it
-    if (error.response?.status === 401) {
-      redirectHandlerService.handleUnauthorized(globalThis.location.href);
-    } else if (error.response?.status === 409) {
+    if (status === 409) {
       globalThis.location.replace(
         `${import.meta.env.BASE_URL}api/auth/logout?redirectUri=/`
       );
-    } else if (error.response.status !== 403) {
+    } else if (status !== 403 && status !== 401) {
       // The user should be notified about unhandled server exceptions.
       this.snackBarStore.showSnackbar(
         'Something went wrong, please contact your Administrator.',


### PR DESCRIPTION
## Description

No ticket, but this fixes an issue where a judge making a DARS search after their JASPER token expires would see a 401 instead of jasper requesting they login again via the standard 401 handler.

Fixes # (issue)  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Tested that the judge is redirected appropriately when they perform a DARS search after their JASPER token has expired.

**Test Configuration**:
If applicable

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   