### PR TITLE
JASPER 731: Display only unique civil documents

### DIFF
--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -270,9 +270,7 @@
     );
     return binderDocumentIds
       .map((id) => documentsMaps.get(id))
-      .filter(
-        (item): item is civilDocumentType => item !== undefined
-      );
+      .filter((item): item is civilDocumentType => item !== undefined);
   });
 
   const categoryCount = (category: string): number => {
@@ -281,8 +279,9 @@
     }
 
     if (category.toLowerCase() === CSR_CATEGORY_DESC.toLowerCase()) {
-      return uniqueDocuments.value.filter((doc) => doc.category === CSR_CATEGORY)
-        .length;
+      return uniqueDocuments.value.filter(
+        (doc) => doc.category === CSR_CATEGORY
+      ).length;
     }
 
     return uniqueDocuments.value.filter(

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -155,8 +155,21 @@
   const enableViewTogether = computed<boolean>(
     () => selectedItems.value.filter((d) => d.imageId).length > 1
   );
+  const uniqueDocuments = computed<civilDocumentType[]>(() => {
+    const seen = new Set<string>();
+
+    return props.documents.filter((document) => {
+      if (seen.has(document.civilDocumentId)) {
+        return false;
+      }
+
+      seen.add(document.civilDocumentId);
+      return true;
+    });
+  });
+
   const scheduledDocuments = computed(() =>
-    props.documents.filter((doc) => doc.nextAppearanceDt)
+    uniqueDocuments.value.filter((doc) => doc.nextAppearanceDt)
   );
   const selectedCategory = ref<string | undefined>(
     scheduledDocuments.value.length > 0 ? SCHEDULED_CATEGORY : undefined
@@ -210,7 +223,9 @@
     ).concat(
       [
         ...new Set(
-          props.documents.filter((d) => d.category).map((doc) => doc.category)
+          uniqueDocuments.value
+            .filter((d) => d.category)
+            .map((doc) => doc.category)
         ),
       ].map((category) => ({
         title: getCategoryDisplayTitle(category),
@@ -237,7 +252,7 @@
   };
 
   const filteredDocuments = computed(() =>
-    props.documents.filter(filterByCategory)
+    uniqueDocuments.value.filter(filterByCategory)
   );
 
   const binderDocuments = computed(() => {
@@ -251,26 +266,26 @@
     }
 
     const documentsMaps = new Map(
-      props.documents.map((d) => [d.civilDocumentId, d])
+      uniqueDocuments.value.map((d) => [d.civilDocumentId, d])
     );
     return binderDocumentIds
       .map((id) => documentsMaps.get(id))
       .filter(
-        (item): item is (typeof props.documents)[number] => item !== undefined
+        (item): item is civilDocumentType => item !== undefined
       );
   });
 
   const categoryCount = (category: string): number => {
     if (category.toLowerCase() === SCHEDULED_CATEGORY.toLowerCase()) {
-      return props.documents.filter((doc) => doc.nextAppearanceDt).length;
+      return uniqueDocuments.value.filter((doc) => doc.nextAppearanceDt).length;
     }
 
     if (category.toLowerCase() === CSR_CATEGORY_DESC.toLowerCase()) {
-      return props.documents.filter((doc) => doc.category === CSR_CATEGORY)
+      return uniqueDocuments.value.filter((doc) => doc.category === CSR_CATEGORY)
         .length;
     }
 
-    return props.documents.filter(
+    return uniqueDocuments.value.filter(
       (doc) => doc.category?.toLowerCase() === category.toLowerCase()
     ).length;
   };

--- a/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
+++ b/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
@@ -388,4 +388,75 @@ describe('CivilDocumentsView.vue', () => {
       expect(wrapper.vm.filteredDocuments[0].civilDocumentId).toBe('2');
     });
   });
+
+  describe('Unique documents', () => {
+    const duplicateDocuments = [
+      {
+        civilDocumentId: '1',
+        category: 'CSR',
+        documentTypeDescription: 'Civil Document 1 - Original',
+        filedDt: '2024-01-01',
+        filedBy: [{ roleTypeCode: 'Role1' }],
+        fileSeqNo: '1',
+        issue: [{ issueTypeDesc: 'Issue1' }],
+        documentSupport: [{ actCd: 'Act1' }],
+      },
+      {
+        civilDocumentId: '1',
+        category: 'CSR',
+        documentTypeDescription: 'Civil Document 1 - Duplicate',
+        filedDt: '2024-01-02',
+        filedBy: [{ roleTypeCode: 'Role1' }],
+        fileSeqNo: '99',
+        issue: [{ issueTypeDesc: 'Issue1' }],
+        documentSupport: [{ actCd: 'Act1' }],
+      },
+      {
+        civilDocumentId: '2',
+        category: 'ROP',
+        documentTypeDescription: 'Civil Document 2',
+        filedDt: '2024-02-01',
+        filedBy: [{ roleTypeCode: 'Role2' }],
+        fileSeqNo: '2',
+        issue: [{ issueTypeDesc: 'Issue2' }],
+        documentSupport: [{ actCd: 'Act2' }],
+      },
+    ];
+
+    beforeEach(async () => {
+      wrapper = shallowMount(CivilDocumentsView, {
+        props: {
+          documents: duplicateDocuments,
+          courtClassCd: 'F',
+          fileId: 'PF-123',
+        },
+        global: {
+          provide: {
+            binderService: mockBinderService,
+          },
+        },
+      });
+
+      await nextTick();
+    });
+
+    it('removes duplicate documents by civilDocumentId', () => {
+      expect(wrapper.vm.uniqueDocuments).toHaveLength(2);
+      expect(wrapper.vm.uniqueDocuments.map((d) => d.civilDocumentId)).toEqual([
+        '1',
+        '2',
+      ]);
+    });
+
+    it('uses deduplicated documents in filteredDocuments', () => {
+      expect(wrapper.vm.filteredDocuments).toHaveLength(2);
+      expect(
+        wrapper.vm.filteredDocuments.filter((d) => d.civilDocumentId === '1')
+      ).toHaveLength(1);
+    });
+
+    it('uses deduplicated documents for category counts', () => {
+      expect(wrapper.vm.categoryCount('CSR')).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[731](https://jira.justice.gov.bc.ca/browse/JASPER-731)**----    

## Description
Civil files were displaying duplicate documents from their appearances. Long term we are going to decide how to deal with this in the BE and remove the "real" appearance. We currently are awaiting the requirements on removing duplicate appearances. But since we can't define that right now we are applying a quick adjustment to hide them in the FE.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran `./manage` script
- [x] Unit tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   