### PR TITLE
Fix idir name population

### DIFF
--- a/core/Helpers/ClaimsTypes.cs
+++ b/core/Helpers/ClaimsTypes.cs
@@ -31,6 +31,8 @@ namespace Scv.Core.Helpers
             "preferred_username",
             "groups",
             ClaimTypes.Email,
+            ClaimTypes.GivenName,
+            ClaimTypes.Surname,
             UserGuid,
             ProvjudUserGuid,
             ExternalJudgeId


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**N/A**----    

## Description

Fixes long-standing issue with first/last population in mongo for new users. Partially fixed previously by PCSS sync, but IDIR users would suffer from null first/last names in the db. Not visible due to frontend using claims directly and not db name values.

Fixes # (issue)  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update    





## How Has This Been Tested?

tested when creating new idir/provjud users and checking database values.

**Test Configuration**:
If applicable

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   
