### PR TITLE
jasper-625 allow multi-select of document categories with chips.

### DIFF
--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -33,10 +33,10 @@
     :openIndividualDocument
     :selectedItems
     :binderDocumentIds="currentBinder?.documents.map((d) => d.documentId) ?? []"
-    :selectedCategory="selectedCategory"
+    :hasActiveFilters="activeCategories.length > 0"
+    :isScheduledView="isScheduledOnlySelected"
     :sectionTitle="allDocumentsSectionTitle"
     :sortBy
-    :getCategoryDisplayTitle="getCategoryDisplayTitle"
     @update:selectedItems="(val) => (selectedItems = val)"
   />
 
@@ -113,11 +113,19 @@
   } from '@/types/shared';
   import { getCourtClassStyle, getRoles } from '@/utils/utils';
   import {
+    DEFAULT_OTHER_LABEL,
+    getActiveSelections,
+    getSectionTitle,
+    getUncategorizedCount,
+    isAllOptionsSelected,
+    matchesCategorySelection,
+  } from '../common/categoryFilterUtils';
+  import {
     mdiFileDocumentMultipleOutline,
     mdiNotebookOutline,
     mdiNotebookRemoveOutline,
   } from '@mdi/js';
-  import { computed, inject, onMounted, ref } from 'vue';
+  import { computed, inject, onMounted, ref, watch } from 'vue';
   import ChipMultiSelect from '../common/ChipMultiSelect.vue';
   import AllDocuments from './documents/AllDocuments.vue';
   import JudicialBinder from './documents/JudicialBinder.vue';
@@ -140,7 +148,7 @@
   const CSR_CATEGORY_DESC = 'Court Summary';
   const AFF_FIN_STMT = 'Affidavits/Financial Stmts';
   const LITIGANT = 'Litigant';
-  const OTHER_CATEGORY = 'Other';
+  const OTHER_CATEGORY = DEFAULT_OTHER_LABEL;
 
   const selectedItems = ref<civilDocumentType[]>([]);
   const selectedBinderItems = ref<civilDocumentType[]>([]);
@@ -177,31 +185,23 @@
       ? selectedCategories.value[0]
       : undefined;
   });
-  const isAllSelected = computed<boolean>(() => {
-    return (
-      documentCategories.value.length > 0 &&
-      selectedCategories.value.length === documentCategories.value.length
-    );
-  });
+  const isAllSelected = computed<boolean>(() =>
+    isAllOptionsSelected(
+      selectedCategories.value,
+      documentCategories.value.length
+    )
+  );
   const activeCategories = computed<string[]>(() =>
-    isAllSelected.value ? [] : selectedCategories.value
+    getActiveSelections(selectedCategories.value, isAllSelected.value)
   );
   const isScheduledOnlySelected = computed<boolean>(
     () =>
       activeCategories.value.length === 1 &&
       activeCategories.value[0] === SCHEDULED_CATEGORY
   );
