### PR TITLE
Update memory value that is valid for a 1024 CPU

### DIFF
--- a/infrastructure/cloud/environments/dev/dev.tfvars
+++ b/infrastructure/cloud/environments/dev/dev.tfvars
@@ -22,7 +22,7 @@ api_ecs_config = {
   min_capacity = 1
   max_capacity = 1
   cpu          = 1024
-  memory_size  = 2560 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
+  memory_size  = 3072 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
 }
 alarm_config = {
   cpu_threshold             = 70

--- a/infrastructure/cloud/environments/lz-dev/lz-dev.tfvars
+++ b/infrastructure/cloud/environments/lz-dev/lz-dev.tfvars
@@ -22,7 +22,7 @@ api_ecs_config = {
   min_capacity = 1
   max_capacity = 1
   cpu          = 1024
-  memory_size  = 2560 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
+  memory_size  = 3072 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
 }
 alarm_config = {
   cpu_threshold             = 70

--- a/infrastructure/cloud/environments/lz-prod/lz-prod.tfvars
+++ b/infrastructure/cloud/environments/lz-prod/lz-prod.tfvars
@@ -22,7 +22,7 @@ api_ecs_config = {
   min_capacity = 3
   max_capacity = 6
   cpu          = 1024
-  memory_size  = 2560 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
+  memory_size  = 3072 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
 }
 alarm_config = {
   cpu_threshold             = 70

--- a/infrastructure/cloud/environments/lz-test/lz-test.tfvars
+++ b/infrastructure/cloud/environments/lz-test/lz-test.tfvars
@@ -22,7 +22,7 @@ api_ecs_config = {
   min_capacity = 1
   max_capacity = 1
   cpu          = 1024
-  memory_size  = 2560 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
+  memory_size  = 3072 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
 }
 alarm_config = {
   cpu_threshold             = 70

--- a/infrastructure/cloud/environments/prod/prod.tfvars
+++ b/infrastructure/cloud/environments/prod/prod.tfvars
@@ -22,7 +22,7 @@ api_ecs_config = {
   min_capacity = 3
   max_capacity = 6
   cpu          = 1024
-  memory_size  = 2560 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
+  memory_size  = 3072 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
 }
 alarm_config = {
   cpu_threshold             = 70

--- a/infrastructure/cloud/environments/test/test.tfvars
+++ b/infrastructure/cloud/environments/test/test.tfvars
@@ -22,7 +22,7 @@ api_ecs_config = {
   min_capacity = 1
   max_capacity = 1
   cpu          = 1024
-  memory_size  = 2560 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
+  memory_size  = 3072 # Increased from 2048 to accommodate ClamAV sidecar (~512MB)
 }
 alarm_config = {
   cpu_threshold             = 70


### PR DESCRIPTION
Bump api ecs memory to reflect a valid value for a 1024 CPU.