-  const allDocumentsSectionTitle = computed<string>(() => {
-    if (activeCategories.value.length === 0) {
-      return 'All Documents';
-    }
-
-    if (activeCategories.value.length === 1) {
-      return getCategoryDisplayTitle(activeCategories.value[0]);
-    }
-
-    return 'Selected Categories';
-  });
+  const allDocumentsSectionTitle = computed<string>(() =>
+    getSectionTitle(activeCategories.value, getCategoryDisplayTitle)
+  );
   const sortBy = computed<[{ key: string; order: 'desc' | 'asc' }]>(() => {
     return selectedCategory?.value === CSR_CATEGORY
       ? [{ key: 'filedDt', order: 'desc' as const }]
@@ -240,85 +240,7 @@
   };
 
   const getUncategorizedDocumentCount = (): number =>
-    uniqueDocuments.value.filter((doc) => !doc.category?.trim()).length;
-
-  const documentCategories = computed<
-    { title: string; value: string; count: number }[]
-  >(() =>
-    (scheduledDocuments.value.length > 0
-      ? [
-          {
-            title: SCHEDULED_CATEGORY,
-            value: SCHEDULED_CATEGORY,
-            count: categoryCount(SCHEDULED_CATEGORY),
-          },
-        ]
-      : []
-    ).concat(
-      [
-        ...new Set(
-          uniqueDocuments.value
-            .filter((d) => d.category)
-            .map((doc) => doc.category)
-        ),
-      ]
-        .map((category) => ({
-          title: getCategoryDisplayTitle(category),
-          value: category,
-          count: categoryCount(category),
-        }))
-        .concat([
-          {
-            title: OTHER_CATEGORY,
-            value: OTHER_CATEGORY,
-            count: getUncategorizedDocumentCount(),
-          },
-        ])
-    )
-  );
-
-  const filterByCategory = (item: civilDocumentType) => {
-    if (activeCategories.value.length === 0) {
-      return true;
-    }
-
-    const normalizedItemCategory = item.category?.trim().toLowerCase();
-    return activeCategories.value.some((category) => {
-      const normalizedCategory = category.toLowerCase();
-
-      if (normalizedCategory === SCHEDULED_CATEGORY.toLowerCase()) {
-        return !!item.nextAppearanceDt;
-      }
-
-      if (normalizedCategory === OTHER_CATEGORY.toLowerCase()) {
-        return !normalizedItemCategory;
-      }
-
-      return normalizedItemCategory === normalizedCategory;
-    });
-  };
-
-  const filteredDocuments = computed(() =>
-    uniqueDocuments.value.filter(filterByCategory)
-  );
-
-  const binderDocuments = computed(() => {
-    const binderDocumentIds = currentBinder.value?.documents
-      .slice()
-      .sort((d) => d.order)
-      .map((d) => d.documentId);
-
-    if (!binderDocumentIds || binderDocumentIds.length === 0) {
-      return [];
-    }
-
-    const documentsMaps = new Map(
-      uniqueDocuments.value.map((d) => [d.civilDocumentId, d])
-    );
-    return binderDocumentIds
-      .map((id) => documentsMaps.get(id))
-      .filter((item): item is civilDocumentType => item !== undefined);
-  });
+    getUncategorizedCount(uniqueDocuments.value, (doc) => doc.category);
 
   const categoryCount = (category: string): number => {
     if (category.toLowerCase() === SCHEDULED_CATEGORY.toLowerCase()) {
@@ -343,6 +265,99 @@
       (doc) => doc.category?.trim().toLowerCase() === category.toLowerCase()
     ).length;
   };
+
+  const documentCategories = computed<
+    { title: string; value: string; count: number }[]
+  >(() => {
+    const uncategorizedDocumentCount = getUncategorizedDocumentCount();
+
+    return (
+      scheduledDocuments.value.length > 0
+        ? [
+            {
+              title: SCHEDULED_CATEGORY,
+              value: SCHEDULED_CATEGORY,
+              count: categoryCount(SCHEDULED_CATEGORY),
+            },
+          ]
+        : []
+    ).concat(
+      [
+        ...new Set(
+          uniqueDocuments.value
+            .filter((d) => d.category)
+            .map((doc) => doc.category)
+        ),
+      ]
+        .map((category) => ({
+          title: getCategoryDisplayTitle(category),
+          value: category,
+          count: categoryCount(category),
+        }))
+        .concat(
+          uncategorizedDocumentCount > 0
+            ? [
+                {
+                  title: OTHER_CATEGORY,
+                  value: OTHER_CATEGORY,
+                  count: uncategorizedDocumentCount,
+                },
+              ]
+            : []
+        )
+    );
+  });
+
+  watch(
+    documentCategories,
+    (categories) => {
+      const validValues = new Set(categories.map((category) => category.value));
+      const filteredSelections = selectedCategories.value.filter((value) =>
+        validValues.has(value)
+      );
+
+      if (filteredSelections.length !== selectedCategories.value.length) {
+        selectedCategories.value = filteredSelections;
+      }
+    },
+    { immediate: true }
+  );
+
+  const filterByCategory = (item: civilDocumentType) => {
+    return matchesCategorySelection(
+      item,
+      activeCategories.value,
+      (doc) => doc.category,
+      {
+        otherLabel: OTHER_CATEGORY,
+        specialPredicates: {
+          [SCHEDULED_CATEGORY.toLowerCase()]: (doc) => !!doc.nextAppearanceDt,
+        },
+      }
+    );
+  };
+
+  const filteredDocuments = computed(() =>
+    uniqueDocuments.value.filter(filterByCategory)
+  );
+
+  const binderDocuments = computed(() => {
+    const binderDocumentIds = currentBinder.value?.documents
+      .slice()
+      .sort((d) => d.order)
+      .map((d) => d.documentId);
+
+    if (!binderDocumentIds || binderDocumentIds.length === 0) {
+      return [];
+    }
+
+    const documentsMaps = new Map(
+      uniqueDocuments.value.map((d) => [d.civilDocumentId, d])
+    );
+    return binderDocumentIds
+      .map((id) => documentsMaps.get(id))
+      .filter((item): item is civilDocumentType => item !== undefined);
+  });
 
   onMounted(async () => {
     try {

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -19,7 +19,7 @@
       <ChipMultiSelect
         v-model="selectedCategories"
         :items="documentCategories"
-        :select-all-count="props.documents.length"
+        :select-all-count="uniqueDocuments.length"
       />
     </v-col>
   </v-row>

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -16,21 +16,11 @@
   <v-row>
     <v-col cols="6" />
     <v-col cols="3" class="ml-auto" v-if="documentCategories.length > 1">
-      <v-select
-        v-model="selectedCategory"
-        placeholder="All documents"
-        hide-details
+      <ChipMultiSelect
+        v-model="selectedCategories"
         :items="documentCategories"
-        item-title="title"
-        item-value="value"
-      >
-        <template v-slot:item="{ props: itemProps, item }">
-          <v-list-item
-            v-bind="itemProps"
-            :title="`${item.title} (${categoryCount(item.raw.value)})`"
-          ></v-list-item>
-        </template>
-      </v-select>
+        :select-all-count="props.documents.length"
+      />
     </v-col>
   </v-row>
   <AllDocuments
@@ -44,6 +34,7 @@
     :selectedItems
     :binderDocumentIds="currentBinder?.documents.map((d) => d.documentId) ?? []"
     :selectedCategory="selectedCategory"
+    :sectionTitle="allDocumentsSectionTitle"
     :sortBy
     :getCategoryDisplayTitle="getCategoryDisplayTitle"
     @update:selectedItems="(val) => (selectedItems = val)"
@@ -127,6 +118,7 @@
     mdiNotebookRemoveOutline,
   } from '@mdi/js';
   import { computed, inject, onMounted, ref } from 'vue';
+  import ChipMultiSelect from '../common/ChipMultiSelect.vue';
   import AllDocuments from './documents/AllDocuments.vue';
   import JudicialBinder from './documents/JudicialBinder.vue';
 
@@ -148,6 +140,7 @@
   const CSR_CATEGORY_DESC = 'Court Summary';
   const AFF_FIN_STMT = 'Affidavits/Financial Stmts';
   const LITIGANT = 'Litigant';
+  const OTHER_CATEGORY = 'Other';
 
   const selectedItems = ref<civilDocumentType[]>([]);
   const selectedBinderItems = ref<civilDocumentType[]>([]);
@@ -171,14 +164,44 @@
   const scheduledDocuments = computed(() =>
     uniqueDocuments.value.filter((doc) => doc.nextAppearanceDt)
   );
-  const selectedCategory = ref<string | undefined>(
-    scheduledDocuments.value.length > 0 ? SCHEDULED_CATEGORY : undefined
+  const selectedCategories = ref<string[]>(
+    scheduledDocuments.value.length > 0 ? [SCHEDULED_CATEGORY] : []
   );
   const isBinderLoading = ref(true);
   const rolesLoading = ref(false);
   const roles = ref<LookupCode[]>();
   const currentBinder = ref<Binder>();
   const courtClassCdStyle = getCourtClassStyle(props.courtClassCd);
+  const selectedCategory = computed<string | undefined>(() => {
+    return selectedCategories.value.length === 1
+      ? selectedCategories.value[0]
+      : undefined;
+  });
+  const isAllSelected = computed<boolean>(() => {
+    return (
+      documentCategories.value.length > 0 &&
+      selectedCategories.value.length === documentCategories.value.length
+    );
+  });
+  const activeCategories = computed<string[]>(() =>
+    isAllSelected.value ? [] : selectedCategories.value
+  );
+  const isScheduledOnlySelected = computed<boolean>(
+    () =>
+      activeCategories.value.length === 1 &&
+      activeCategories.value[0] === SCHEDULED_CATEGORY
+  );
+  const allDocumentsSectionTitle = computed<string>(() => {
+    if (activeCategories.value.length === 0) {
+      return 'All Documents';
+    }
+
+    if (activeCategories.value.length === 1) {
+      return getCategoryDisplayTitle(activeCategories.value[0]);
+    }
+
+    return 'Selected Categories';
+  });
   const sortBy = computed<[{ key: string; order: 'desc' | 'asc' }]>(() => {
     return selectedCategory?.value === CSR_CATEGORY
       ? [{ key: 'filedDt', order: 'desc' as const }]
@@ -187,7 +210,7 @@
 
   const headers = computed<DataTableHeader[]>(() => {
     const baseHeaders = shared.getBaseCivilDocumentTableHeaders(
-      selectedCategory.value === SCHEDULED_CATEGORY
+      isScheduledOnlySelected.value
     );
 
     return [
@@ -216,9 +239,20 @@
     return categoryMap[category] || category;
   };
 
-  const documentCategories = computed<{ title: string; value: string }[]>(() =>
+  const getUncategorizedDocumentCount = (): number =>
+    uniqueDocuments.value.filter((doc) => !doc.category?.trim()).length;
+
+  const documentCategories = computed<
+    { title: string; value: string; count: number }[]
+  >(() =>
     (scheduledDocuments.value.length > 0
-      ? [{ title: SCHEDULED_CATEGORY, value: SCHEDULED_CATEGORY }]
+      ? [
+          {
+            title: SCHEDULED_CATEGORY,
+            value: SCHEDULED_CATEGORY,
+            count: categoryCount(SCHEDULED_CATEGORY),
+          },
+        ]
       : []
     ).concat(
       [
@@ -227,28 +261,41 @@
             .filter((d) => d.category)
             .map((doc) => doc.category)
         ),
-      ].map((category) => ({
-        title: getCategoryDisplayTitle(category),
-        value: category,
-      }))
+      ]
+        .map((category) => ({
+          title: getCategoryDisplayTitle(category),
+          value: category,
+          count: categoryCount(category),
+        }))
+        .concat([
+          {
+            title: OTHER_CATEGORY,
+            value: OTHER_CATEGORY,
+            count: getUncategorizedDocumentCount(),
+          },
+        ])
     )
   );
 
   const filterByCategory = (item: civilDocumentType) => {
-    const category = selectedCategory.value?.toLowerCase();
-    if (!category) {
+    if (activeCategories.value.length === 0) {
       return true;
     }
 
-    if (category === SCHEDULED_CATEGORY.toLowerCase()) {
-      return !!item.nextAppearanceDt;
-    }
+    const normalizedItemCategory = item.category?.trim().toLowerCase();
+    return activeCategories.value.some((category) => {
+      const normalizedCategory = category.toLowerCase();
 
-    if (category === CSR_CATEGORY_DESC.toLowerCase()) {
-      return item.category === CSR_CATEGORY;
-    }
+      if (normalizedCategory === SCHEDULED_CATEGORY.toLowerCase()) {
+        return !!item.nextAppearanceDt;
+      }
 
-    return item.category?.toLowerCase() === category;
+      if (normalizedCategory === OTHER_CATEGORY.toLowerCase()) {
+        return !normalizedItemCategory;
+      }
+
+      return normalizedItemCategory === normalizedCategory;
+    });
   };
 
   const filteredDocuments = computed(() =>
@@ -278,14 +325,22 @@
       return uniqueDocuments.value.filter((doc) => doc.nextAppearanceDt).length;
     }
 
-    if (category.toLowerCase() === CSR_CATEGORY_DESC.toLowerCase()) {
+    if (
+      category.toLowerCase() === CSR_CATEGORY_DESC.toLowerCase() ||
+      category.toLowerCase() === CSR_CATEGORY.toLowerCase()
+    ) {
       return uniqueDocuments.value.filter(
-        (doc) => doc.category === CSR_CATEGORY
+        (doc) =>
+          doc.category?.trim().toLowerCase() === CSR_CATEGORY.toLowerCase()
       ).length;
     }
 
+    if (category.toLowerCase() === OTHER_CATEGORY.toLowerCase()) {
+      return getUncategorizedDocumentCount();
+    }
+
     return uniqueDocuments.value.filter(
-      (doc) => doc.category?.toLowerCase() === category.toLowerCase()
+      (doc) => doc.category?.trim().toLowerCase() === category.toLowerCase()
     ).length;
   };
 

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -115,11 +115,12 @@
   import {
     DEFAULT_OTHER_LABEL,
     getActiveSelections,
+    pruneInvalidSelections,
     getSectionTitle,
     getUncategorizedCount,
     isAllOptionsSelected,
     matchesCategorySelection,
-  } from '../common/categoryFilterUtils';
+  } from '@/utils/categoryFilterUtils';
   import {
     mdiFileDocumentMultipleOutline,
     mdiNotebookOutline,
@@ -311,9 +312,9 @@
   watch(
     documentCategories,
     (categories) => {
-      const validValues = new Set(categories.map((category) => category.value));
-      const filteredSelections = selectedCategories.value.filter((value) =>
-        validValues.has(value)
+      const filteredSelections = pruneInvalidSelections(
+        selectedCategories.value,
+        categories.map((category) => category.value)
       );
 
       if (filteredSelections.length !== selectedCategories.value.length) {

--- a/web/src/components/case-details/civil/documents/AllDocuments.vue
+++ b/web/src/components/case-details/civil/documents/AllDocuments.vue
@@ -4,18 +4,12 @@
     color="var(--bg-gray-500)"
     elevation="0"
     data-testid="all-documents-container"
-    v-if="documents?.length > 0 || props.selectedCategory"
+    v-if="documents?.length > 0 || props.hasActiveFilters"
   >
     <v-card-text>
       <v-row align="center" no-gutters>
         <v-col class="text-h5" cols="6">
-          {{
-            props.sectionTitle
-              ? props.sectionTitle
-              : props.selectedCategory && props.getCategoryDisplayTitle
-                ? props.getCategoryDisplayTitle(props.selectedCategory)
-                : 'All Documents'
-          }}
+          {{ props.sectionTitle || 'All Documents' }}
           ({{ documents.length }})
         </v-col>
       </v-row>
@@ -55,10 +49,7 @@
       <span v-else>
         {{ item.documentTypeDescription }}
       </span>
-      <span
-        v-if="selectedCategory === 'Scheduled' && item.filedDt"
-        class="text-caption"
-      >
+      <span v-if="isScheduledView && item.filedDt" class="text-caption">
         <br />
         Date Filed: {{ formatDateToDDMMMYYYY(item.filedDt) }}
       </span>
@@ -106,10 +97,10 @@
     baseHeaders: DataTableHeader[];
     binderDocumentIds: string[];
     addDocumentToBinder: (document: civilDocumentType) => void;
-    selectedCategory?: string;
+    hasActiveFilters?: boolean;
+    isScheduledView?: boolean;
     sectionTitle?: string;
     sortBy?: [{ key: string; order: 'asc' | 'desc' }];
-    getCategoryDisplayTitle?: (category: string) => string;
     openIndividualDocument: (data: civilDocumentType) => void;
   }>();
   const emit =

--- a/web/src/components/case-details/civil/documents/AllDocuments.vue
+++ b/web/src/components/case-details/civil/documents/AllDocuments.vue
@@ -4,15 +4,17 @@
     color="var(--bg-gray-500)"
     elevation="0"
     data-testid="all-documents-container"
-    v-if="documents?.length > 0"
+    v-if="documents?.length > 0 || props.selectedCategory"
   >
     <v-card-text>
       <v-row align="center" no-gutters>
         <v-col class="text-h5" cols="6">
           {{
-            props.selectedCategory && props.getCategoryDisplayTitle
-              ? props.getCategoryDisplayTitle(props.selectedCategory)
-              : 'All Documents'
+            props.sectionTitle
+              ? props.sectionTitle
+              : props.selectedCategory && props.getCategoryDisplayTitle
+                ? props.getCategoryDisplayTitle(props.selectedCategory)
+                : 'All Documents'
           }}
           ({{ documents.length }})
         </v-col>
@@ -105,6 +107,7 @@
     binderDocumentIds: string[];
     addDocumentToBinder: (document: civilDocumentType) => void;
     selectedCategory?: string;
+    sectionTitle?: string;
     sortBy?: [{ key: string; order: 'asc' | 'desc' }];
     getCategoryDisplayTitle?: (category: string) => string;
     openIndividualDocument: (data: civilDocumentType) => void;

--- a/web/src/components/case-details/common/ChipMultiSelect.vue
+++ b/web/src/components/case-details/common/ChipMultiSelect.vue
@@ -1,0 +1,152 @@
+<template>
+  <v-select
+    :model-value="modelValue"
+    @update:model-value="onUpdate"
+    multiple
+    chips
+    closable-chips
+    density="compact"
+    :placeholder="placeholder"
+    hide-details
+    :items="items"
+    item-title="title"
+    item-value="value"
+  >
+    <template #prepend-item>
+      <v-list-item
+        class="py-0"
+        density="compact"
+        :title="getSelectAllTitle()"
+        @click="toggleSelectAll"
+      >
+        <template #prepend>
+          <v-checkbox-btn
+            :model-value="isAllSelected"
+            hide-details
+            @click.stop="toggleSelectAll"
+          />
+        </template>
+      </v-list-item>
+      <hr class="select-divider" />
+    </template>
+    <template #item="{ props: itemProps, item }">
+      <v-list-item
+        v-bind="itemProps"
+        density="compact"
+        :title="getItemTitle(item.raw)"
+      >
+        <template #prepend>
+          <v-checkbox-btn
+            :model-value="isSelected(item.raw.value)"
+            hide-details
+            @click.stop="toggleValue(item.raw.value)"
+          />
+        </template>
+      </v-list-item>
+    </template>
+    <template #chip="{ props: chipProps, item }">
+      <v-chip
+        v-bind="chipProps"
+        closable
+        size="small"
+        @click:close.stop="removeValue(item.raw.value)"
+      >
+        {{ item.raw.title }}
+      </v-chip>
+    </template>
+  </v-select>
+</template>
+
+<script setup lang="ts">
+  import { computed } from 'vue';
+
+  type SelectOption = {
+    title: string;
+    value: string;
+    count?: number;
+  };
+
+  const props = withDefaults(
+    defineProps<{
+      modelValue: string[];
+      items: SelectOption[];
+      selectAllCount?: number;
+      selectAllLabel?: string;
+      placeholder?: string;
+    }>(),
+    {
+      selectAllLabel: 'Select All',
+      placeholder: 'Select options',
+    }
+  );
+
+  const emit = defineEmits<{
+    (e: 'update:modelValue', value: string[]): void;
+  }>();
+
+  const isAllSelected = computed<boolean>(() => {
+    return (
+      props.items.length > 0 && props.modelValue.length === props.items.length
+    );
+  });
+
+  const onUpdate = (value: string[]) => {
+    emit('update:modelValue', value ?? []);
+  };
+
+  const getSelectAllTitle = (): string => {
+    if (typeof props.selectAllCount === 'number') {
+      return `${props.selectAllLabel} (${props.selectAllCount})`;
+    }
+
+    return props.selectAllLabel;
+  };
+
+  const getItemTitle = (item: SelectOption): string => {
+    if (typeof item.count === 'number') {
+      return `${item.title} (${item.count})`;
+    }
+
+    return item.title;
+  };
+
+  const toggleSelectAll = () => {
+    if (isAllSelected.value) {
+      emit('update:modelValue', []);
+      return;
+    }
+
+    emit(
+      'update:modelValue',
+      props.items.map((item) => item.value)
+    );
+  };
+
+  const removeValue = (value: string) => {
+    emit(
+      'update:modelValue',
+      props.modelValue.filter((selected) => selected !== value)
+    );
+  };
+
+  const isSelected = (value: string): boolean => {
+    return props.modelValue.includes(value);
+  };
+
+  const toggleValue = (value: string) => {
+    if (isSelected(value)) {
+      removeValue(value);
+      return;
+    }
+
+    emit('update:modelValue', [...props.modelValue, value]);
+  };
+</script>
+
+<style scoped>
+  .select-divider {
+    border: 0;
+    border-top: 1px solid var(--border-gray-300);
+    margin: 4px 0;
+  }
+</style>

--- a/web/src/components/case-details/common/categoryFilterUtils.ts
+++ b/web/src/components/case-details/common/categoryFilterUtils.ts
@@ -1,0 +1,73 @@
+export const DEFAULT_OTHER_LABEL = 'Other';
+export const DEFAULT_SECTION_TITLE = 'All Documents';
+export const MULTI_SECTION_TITLE = 'Selected Categories';
+
+type CategoryValue = string | null | undefined;
+
+const normalizeCategory = (value: CategoryValue): string =>
+  (value ?? '').trim().toLowerCase();
+
+export const isAllOptionsSelected = (
+  selectedValues: string[],
+  totalOptions: number
+): boolean => totalOptions > 0 && selectedValues.length === totalOptions;
+
+export const getActiveSelections = (
+  selectedValues: string[],
+  allSelected: boolean
+): string[] => (allSelected ? [] : selectedValues);
+
+export const getSectionTitle = (
+  activeValues: string[],
+  mapDisplayTitle?: (value: string) => string
+): string => {
+  if (activeValues.length === 0) {
+    return DEFAULT_SECTION_TITLE;
+  }
+
+  if (activeValues.length === 1) {
+    return mapDisplayTitle ? mapDisplayTitle(activeValues[0]) : activeValues[0];
+  }
+
+  return MULTI_SECTION_TITLE;
+};
+
+export const getUncategorizedCount = <T>(
+  items: T[],
+  getCategory: (item: T) => CategoryValue
+): number =>
+  items.filter((item) => !normalizeCategory(getCategory(item))).length;
+
+export const matchesCategorySelection = <T>(
+  item: T,
+  activeValues: string[],
+  getCategory: (entry: T) => CategoryValue,
+  options?: {
+    otherLabel?: string;
+    specialPredicates?: Record<string, (entry: T) => boolean>;
+  }
+): boolean => {
+  if (activeValues.length === 0) {
+    return true;
+  }
+
+  const normalizedCategory = normalizeCategory(getCategory(item));
+  const normalizedOtherLabel = normalizeCategory(
+    options?.otherLabel ?? DEFAULT_OTHER_LABEL
+  );
+
+  return activeValues.some((value) => {
+    const normalizedValue = normalizeCategory(value);
+    const specialPredicate = options?.specialPredicates?.[normalizedValue];
+
+    if (specialPredicate) {
+      return specialPredicate(item);
+    }
+
+    if (normalizedValue === normalizedOtherLabel) {
+      return !normalizedCategory;
+    }
+
+    return normalizedCategory === normalizedValue;
+  });
+};

--- a/web/src/components/case-details/criminal/CriminalDocumentsView.vue
+++ b/web/src/components/case-details/criminal/CriminalDocumentsView.vue
@@ -15,19 +15,11 @@
     <v-row v-if="type === 'documents'">
       <v-col cols="6" />
       <v-col cols="3" class="ml-auto" v-if="documentCategories.length > 1">
-        <v-select
-          v-model="selectedCategory"
-          placeholder="All documents"
-          hide-details
+        <ChipMultiSelect
+          v-model="selectedCategories"
           :items="documentCategories"
-        >
-          <template v-slot:[`item`]="{ props: itemProps, item }">
-            <v-list-item
-              v-bind="itemProps"
-              :title="item.raw + ' (' + categoryCount(item.raw) + ')'"
-            ></v-list-item>
-          </template>
-        </v-select>
+          :select-all-count="unfilteredDocuments.length"
+        />
       </v-col>
     </v-row>
     <v-card
@@ -40,9 +32,7 @@
         <v-row align="center" no-gutters>
           <v-col class="text-h5" cols="6">
             {{
-              type === 'keyDocuments'
-                ? 'Key Documents'
-                : getCategoryDisplayTitle()
+              type === 'keyDocuments' ? 'Key Documents' : documentsSectionTitle
             }}
             ({{ documentList.length }})
           </v-col>
@@ -154,6 +144,7 @@
   import { formatFromFullname } from '@/utils/utils';
   import { mdiFileDocumentMultipleOutline } from '@mdi/js';
   import { computed, ref } from 'vue';
+  import ChipMultiSelect from '../common/ChipMultiSelect.vue';
 
   const props = defineProps<{ participants: criminalParticipantType[] }>();
 
@@ -163,12 +154,36 @@
   );
   const sortBy = ref([{ key: 'issueDate', order: 'desc' }] as const);
   const keyDocumentsSortBy = ref([{ key: 'category', order: 'asc' }] as const);
-  const selectedCategory = ref<string>();
+  const selectedCategories = ref<string[]>([]);
   const selectedAccused = ref<string>();
+  const OTHER_CATEGORY = 'Other';
 
-  const filterByCategory = (item: any) =>
-    !selectedCategory.value ||
-    item.category?.toLowerCase() === selectedCategory.value?.toLowerCase();
+  const isAllSelected = computed<boolean>(() => {
+    return (
+      documentCategories.value.length > 0 &&
+      selectedCategories.value.length === documentCategories.value.length
+    );
+  });
+
+  const activeCategories = computed<string[]>(() =>
+    isAllSelected.value ? [] : selectedCategories.value
+  );
+
+  const filterByCategory = (item: any) => {
+    if (activeCategories.value.length === 0) {
+      return true;
+    }
+
+    const normalizedItemCategory = item.category?.trim().toLowerCase();
+    return activeCategories.value.some((category) => {
+      if (category.toLowerCase() === OTHER_CATEGORY.toLowerCase()) {
+        return !normalizedItemCategory;
+      }
+
+      return normalizedItemCategory === category.toLowerCase();
+    });
+  };
+
   const filterByAccused = (item: any) =>
     !selectedAccused.value ||
     (item.fullName &&
@@ -218,22 +233,54 @@
     unfilteredKeyDocuments.value.filter(filterByAccused)
   );
 
+  const getUncategorizedDocumentCount = (): number =>
+    unfilteredDocuments.value.filter((doc) => !doc.category?.trim()).length;
+
   const categoryCount = (category: string): number => {
-    return unfilteredDocuments.value.filter((doc) => doc.category === category)
-      .length;
+    if (category.toLowerCase() === OTHER_CATEGORY.toLowerCase()) {
+      return getUncategorizedDocumentCount();
+    }
+
+    return unfilteredDocuments.value.filter(
+      (doc) => doc.category?.trim().toLowerCase() === category.toLowerCase()
+    ).length;
   };
 
-  const getCategoryDisplayTitle = (): string => {
-    return selectedCategory.value ? selectedCategory.value : 'All Documents';
-  };
+  const documentsSectionTitle = computed<string>(() => {
+    if (activeCategories.value.length === 0) {
+      return 'All Documents';
+    }
 
-  const documentCategories = computed<string[]>(() => [
-    ...new Set(
-      (unfilteredDocuments.value ?? [])
-        .filter((doc) => doc.category)
-        .map((doc) => doc.category)
-    ),
-  ]);
+    if (activeCategories.value.length === 1) {
+      return activeCategories.value[0];
+    }
+
+    return 'Selected Categories';
+  });
+
+  const documentCategories = computed<
+    { title: string; value: string; count: number }[]
+  >(() =>
+    [
+      ...new Set(
+        unfilteredDocuments.value
+          ?.filter((doc) => doc.category)
+          .map((doc) => doc.category) || []
+      ),
+    ]
+      .map((category) => ({
+        title: category,
+        value: category,
+        count: categoryCount(category),
+      }))
+      .concat([
+        {
+          title: OTHER_CATEGORY,
+          value: OTHER_CATEGORY,
+          count: getUncategorizedDocumentCount(),
+        },
+      ])
+  );
 
   const groupBy = ref([
     {

--- a/web/src/components/case-details/criminal/CriminalDocumentsView.vue
+++ b/web/src/components/case-details/criminal/CriminalDocumentsView.vue
@@ -143,15 +143,16 @@
   import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
   import { formatFromFullname } from '@/utils/utils';
   import { mdiFileDocumentMultipleOutline } from '@mdi/js';
-  import { computed, ref } from 'vue';
+  import { computed, ref, watch } from 'vue';
   import {
     DEFAULT_OTHER_LABEL,
     getActiveSelections,
+    pruneInvalidSelections,
     getSectionTitle,
     getUncategorizedCount,
     isAllOptionsSelected,
     matchesCategorySelection,
-  } from '../common/categoryFilterUtils';
+  } from '@/utils/categoryFilterUtils';
   import ChipMultiSelect from '../common/ChipMultiSelect.vue';
 
   const props = defineProps<{ participants: criminalParticipantType[] }>();
@@ -289,6 +290,21 @@
           : []
       );
   });
+
+  watch(
+    documentCategories,
+    (categories) => {
+      const filteredSelections = pruneInvalidSelections(
+        selectedCategories.value,
+        categories.map((category) => category.value)
+      );
+
+      if (filteredSelections.length !== selectedCategories.value.length) {
+        selectedCategories.value = filteredSelections;
+      }
+    },
+    { immediate: true }
+  );
 
   const groupBy = ref([
     {

--- a/web/src/components/case-details/criminal/CriminalDocumentsView.vue
+++ b/web/src/components/case-details/criminal/CriminalDocumentsView.vue
@@ -144,6 +144,14 @@
   import { formatFromFullname } from '@/utils/utils';
   import { mdiFileDocumentMultipleOutline } from '@mdi/js';
   import { computed, ref } from 'vue';
+  import {
+    DEFAULT_OTHER_LABEL,
+    getActiveSelections,
+    getSectionTitle,
+    getUncategorizedCount,
+    isAllOptionsSelected,
+    matchesCategorySelection,
+  } from '../common/categoryFilterUtils';
   import ChipMultiSelect from '../common/ChipMultiSelect.vue';
 
   const props = defineProps<{ participants: criminalParticipantType[] }>();
@@ -156,37 +164,39 @@
   const keyDocumentsSortBy = ref([{ key: 'category', order: 'asc' }] as const);
   const selectedCategories = ref<string[]>([]);
   const selectedAccused = ref<string>();
-  const OTHER_CATEGORY = 'Other';
-
-  const isAllSelected = computed<boolean>(() => {
-    return (
-      documentCategories.value.length > 0 &&
-      selectedCategories.value.length === documentCategories.value.length
-    );
-  });
-
-  const activeCategories = computed<string[]>(() =>
-    isAllSelected.value ? [] : selectedCategories.value
-  );
-
-  const filterByCategory = (item: any) => {
-    if (activeCategories.value.length === 0) {
-      return true;
-    }
-
-    const normalizedItemCategory = item.category?.trim().toLowerCase();
-    return activeCategories.value.some((category) => {
-      if (category.toLowerCase() === OTHER_CATEGORY.toLowerCase()) {
-        return !normalizedItemCategory;
-      }
-
-      return normalizedItemCategory === category.toLowerCase();
-    });
+  const OTHER_CATEGORY = DEFAULT_OTHER_LABEL;
+  type CriminalViewDocument = documentType & {
+    fullName?: string;
+    fullNameLastFirst?: string;
+    profSeqNo?: string | number;
+    id: string;
   };
 
-  const filterByAccused = (item: any) =>
+  const isAllSelected = computed<boolean>(() =>
+    isAllOptionsSelected(
+      selectedCategories.value,
+      documentCategories.value.length
+    )
+  );
+
+  const activeCategories = computed<string[]>(() =>
+    getActiveSelections(selectedCategories.value, isAllSelected.value)
+  );
+
+  const filterByCategory = (item: CriminalViewDocument) => {
+    return matchesCategorySelection(
+      item,
+      activeCategories.value,
+      (doc) => doc.category,
+      {
+        otherLabel: OTHER_CATEGORY,
+      }
+    );
+  };
+
+  const filterByAccused = (item: CriminalViewDocument) =>
     !selectedAccused.value ||
-    (item.fullName &&
+    (!!item.fullName &&
       formatFromFullname(item.fullName) === selectedAccused.value);
 
   const unfilteredDocuments = computed(
@@ -234,7 +244,7 @@
   );
 
   const getUncategorizedDocumentCount = (): number =>
-    unfilteredDocuments.value.filter((doc) => !doc.category?.trim()).length;
+    getUncategorizedCount(unfilteredDocuments.value, (doc) => doc.category);
 
   const categoryCount = (category: string): number => {
     if (category.toLowerCase() === OTHER_CATEGORY.toLowerCase()) {
@@ -246,22 +256,16 @@
     ).length;
   };
 
-  const documentsSectionTitle = computed<string>(() => {
-    if (activeCategories.value.length === 0) {
-      return 'All Documents';
-    }
-
-    if (activeCategories.value.length === 1) {
-      return activeCategories.value[0];
-    }
-
-    return 'Selected Categories';
-  });
+  const documentsSectionTitle = computed<string>(() =>
+    getSectionTitle(activeCategories.value)
+  );
 
   const documentCategories = computed<
     { title: string; value: string; count: number }[]
-  >(() =>
-    [
+  >(() => {
+    const uncategorizedDocumentCount = getUncategorizedDocumentCount();
+
+    return [
       ...new Set(
         unfilteredDocuments.value
           ?.filter((doc) => doc.category)
@@ -273,14 +277,18 @@
         value: category,
         count: categoryCount(category),
       }))
-      .concat([
-        {
-          title: OTHER_CATEGORY,
-          value: OTHER_CATEGORY,
-          count: getUncategorizedDocumentCount(),
-        },
-      ])
-  );
+      .concat(
+        uncategorizedDocumentCount > 0
+          ? [
+              {
+                title: OTHER_CATEGORY,
+                value: OTHER_CATEGORY,
+                count: uncategorizedDocumentCount,
+              },
+            ]
+          : []
+      );
+  });
 
   const groupBy = ref([
     {

--- a/web/src/utils/categoryFilterUtils.ts
+++ b/web/src/utils/categoryFilterUtils.ts
@@ -17,6 +17,14 @@ export const getActiveSelections = (
   allSelected: boolean
 ): string[] => (allSelected ? [] : selectedValues);
 
+export const pruneInvalidSelections = (
+  selectedValues: string[],
+  validValues: string[]
+): string[] => {
+  const validSet = new Set(validValues);
+  return selectedValues.filter((value) => validSet.has(value));
+};
+
 export const getSectionTitle = (
   activeValues: string[],
   mapDisplayTitle?: (value: string) => string

--- a/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
+++ b/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
@@ -463,5 +463,30 @@ describe('CivilDocumentsView.vue', () => {
     it('uses deduplicated documents for category counts', () => {
       expect(wrapper.vm.categoryCount('CSR')).toBe(1);
     });
+
+    it('removes stale selected categories that are no longer valid', async () => {
+      wrapper.vm.selectedCategories = ['Scheduled'];
+
+      await wrapper.setProps({
+        documents: [
+          {
+            civilDocumentId: '10',
+            category: 'CSR',
+            documentTypeDescription: 'Civil Document 10',
+            filedDt: '2024-04-01',
+            filedBy: [{ roleTypeCode: 'Role10' }],
+            fileSeqNo: '10',
+            issue: [{ issueTypeDesc: 'Issue10' }],
+            documentSupport: [{ actCd: 'Act10' }],
+            nextAppearanceDt: '',
+          },
+        ],
+      });
+
+      await nextTick();
+
+      expect(wrapper.vm.selectedCategories).toEqual([]);
+      expect(wrapper.vm.allDocumentsSectionTitle).toBe('All Documents');
+    });
   });
 });

--- a/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
+++ b/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
@@ -107,7 +107,9 @@ describe('CivilDocumentsView.vue', () => {
     (mockBinderService.getBinders as Mock).mockResolvedValue([]);
 
     expect(wrapper.exists()).toBe(true);
-    expect(wrapper.find('v-select').exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'ChipMultiSelect' }).exists()).toBe(
+      true
+    );
     expect(wrapper.findComponent({ name: 'JudicialBinder' }).exists()).toBe(
       true
     );
@@ -115,7 +117,7 @@ describe('CivilDocumentsView.vue', () => {
   });
 
   it('filters documents by selected type', async () => {
-    wrapper.vm.selectedCategory = 'CSR';
+    wrapper.vm.selectedCategories = ['CSR'];
 
     expect(wrapper.vm.filteredDocuments).toEqual([mockDocuments[0]]);
   });
@@ -167,6 +169,7 @@ describe('CivilDocumentsView.vue', () => {
     expect(wrapper.vm.documentCategories[0]).toEqual({
       title: 'Scheduled',
       value: 'Scheduled',
+      count: 2,
     });
   });
 
@@ -174,6 +177,7 @@ describe('CivilDocumentsView.vue', () => {
     expect(wrapper.vm.documentCategories[1]).toEqual({
       title: 'Court Summary',
       value: 'CSR',
+      count: 1,
     });
   });
 
@@ -181,6 +185,7 @@ describe('CivilDocumentsView.vue', () => {
     expect(wrapper.vm.documentCategories[4]).toEqual({
       title: 'Affidavits/Financial Stmts',
       value: 'Affidavits',
+      count: 1,
     });
   });
 
@@ -367,7 +372,7 @@ describe('CivilDocumentsView.vue', () => {
     });
 
     it('does not filter judicial binder documents by category', async () => {
-      wrapper.vm.selectedCategory = 'CSR';
+      wrapper.vm.selectedCategories = ['CSR'];
       await nextTick();
 
       expect(wrapper.vm.filteredDocuments).toHaveLength(1);
@@ -380,7 +385,7 @@ describe('CivilDocumentsView.vue', () => {
     });
 
     it('filters all documents table by category', async () => {
-      wrapper.vm.selectedCategory = 'ROP';
+      wrapper.vm.selectedCategories = ['ROP'];
       await nextTick();
 
       expect(wrapper.vm.filteredDocuments).toHaveLength(1);

--- a/web/tests/components/case-details/civil/documents/AllDocuments.test.ts
+++ b/web/tests/components/case-details/civil/documents/AllDocuments.test.ts
@@ -31,6 +31,22 @@ describe('AllDocuments.vue', () => {
     expect(mainEl.exists()).toBe(false);
   });
 
+  it('renders header when selectedCategory is set even if there are no documents', () => {
+    const wrapper = mount(AllDocuments, {
+      props: {
+        ...mockProps,
+        documents: [],
+        selectedCategory: 'Scheduled',
+      },
+    });
+
+    const mainEl = wrapper.find('[data-testid="all-documents-container"]');
+    const header = wrapper.find('.text-h5');
+
+    expect(mainEl.exists()).toBe(true);
+    expect(header.text()).toContain('All Documents (0)');
+  });
+
   it('renders All Documents', () => {
     const mockDocuments = [{} as civilDocumentType, {} as civilDocumentType];
     mockProps.documents = mockDocuments;
@@ -116,7 +132,7 @@ describe('AllDocuments.vue', () => {
       imageId: 'img-123',
       nextAppearanceDt: '2026-01-15',
     } as civilDocumentType;
-    
+
     mockProps.documents = [mockDocument];
     const wrapper = mount(AllDocuments, {
       props: {
@@ -125,7 +141,9 @@ describe('AllDocuments.vue', () => {
       },
     });
 
-    const documentCell = wrapper.find('[data-testid="all-documents-container"]');
+    const documentCell = wrapper.find(
+      '[data-testid="all-documents-container"]'
+    );
     expect(documentCell.exists()).toBe(true);
     // The scheduled date should be formatted and displayed
     const tableEl = wrapper.find('v-data-table-virtual');
@@ -139,7 +157,7 @@ describe('AllDocuments.vue', () => {
       imageId: 'img-123',
       nextAppearanceDt: '2026-01-15',
     } as civilDocumentType;
-    
+
     mockProps.documents = [mockDocument];
     const wrapper = mount(AllDocuments, {
       props: {
@@ -158,7 +176,7 @@ describe('AllDocuments.vue', () => {
       documentTypeDescription: 'Test Document',
       imageId: 'img-123',
     } as civilDocumentType;
-    
+
     mockProps.documents = [mockDocument];
     const wrapper = mount(AllDocuments, {
       props: {

--- a/web/tests/components/case-details/civil/documents/AllDocuments.test.ts
+++ b/web/tests/components/case-details/civil/documents/AllDocuments.test.ts
@@ -36,7 +36,7 @@ describe('AllDocuments.vue', () => {
       props: {
         ...mockProps,
         documents: [],
-        selectedCategory: 'Scheduled',
+        hasActiveFilters: true,
       },
     });
 
@@ -81,43 +81,26 @@ describe('AllDocuments.vue', () => {
     expect(tableEl.exists()).toBe(true);
   });
 
-  it('displays "All Documents" when no category is selected', () => {
+  it('displays sectionTitle when provided', () => {
     mockProps.documents = [{} as civilDocumentType];
     mockProps.binderDocumentIds = [];
     const wrapper = mount(AllDocuments, {
       props: {
         ...mockProps,
-        selectedCategory: undefined,
+        sectionTitle: 'Orders',
       },
     });
 
     const header = wrapper.find('.text-h5');
-    expect(header.text()).toContain('All Documents (1)');
-  });
-
-  it('displays category display title when category is selected', () => {
-    mockProps.documents = [{} as civilDocumentType];
-    const getCategoryDisplayTitle = vi.fn().mockReturnValue('Orders');
-    const wrapper = mount(AllDocuments, {
-      props: {
-        ...mockProps,
-        selectedCategory: 'ORDER',
-        getCategoryDisplayTitle,
-      },
-    });
-
-    const header = wrapper.find('.text-h5');
-    expect(getCategoryDisplayTitle).toHaveBeenCalledWith('ORDER');
     expect(header.text()).toContain('Orders (1)');
   });
 
-  it('displays "All Documents" when category is selected but getCategoryDisplayTitle is not provided', () => {
+  it('displays "All Documents" when sectionTitle is not provided', () => {
     mockProps.documents = [{} as civilDocumentType];
     const wrapper = mount(AllDocuments, {
       props: {
         ...mockProps,
-        selectedCategory: 'ORDER',
-        getCategoryDisplayTitle: undefined,
+        sectionTitle: undefined,
       },
     });
 
@@ -125,7 +108,7 @@ describe('AllDocuments.vue', () => {
     expect(header.text()).toContain('All Documents (1)');
   });
 
-  it('displays scheduled date when selectedCategory is "Scheduled" and nextAppearanceDt exists', () => {
+  it('displays scheduled date when isScheduledView is true and nextAppearanceDt exists', () => {
     const mockDocument = {
       civilDocumentId: '1',
       documentTypeDescription: 'Test Document',
@@ -137,7 +120,7 @@ describe('AllDocuments.vue', () => {
     const wrapper = mount(AllDocuments, {
       props: {
         ...mockProps,
-        selectedCategory: 'Scheduled',
+        isScheduledView: true,
       },
     });
 
@@ -150,7 +133,7 @@ describe('AllDocuments.vue', () => {
     expect(tableEl.exists()).toBe(true);
   });
 
-  it('does not display scheduled date when selectedCategory is not "Scheduled"', () => {
+  it('does not display scheduled date when isScheduledView is false', () => {
     const mockDocument = {
       civilDocumentId: '1',
       documentTypeDescription: 'Test Document',
@@ -162,7 +145,7 @@ describe('AllDocuments.vue', () => {
     const wrapper = mount(AllDocuments, {
       props: {
         ...mockProps,
-        selectedCategory: 'ORDER',
+        isScheduledView: false,
       },
     });
 
@@ -181,7 +164,7 @@ describe('AllDocuments.vue', () => {
     const wrapper = mount(AllDocuments, {
       props: {
         ...mockProps,
-        selectedCategory: 'Scheduled',
+        isScheduledView: true,
       },
     });
 

--- a/web/tests/components/case-details/common/ChipMultiSelect.test.ts
+++ b/web/tests/components/case-details/common/ChipMultiSelect.test.ts
@@ -1,0 +1,138 @@
+import ChipMultiSelect from '@/components/case-details/common/ChipMultiSelect.vue';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+describe('ChipMultiSelect.vue', () => {
+  const baseProps = {
+    modelValue: [] as string[],
+    items: [
+      { title: 'Option A', value: 'a', count: 2 },
+      { title: 'Option B', value: 'b' },
+      { title: 'Option C', value: 'c', count: 0 },
+    ],
+  };
+
+  it('uses generic defaults for select text', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: baseProps,
+    });
+
+    expect(wrapper.vm.getSelectAllTitle()).toBe('Select All');
+  });
+
+  it('includes select all count when provided', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: {
+        ...baseProps,
+        selectAllCount: 12,
+      },
+    });
+
+    expect(wrapper.vm.getSelectAllTitle()).toBe('Select All (12)');
+  });
+
+  it('supports overriding select-all label', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: {
+        ...baseProps,
+        selectAllLabel: 'Select everything',
+      },
+    });
+
+    expect(wrapper.vm.getSelectAllTitle()).toBe('Select everything');
+  });
+
+  it('formats item title with count only when count is present', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: baseProps,
+    });
+
+    expect(wrapper.vm.getItemTitle(baseProps.items[0])).toBe('Option A (2)');
+    expect(wrapper.vm.getItemTitle(baseProps.items[1])).toBe('Option B');
+    expect(wrapper.vm.getItemTitle(baseProps.items[2])).toBe('Option C (0)');
+  });
+
+  it('emits an empty selection when update value is undefined', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: baseProps,
+    });
+
+    wrapper.vm.onUpdate(undefined as unknown as string[]);
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[[]]]);
+  });
+
+  it('selects all values when toggleSelectAll is called and not all selected', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: baseProps,
+    });
+
+    wrapper.vm.toggleSelectAll();
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[['a', 'b', 'c']]]);
+  });
+
+  it('clears values when toggleSelectAll is called and all selected', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: {
+        ...baseProps,
+        modelValue: ['a', 'b', 'c'],
+      },
+    });
+
+    wrapper.vm.toggleSelectAll();
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[[]]]);
+  });
+
+  it('removeValue emits model without removed option', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: {
+        ...baseProps,
+        modelValue: ['a', 'b'],
+      },
+    });
+
+    wrapper.vm.removeValue('a');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[['b']]]);
+  });
+
+  it('toggleValue removes value when selected', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: {
+        ...baseProps,
+        modelValue: ['b'],
+      },
+    });
+
+    wrapper.vm.toggleValue('b');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[[]]]);
+  });
+
+  it('toggleValue adds value when not selected', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: {
+        ...baseProps,
+        modelValue: ['a'],
+      },
+    });
+
+    wrapper.vm.toggleValue('c');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[['a', 'c']]]);
+  });
+
+  it('detects selected values through isSelected', () => {
+    const wrapper = shallowMount(ChipMultiSelect, {
+      props: {
+        ...baseProps,
+        modelValue: ['b'],
+      },
+    });
+
+    expect(wrapper.vm.isSelected('b')).toBe(true);
+    expect(wrapper.vm.isSelected('a')).toBe(false);
+  });
+});

--- a/web/tests/components/case-details/criminal/CriminalDocumentsView.test.ts
+++ b/web/tests/components/case-details/criminal/CriminalDocumentsView.test.ts
@@ -703,4 +703,35 @@ describe('CriminalDocumentsView.vue', () => {
       expect(documentIds[1]).toContain('IMG-002');
     });
   });
+
+  it('removes stale selected categories that are no longer valid', async () => {
+    wrapper.vm.selectedCategories = ['bail'];
+
+    await wrapper.setProps({
+      participants: [
+        {
+          fullName: 'New Person',
+          lastNm: 'Person',
+          givenNm: 'New',
+          profSeqNo: 99,
+          keyDocuments: [],
+          document: [
+            {
+              issueDate: '2023-09-01',
+              documentTypeDescription: 'Only Transcript',
+              category: 'Transcript',
+              documentPageCount: 1,
+              imageId: '999',
+              docmDispositionDsc: 'Disposition',
+            },
+          ],
+        },
+      ],
+    });
+
+    await nextTick();
+
+    expect(wrapper.vm.selectedCategories).toEqual([]);
+    expect(wrapper.vm.documentsSectionTitle).toBe('All Documents');
+  });
 });

--- a/web/tests/components/case-details/criminal/CriminalDocumentsView.test.ts
+++ b/web/tests/components/case-details/criminal/CriminalDocumentsView.test.ts
@@ -142,14 +142,12 @@ describe('CriminalDocumentsView.vue', () => {
   });
 
   it('computes unfilteredDocuments correctly', async () => {
-    wrapper.vm.selectedCategory = 'ROP';
-
     const unfilteredDocuments = wrapper.vm.unfilteredDocuments;
     expect(unfilteredDocuments).toHaveLength(2);
   });
 
   it('filters documents by category', async () => {
-    wrapper.vm.selectedCategory = 'bail';
+    wrapper.vm.selectedCategories = ['bail'];
 
     const documents = wrapper.vm.documents;
     expect(documents).toHaveLength(1);
@@ -173,7 +171,7 @@ describe('CriminalDocumentsView.vue', () => {
       },
     });
 
-    (wrapper.vm as any).selectedCategory = 'bail';
+    (wrapper.vm as any).selectedCategories = ['bail'];
     await nextTick();
 
     const documents = (wrapper.vm as any).documents;
@@ -554,7 +552,7 @@ describe('CriminalDocumentsView.vue', () => {
     });
 
     it('displays original category name when no special formatting applies', async () => {
-      wrapper.vm.selectedCategory = 'bail';
+      wrapper.vm.selectedCategories = ['bail'];
       await nextTick();
 
       const sections = wrapper.findAll('v-card-text .text-h5');
@@ -648,7 +646,7 @@ describe('CriminalDocumentsView.vue', () => {
       expect(documentIds[2]).toContain('145');
 
       // Filter to only show transcripts
-      wrapper.vm.selectedCategory = 'Transcript';
+      wrapper.vm.selectedCategories = ['Transcript'];
       await nextTick();
 
       const filteredDocuments = wrapper.vm.documents;

--- a/web/tests/utils/categoryFilterUtils.test.ts
+++ b/web/tests/utils/categoryFilterUtils.test.ts
@@ -1,0 +1,131 @@
+import {
+  DEFAULT_SECTION_TITLE,
+  MULTI_SECTION_TITLE,
+  getSectionTitle,
+  getUncategorizedCount,
+  matchesCategorySelection,
+  pruneInvalidSelections,
+} from '@/utils/categoryFilterUtils';
+import { describe, expect, it } from 'vitest';
+
+describe('categoryFilterUtils', () => {
+  describe('pruneInvalidSelections', () => {
+    it('keeps only selections present in valid values', () => {
+      const result = pruneInvalidSelections(
+        ['Scheduled', 'Other', 'Missing'],
+        ['Scheduled', 'CSR', 'Other']
+      );
+
+      expect(result).toEqual(['Scheduled', 'Other']);
+    });
+
+    it('returns empty when no selections are valid', () => {
+      const result = pruneInvalidSelections(['A', 'B'], ['X', 'Y']);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getSectionTitle', () => {
+    it('returns default title when there are no active values', () => {
+      expect(getSectionTitle([])).toBe(DEFAULT_SECTION_TITLE);
+    });
+
+    it('returns mapped display title for a single selection when mapper is provided', () => {
+      const mapDisplayTitle = (value: string) =>
+        value === 'CSR' ? 'Court Summary' : value;
+
+      expect(getSectionTitle(['CSR'], mapDisplayTitle)).toBe('Court Summary');
+    });
+
+    it('returns single raw value when mapper is not provided', () => {
+      expect(getSectionTitle(['Transcript'])).toBe('Transcript');
+    });
+
+    it('returns multi-selection title when multiple values are active', () => {
+      expect(getSectionTitle(['CSR', 'Transcript'])).toBe(MULTI_SECTION_TITLE);
+    });
+  });
+
+  describe('getUncategorizedCount', () => {
+    it('counts null, undefined, empty and whitespace-only categories as uncategorized', () => {
+      const items = [
+        { category: null },
+        { category: undefined },
+        { category: '' },
+        { category: '   ' },
+        { category: 'CSR' },
+      ];
+
+      const count = getUncategorizedCount(items, (item) => item.category);
+      expect(count).toBe(4);
+    });
+  });
+
+  describe('matchesCategorySelection', () => {
+    const getCategory = (item: { category?: string | null }) => item.category;
+
+    it('returns true when no active filters are selected', () => {
+      expect(
+        matchesCategorySelection({ category: 'CSR' }, [], getCategory)
+      ).toBe(true);
+    });
+
+    it('matches selected category case-insensitively and ignores whitespace', () => {
+      expect(
+        matchesCategorySelection({ category: '  csr  ' }, ['CSR'], getCategory)
+      ).toBe(true);
+    });
+
+    it('matches Other against uncategorized items', () => {
+      expect(
+        matchesCategorySelection({ category: '   ' }, ['Other'], getCategory)
+      ).toBe(true);
+    });
+
+    it('does not match Other when item has a real category', () => {
+      expect(
+        matchesCategorySelection({ category: 'CSR' }, ['Other'], getCategory)
+      ).toBe(false);
+    });
+
+    it('supports custom other label', () => {
+      expect(
+        matchesCategorySelection({ category: '' }, ['Misc'], getCategory, {
+          otherLabel: 'Misc',
+        })
+      ).toBe(true);
+    });
+
+    it('uses special predicates when provided', () => {
+      const item = { category: 'CSR', nextAppearanceDt: '2025-01-01' };
+      const result = matchesCategorySelection(
+        item,
+        ['Scheduled'],
+        (doc) => doc.category,
+        {
+          specialPredicates: {
+            scheduled: (doc) => !!doc.nextAppearanceDt,
+          },
+        }
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('falls back to category matching when special predicate is not available', () => {
+      const item = { category: 'Transcript', nextAppearanceDt: '' };
+      const result = matchesCategorySelection(
+        item,
+        ['Transcript', 'Scheduled'],
+        (doc) => doc.category,
+        {
+          specialPredicates: {
+            scheduled: (doc) => !!doc.nextAppearanceDt,
+          },
+        }
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**jasper-625**----    

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-625

## Description

Add new generic multi-select component which provides removable chips, select all. Update criminal/civil documents to use new component and display appropriate headers.

Fixes # (issue)  

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)



## How Has This Been Tested?

Tested that scheduled documents are defaulted appropriately for civil documents.
All documents and no filter function the same.
Chips are displayed based on selection and can be clicked to cancel.
Headers display based on selection.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   
