### PR TITLE
Jasper 736 - show notification popup when order received while user logged in.

### DIFF
--- a/web/src/components/documents/strategies/OrderPDFStrategy.ts
+++ b/web/src/components/documents/strategies/OrderPDFStrategy.ts
@@ -69,21 +69,21 @@ export class OrderPDFStrategy extends FilePDFStrategy {
       case OrderReviewStatus.Approved:
         this.snackBarStore.showSnackbar(
           'The order has been approved.',
-          'rgb(46, 139, 43)',
+          'success',
           '✅ Approved!'
         );
         break;
       case OrderReviewStatus.Unapproved:
         this.snackBarStore.showSnackbar(
           'The order has been rejected.',
-          'rgb(46, 139, 43)',
+          'success',
           '📋 Rejected'
         );
         break;
       case OrderReviewStatus.AwaitingDocumentation:
         this.snackBarStore.showSnackbar(
           'The order review is awaiting documentation.',
-          'rgb(46, 139, 43)',
+          'success',
           '⏳ Pending'
         );
         break;

--- a/web/src/components/shared/Snackbar.vue
+++ b/web/src/components/shared/Snackbar.vue
@@ -2,35 +2,130 @@
   <v-snackbar
     v-model="snackbarStore.isVisible"
     :timeout="snackbarStore.timeout"
-    :color="snackbarStore.color"
+    :color="resolvedSnackbarStyle.color"
+    :class="resolvedSnackbarClass"
     location="bottom right"
   >
-    <h3>{{ snackbarStore.title }}</h3>
-    <span>{{ snackbarStore.message }}</span>
-    <template v-slot:actions>
-      <v-btn
-        v-if="snackbarStore.actionLabel && snackbarStore.actionHandler"
-        variant="text"
-        size="small"
-        class="mx-1"
-        @click="runAction"
-      >
-        {{ snackbarStore.actionLabel }}
-      </v-btn>
-      <v-icon class="mx-2" :icon="mdiCloseCircle" @click="close" />
-    </template>
+    <div class="snackbar-content">
+      <div class="snackbar-header">
+        <h3>{{ snackbarStore.title }}</h3>
+        <v-icon
+          class="snackbar-close-icon"
+          :icon="mdiCloseCircle"
+          @click="close"
+        />
+      </div>
+
+      <div class="snackbar-text">
+        <span>{{ snackbarStore.message }}</span>
+      </div>
+
+      <div class="snackbar-actions">
+        <v-btn
+          v-if="snackbarStore.actionLabel && snackbarStore.actionHandler"
+          variant="outlined"
+          size="small"
+          class="snackbar-action-button mx-1"
+          @click="runAction"
+        >
+          {{ snackbarStore.actionLabel }}
+        </v-btn>
+      </div>
+    </div>
   </v-snackbar>
 </template>
 
 <script setup lang="ts">
   import { useSnackbarStore } from '@/stores/SnackbarStore';
   import { mdiCloseCircle } from '@mdi/js';
-  const snackbarStore = useSnackbarStore();
-  const runAction = () => {
-    snackbarStore.actionHandler?.();
-    snackbarStore.hideSnackbar();
+  import { computed } from 'vue';
+
+  type SnackbarStyle = 'warning' | 'success' | 'error' | 'light' | 'dark';
+
+  const snackbarStyleMap: Record<
+    SnackbarStyle,
+    { color?: string; className?: string }
+  > = {
+    warning: { color: 'warning' },
+    success: { color: 'success' },
+    error: { color: 'error' },
+    light: { className: 'snackbar-light' },
+    dark: { className: 'snackbar-dark' },
   };
+
+  const snackbarStore = useSnackbarStore();
+
+  const resolvedSnackbarStyle = computed(() => {
+    const configuredStyle = snackbarStore.color as SnackbarStyle;
+    return snackbarStyleMap[configuredStyle] ?? { color: snackbarStore.color };
+  });
+
+  const resolvedSnackbarClass = computed(() => [
+    'snackbar',
+    resolvedSnackbarStyle.value.className,
+  ]);
+
+  const runAction = () => {
+    try {
+      snackbarStore.actionHandler?.();
+    } finally {
+      snackbarStore.hideSnackbar();
+    }
+  };
+
   const close = () => {
     snackbarStore.hideSnackbar();
   };
 </script>
+
+<style scoped>
+  .snackbar-light :deep(.v-snackbar__wrapper) {
+    background-color: var(--bg-white-500);
+    color: var(--text-black-500);
+  }
+
+  .snackbar-dark :deep(.v-snackbar__wrapper) {
+    background-color: var(--bg-blue-800);
+    color: var(--text-white-500);
+  }
+
+  .snackbar-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .snackbar-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .snackbar-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .snackbar-close-icon {
+    color: inherit;
+    flex-shrink: 0;
+    margin-top: 0.125rem;
+  }
+
+  .snackbar-actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+  }
+
+  .snackbar-action-button {
+    color: inherit !important;
+    border-color: currentColor !important;
+  }
+
+  .snackbar-action-button :deep(.v-btn__content) {
+    color: inherit;
+  }
+</style>

--- a/web/src/signalr/handlers/orderReceivedHandler.ts
+++ b/web/src/signalr/handlers/orderReceivedHandler.ts
@@ -1,0 +1,67 @@
+import type { OrderService } from '@/services';
+import { useOrdersStore } from '@/stores/OrdersStore';
+import { useSnackbarStore } from '@/stores/SnackbarStore';
+import type { Order } from '@/types';
+import { NotificationType } from '@/types/common';
+import { getCourtClassLabel } from '@/utils/utils';
+import type { NotificationHandler } from '../notifications';
+import { type OrderReceivedNotificationPayload } from '../payloads';
+
+export const priorityText = (order: Order) =>
+  order.priorityTypeDescription
+    ? ` with priority class: ${order.priorityTypeDescription}`
+    : ``;
+
+export const buildOrderReceivedMessage = (order: Order) =>
+  `Received ${order.courtListType} for file ${getCourtClassLabel(order.courtClass)} - ${order.courtFileNumber}${priorityText(order)}`;
+
+export const createOrderReceivedHandler = ({
+  orderService,
+  ordersStore,
+  snackbarStore,
+  viewOrderDetails,
+  viewOrders,
+}: {
+  orderService: OrderService;
+  ordersStore: ReturnType<typeof useOrdersStore>;
+  snackbarStore: ReturnType<typeof useSnackbarStore>;
+  viewOrderDetails: (order: Order) => void;
+  viewOrders: () => void;
+}): NotificationHandler<OrderReceivedNotificationPayload> => {
+  return async (notification) => {
+    if (notification.type !== NotificationType.ORDER_RECEIVED) {
+      return;
+    }
+
+    const newOrders = await ordersStore.fetchOrders(orderService);
+    const order = newOrders?.find(
+      (o) => o.id === notification.payload?.orderId
+    );
+
+    if (!order) {
+      // display fallback message if new order matching notification can not be retrieved.
+      snackbarStore.showSnackbar(
+        'Package received requiring signature/action',
+        'light',
+        'Notification received!',
+        15000,
+        {
+          label: `View orders/applications`,
+          onClick: () => viewOrders(),
+        }
+      );
+      return;
+    }
+
+    snackbarStore.showSnackbar(
+      buildOrderReceivedMessage(order),
+      'light',
+      `${order.courtListType} received!`,
+      15000,
+      {
+        label: `View package #${order.packageId}`,
+        onClick: () => viewOrderDetails(order),
+      }
+    );
+  };
+};

--- a/web/src/signalr/handlers/orderReceivedHandler.ts
+++ b/web/src/signalr/handlers/orderReceivedHandler.ts
@@ -33,8 +33,9 @@ export const createOrderReceivedHandler = ({
       return;
     }
 
-    const newOrders = await ordersStore.fetchOrders(orderService);
-    const order = newOrders?.find(
+    const fetchedOrders = await ordersStore.fetchOrders(orderService);
+    const candidateOrders = fetchedOrders ?? ordersStore.orders ?? [];
+    const order = candidateOrders.find(
       (o) => o.id === notification.payload?.orderId
     );
 

--- a/web/src/signalr/notifications.ts
+++ b/web/src/signalr/notifications.ts
@@ -22,7 +22,7 @@ export type NotificationHandler<TPayload = unknown> = (
 export class NotificationsService {
   private connection: HubConnection | null = null;
   private handlerProvider:
-    | (() => Iterable<NotificationHandler<unknown>>)
+    | ((type: NotificationType) => Iterable<NotificationHandler<unknown>>)
     | null = null;
   private readonly seenAckGuids = new Set<string>();
   private readonly seenAckQueue: string[] = [];
@@ -46,31 +46,35 @@ export class NotificationsService {
     this.connection.keepAliveIntervalInMilliseconds = 15000;
     this.connection.serverTimeoutInMilliseconds = 120000;
 
-    this.connection.on('sendNotification', (notification: NotificationDto) => {
-      if (notification.ackGuid != null) {
-        if (this.seenAckGuids.has(notification.ackGuid)) {
+    this.connection.on(
+      'sendNotification',
+      async (notification: NotificationDto) => {
+        if (this.isDuplicateAck(notification.ackGuid)) {
           return;
         }
 
-        this.seenAckGuids.add(notification.ackGuid);
-        this.seenAckQueue.push(notification.ackGuid);
-        if (this.seenAckQueue.length > this.maxSeenAckGuids) {
-          const oldest = this.seenAckQueue.shift();
-          if (oldest != null) {
-            this.seenAckGuids.delete(oldest);
+        const handlers = Array.from(
+          this.handlerProvider?.(notification.type) ?? []
+        );
+
+        const results = await Promise.allSettled(
+          handlers.map(async (handler) => await handler(notification))
+        );
+
+        for (const result of results) {
+          if (result.status === 'rejected') {
+            console.error('Notification handler failed', result.reason);
           }
         }
-      }
 
-      void this.sendAckIfRequired(notification);
-      const handlers = this.handlerProvider?.() ?? [];
-      for (const handler of handlers) {
-        handler(notification);
+        void this.sendAckIfRequired(notification);
       }
-    });
+    );
   }
 
-  setHandlerProvider(provider: () => Iterable<NotificationHandler<unknown>>) {
+  setHandlerProvider(
+    provider: (type: NotificationType) => Iterable<NotificationHandler<unknown>>
+  ) {
     this.handlerProvider = provider;
   }
 
@@ -97,6 +101,27 @@ export class NotificationsService {
     ) {
       await this.connection.stop();
     }
+  }
+
+  private isDuplicateAck(ackGuid: string | undefined) {
+    if (ackGuid == null) {
+      return false;
+    }
+
+    if (this.seenAckGuids.has(ackGuid)) {
+      return true;
+    }
+
+    this.seenAckGuids.add(ackGuid);
+    this.seenAckQueue.push(ackGuid);
+    if (this.seenAckQueue.length > this.maxSeenAckGuids) {
+      const oldest = this.seenAckQueue.shift();
+      if (oldest != null) {
+        this.seenAckGuids.delete(oldest);
+      }
+    }
+
+    return false;
   }
 
   private async sendAckIfRequired(notification: NotificationDto) {

--- a/web/src/signalr/payloads.ts
+++ b/web/src/signalr/payloads.ts
@@ -1,5 +1,5 @@
 export interface OrderReceivedNotificationPayload {
   orderId: string;
-  phsyicalFileId: string;
+  physicalFileId: string;
   message: string;
 }

--- a/web/src/stores/NotificationsStore.ts
+++ b/web/src/stores/NotificationsStore.ts
@@ -1,31 +1,52 @@
 import { OrderService } from '@/services';
+import { createOrderReceivedHandler } from '@/signalr/handlers/orderReceivedHandler';
 import {
-  NotificationDto,
   type NotificationHandler,
   type NotificationsService,
 } from '@/signalr/notifications';
+import { NotificationType } from '@/types/common';
+import { viewOrderDetails } from '@/utils/orderDetails';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import { useRouter } from 'vue-router';
 import { useOrdersStore } from './OrdersStore';
-import { NotificationType } from '@/types/common';
 import { useSnackbarStore } from './SnackbarStore';
-import { OrderReceivedNotificationPayload } from '@/signalr/payloads';
-import { getCourtClassLabel } from '@/utils/utils';
-import { viewOrderDetails } from '@/utils/orderDetails';
 
 export const useNotificationsStore = defineStore('notifications', () => {
-  const handlers = ref(new Set<NotificationHandler<unknown>>());
+  const handlers = ref(
+    new Map<NotificationType, Set<NotificationHandler<unknown>>>()
+  );
   const isStarted = ref(false);
   const hasOrderHandler = ref(false);
   const startTask = ref<Promise<void> | null>(null);
-  const snackBarStore = useSnackbarStore();
+  const router = useRouter();
+  const viewOrders = () => router.push('/orders');
 
   const registerHandler = <TPayload>(
+    notificationType: NotificationType,
     handler: NotificationHandler<TPayload>
   ) => {
     const widenedHandler = handler as NotificationHandler<unknown>;
-    handlers.value.add(widenedHandler);
-    return () => handlers.value.delete(widenedHandler);
+    const existingHandlers = handlers.value.get(notificationType);
+    if (existingHandlers) {
+      existingHandlers.add(widenedHandler);
+    } else {
+      handlers.value.set(notificationType, new Set([widenedHandler]));
+    }
+
+    return () => {
+      const typeHandlers = handlers.value.get(notificationType);
+      if (!typeHandlers) {
+        return false;
+      }
+
+      const deleted = typeHandlers.delete(widenedHandler);
+      if (typeHandlers.size === 0) {
+        handlers.value.delete(notificationType);
+      }
+
+      return deleted;
+    };
   };
 
   const initialize = async (
@@ -34,30 +55,16 @@ export const useNotificationsStore = defineStore('notifications', () => {
   ) => {
     if (!hasOrderHandler.value) {
       const ordersStore = useOrdersStore();
+      const snackbarStore = useSnackbarStore();
       registerHandler(
-        async (
-          notification: NotificationDto<OrderReceivedNotificationPayload>
-        ) => {
-          if (notification.type === NotificationType.ORDER_RECEIVED) {
-            const newOrders = await ordersStore.fetchOrders(orderService);
-            const notificationOrderId = notification.payload?.orderId;
-            const notificationOrder = newOrders?.find(
-              (o) => o.id === notificationOrderId
-            );
-            if (notificationOrder) {
-              snackBarStore.showSnackbar(
-                `Received order for file ${getCourtClassLabel(notificationOrder.courtClass)} - ${notificationOrder.courtFileNumber}.`,
-                '#b4e6ff',
-                '🔄 Heads-up!',
-                15000,
-                {
-                  label: `Package ${notificationOrder.packageId}`,
-                  onClick: () => viewOrderDetails(notificationOrder),
-                }
-              );
-            }
-          }
-        }
+        NotificationType.ORDER_RECEIVED,
+        createOrderReceivedHandler({
+          orderService,
+          ordersStore,
+          snackbarStore,
+          viewOrderDetails,
+          viewOrders,
+        })
       );
       hasOrderHandler.value = true;
     }
@@ -67,7 +74,9 @@ export const useNotificationsStore = defineStore('notifications', () => {
     }
 
     startTask.value ??= (async () => {
-      notificationsService.setHandlerProvider(() => handlers.value.values());
+      notificationsService.setHandlerProvider(
+        (type) => handlers.value.get(type)?.values() ?? []
+      );
       await notificationsService.start();
       isStarted.value = true;
     })();

--- a/web/tests/components/documents/strategies/OrderPDFStrategy.test.ts
+++ b/web/tests/components/documents/strategies/OrderPDFStrategy.test.ts
@@ -352,7 +352,7 @@ describe('OrderPDFStrategy', () => {
     expect(mockOrderService.review).toHaveBeenCalledWith('123', review);
     expect(mockSnackbarStore.showSnackbar).toHaveBeenCalledWith(
       'The order has been approved.',
-      'rgb(46, 139, 43)',
+        'success',
       '✅ Approved!'
     );
   });
@@ -372,7 +372,7 @@ describe('OrderPDFStrategy', () => {
     expect(mockOrderService.review).toHaveBeenCalledWith('123', review);
     expect(mockSnackbarStore.showSnackbar).toHaveBeenCalledWith(
       'The order has been rejected.',
-      'rgb(46, 139, 43)',
+        'success',
       '📋 Rejected'
     );
   });
@@ -392,7 +392,7 @@ describe('OrderPDFStrategy', () => {
     expect(mockOrderService.review).toHaveBeenCalledWith('123', review);
     expect(mockSnackbarStore.showSnackbar).toHaveBeenCalledWith(
       'The order review is awaiting documentation.',
-      'rgb(46, 139, 43)',
+        'success',
       '⏳ Pending'
     );
   });

--- a/web/tests/components/shared/Snackbar.test.ts
+++ b/web/tests/components/shared/Snackbar.test.ts
@@ -1,16 +1,22 @@
-import { mount } from '@vue/test-utils';
-import { useSnackbarStore } from '@/stores/SnackbarStore';
-import { describe, it, expect, beforeEach } from 'vitest';
 import Snackbar from '@/components/shared/Snackbar.vue';
-import { setActivePinia, createPinia } from 'pinia'
+import { useSnackbarStore } from '@/stores/SnackbarStore';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('Snackbar.vue', () => {
-    let store: ReturnType<typeof useSnackbarStore>;
+  let store: ReturnType<typeof useSnackbarStore>;
 
-    beforeEach(() => {
-        setActivePinia(createPinia());
-        store = useSnackbarStore();
-    });
+  const snackbarStub = {
+    props: ['color'],
+    template:
+      '<div class="snackbar-stub" :data-color="color" :class="$attrs.class"><slot /><slot name="actions" /></div>',
+  };
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    store = useSnackbarStore();
+  });
 
   it('renders snackbar with correct props', () => {
     store.showSnackbar('Test message', 'error', 'Test title');
@@ -26,9 +32,7 @@ describe('Snackbar.vue', () => {
     const wrapper = mount(Snackbar, {
       global: {
         stubs: {
-          'v-snackbar': {
-            template: '<div><slot /><slot name="actions" /></div>',
-          },
+          'v-snackbar': snackbarStub,
         },
       },
     });
@@ -39,5 +43,65 @@ describe('Snackbar.vue', () => {
     await closeButton.trigger('click');
 
     expect(store.isVisible).toBe(false);
+  });
+
+  it('runs action handler and hides snackbar when action is clicked', async () => {
+    const actionHandler = vi.fn();
+    store.showSnackbar('Test message', 'error', 'Test title', 15000, {
+      label: 'View package',
+      onClick: actionHandler,
+    });
+
+    const wrapper = mount(Snackbar, {
+      global: {
+        stubs: {
+          'v-snackbar': snackbarStub,
+          'v-btn': {
+            template:
+              '<button class="action-btn" @click="$emit(\'click\')"><slot /></button>',
+          },
+        },
+      },
+    });
+
+    const actionButton = wrapper.find('.action-btn');
+    expect(actionButton.exists()).toBe(true);
+
+    await actionButton.trigger('click');
+
+    expect(actionHandler).toHaveBeenCalledTimes(1);
+    expect(store.isVisible).toBe(false);
+    expect(store.actionLabel).toBe('');
+    expect(store.actionHandler).toBeNull();
+  });
+
+  it('maps the light snackbar style to the shared light class', () => {
+    store.showSnackbar('Test message', 'light', 'Test title');
+    const wrapper = mount(Snackbar, {
+      global: {
+        stubs: {
+          'v-snackbar': snackbarStub,
+        },
+      },
+    });
+
+    const snackbar = wrapper.find('.snackbar-stub');
+    expect(snackbar.classes()).toContain('snackbar-light');
+    expect(snackbar.attributes('data-color')).toBeUndefined();
+  });
+
+  it('preserves custom snackbar colors for existing callers', () => {
+    store.showSnackbar('Test message', '#b84157', 'Test title');
+    const wrapper = mount(Snackbar, {
+      global: {
+        stubs: {
+          'v-snackbar': snackbarStub,
+        },
+      },
+    });
+
+    expect(wrapper.find('.snackbar-stub').attributes('data-color')).toBe(
+      '#b84157'
+    );
   });
 });

--- a/web/tests/signalr/orderReceivedHandler.test.ts
+++ b/web/tests/signalr/orderReceivedHandler.test.ts
@@ -1,0 +1,139 @@
+import { createOrderReceivedHandler } from '@/signalr/handlers/orderReceivedHandler';
+import type { NotificationDto } from '@/signalr/notifications';
+import type { OrderReceivedNotificationPayload } from '@/signalr/payloads';
+import type { Order } from '@/types';
+import { NotificationType, OrderReviewStatus } from '@/types/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getCourtClassLabelMock } = vi.hoisted(() => ({
+  getCourtClassLabelMock: vi.fn(),
+}));
+
+vi.mock('@/utils/utils', () => ({
+  getCourtClassLabel: getCourtClassLabelMock,
+}));
+
+describe('createOrderReceivedHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCourtClassLabelMock.mockReturnValue('Criminal');
+  });
+
+  it('returns early for non-order-received notifications', async () => {
+    const fetchOrders = vi.fn();
+    const showSnackbar = vi.fn();
+    const viewOrderDetails = vi.fn();
+    const viewOrders = vi.fn();
+
+    const handler = createOrderReceivedHandler({
+      orderService: {} as any,
+      ordersStore: { fetchOrders } as any,
+      snackbarStore: { showSnackbar } as any,
+      viewOrderDetails,
+      viewOrders,
+    });
+
+    const notification: NotificationDto<OrderReceivedNotificationPayload> = {
+      type: 'UNKNOWN' as NotificationType,
+      timestamp: new Date().toISOString(),
+      payload: { orderId: 'order-1', physicalFileId: 'file-1', message: '' },
+    };
+
+    await handler(notification);
+
+    expect(fetchOrders).not.toHaveBeenCalled();
+    expect(showSnackbar).not.toHaveBeenCalled();
+  });
+
+  it('shows snackbar and invokes view callback when order is found', async () => {
+    const order: Order = {
+      id: 'order-1',
+      packageId: 12345,
+      priorityType: 'P1',
+      priorityTypeDescription: 'High',
+      courtListType: 'Trial List',
+      packageDocumentId: 'doc-1',
+      packageName: 'Order Package',
+      receivedDate: '2026-01-01',
+      processedDate: '2026-01-02',
+      courtClass: 'CC',
+      courtFileNumber: '12345-1',
+      styleOfCause: 'R v Smith',
+      physicalFileId: 'file-1',
+      status: OrderReviewStatus.Pending,
+    };
+
+    const orderService = { getOrders: vi.fn() } as any;
+    const fetchOrders = vi.fn().mockResolvedValue([order]);
+    const showSnackbar = vi.fn();
+    const viewOrderDetails = vi.fn();
+    const viewOrders = vi.fn();
+
+    const handler = createOrderReceivedHandler({
+      orderService,
+      ordersStore: { fetchOrders } as any,
+      snackbarStore: { showSnackbar } as any,
+      viewOrderDetails,
+      viewOrders,
+    });
+
+    const notification: NotificationDto<OrderReceivedNotificationPayload> = {
+      type: NotificationType.ORDER_RECEIVED,
+      timestamp: new Date().toISOString(),
+      payload: { orderId: 'order-1', physicalFileId: 'file-1', message: '' },
+    };
+
+    await handler(notification);
+
+    expect(fetchOrders).toHaveBeenCalledWith(orderService);
+    expect(showSnackbar).toHaveBeenCalledWith(
+      'Received Trial List for file Criminal - 12345-1 with priority class: High',
+      'light',
+      'Trial List received!',
+      15000,
+      expect.objectContaining({ label: 'View package #12345' })
+    );
+
+    const action = showSnackbar.mock.calls[0][4];
+    action.onClick();
+    expect(viewOrderDetails).toHaveBeenCalledWith(order);
+  });
+
+  it('shows fallback snackbar when order is not found', async () => {
+    const fetchOrders = vi.fn().mockResolvedValue([]);
+    const showSnackbar = vi.fn();
+    const viewOrders = vi.fn();
+
+    const handler = createOrderReceivedHandler({
+      orderService: {} as any,
+      ordersStore: { fetchOrders } as any,
+      snackbarStore: { showSnackbar } as any,
+      viewOrderDetails: vi.fn(),
+      viewOrders,
+    });
+
+    const notification: NotificationDto<OrderReceivedNotificationPayload> = {
+      type: NotificationType.ORDER_RECEIVED,
+      timestamp: new Date().toISOString(),
+      payload: {
+        orderId: 'missing-order',
+        physicalFileId: 'file-1',
+        message: '',
+      },
+    };
+
+    await handler(notification);
+
+    expect(showSnackbar).toHaveBeenCalledWith(
+      'Package received requiring signature/action',
+      'light',
+      'Notification received!',
+      15000,
+      expect.objectContaining({ label: 'View orders/applications' })
+    );
+
+    const action = showSnackbar.mock.calls[0][4];
+    action.onClick();
+    expect(viewOrders).toHaveBeenCalled();
+  });
+});

--- a/web/tests/stores/NotificationsStore.test.ts
+++ b/web/tests/stores/NotificationsStore.test.ts
@@ -1,0 +1,169 @@
+import { type OrderService } from '@/services';
+import {
+  type NotificationHandler,
+  NotificationsService,
+} from '@/signalr/notifications';
+import { NotificationType } from '@/types/common';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  fetchOrdersMock,
+  showSnackbarMock,
+  viewOrderDetailsMock,
+  getCourtClassLabelMock,
+} = vi.hoisted(() => ({
+  fetchOrdersMock: vi.fn(),
+  showSnackbarMock: vi.fn(),
+  viewOrderDetailsMock: vi.fn(),
+  getCourtClassLabelMock: vi.fn(),
+}));
+
+vi.mock('@/stores/OrdersStore', () => ({
+  useOrdersStore: () => ({
+    fetchOrders: fetchOrdersMock,
+  }),
+}));
+
+vi.mock('@/stores/SnackbarStore', () => ({
+  useSnackbarStore: () => ({
+    showSnackbar: showSnackbarMock,
+  }),
+}));
+
+vi.mock('@/utils/orderDetails', () => ({
+  viewOrderDetails: viewOrderDetailsMock,
+}));
+
+vi.mock('@/utils/utils', () => ({
+  getCourtClassLabel: getCourtClassLabelMock,
+}));
+
+import { useNotificationsStore } from '@/stores/NotificationsStore';
+
+describe('NotificationsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    getCourtClassLabelMock.mockReturnValue('Criminal');
+  });
+
+  it('registers one order handler and starts notifications once', async () => {
+    const store = useNotificationsStore();
+    let provider: (
+      type: NotificationType
+    ) => Iterable<NotificationHandler<unknown>> = () => [];
+    const notificationsService = new NotificationsService();
+    const setHandlerProviderSpy = vi
+      .spyOn(notificationsService, 'setHandlerProvider')
+      .mockImplementation((p) => {
+        provider = p;
+      });
+    const startSpy = vi
+      .spyOn(notificationsService, 'start')
+      .mockResolvedValue(undefined);
+
+    await Promise.all([
+      store.initialize(notificationsService, {} as OrderService),
+      store.initialize(notificationsService, {} as OrderService),
+    ]);
+
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(setHandlerProviderSpy).toHaveBeenCalledTimes(1);
+    expect(Array.from(provider(NotificationType.ORDER_RECEIVED))).toHaveLength(
+      1
+    );
+  });
+
+  it('shows snackbar with action when received order is found', async () => {
+    const order = {
+      id: 'order-1',
+      packageId: 12345,
+      priorityType: 'P1',
+      priorityTypeDescription: 'High',
+      courtListType: 'Trial List',
+      packageDocumentId: 'doc-1',
+      packageName: 'Order Package',
+      receivedDate: '2026-01-01',
+      processedDate: '2026-01-02',
+      courtClass: 'CC',
+      courtFileNumber: '12345-1',
+      styleOfCause: 'R v Smith',
+      physicalFileId: 'file-1',
+      status: 'Pending',
+    };
+    fetchOrdersMock.mockResolvedValue([order]);
+
+    const store = useNotificationsStore();
+    let provider: (
+      type: NotificationType
+    ) => Iterable<NotificationHandler<unknown>> = () => [];
+    const notificationsService = new NotificationsService();
+    vi.spyOn(notificationsService, 'setHandlerProvider').mockImplementation(
+      (p) => {
+        provider = p;
+      }
+    );
+    vi.spyOn(notificationsService, 'start').mockResolvedValue(undefined);
+    const orderService = { getOrders: vi.fn() };
+
+    await store.initialize(
+      notificationsService,
+      orderService as unknown as OrderService
+    );
+
+    const [handler] = Array.from(provider(NotificationType.ORDER_RECEIVED));
+    await handler({
+      type: NotificationType.ORDER_RECEIVED,
+      timestamp: new Date().toISOString(),
+      payload: { orderId: 'order-1' },
+    });
+
+    expect(fetchOrdersMock).toHaveBeenCalledWith(orderService);
+    expect(showSnackbarMock).toHaveBeenCalledTimes(1);
+    expect(showSnackbarMock).toHaveBeenCalledWith(
+      'Received Trial List for file Criminal - 12345-1 with priority class: High',
+      'light',
+      'Trial List received!',
+      15000,
+      expect.objectContaining({ label: 'View package #12345' })
+    );
+
+    const action = showSnackbarMock.mock.calls[0][4];
+    action.onClick();
+    expect(viewOrderDetailsMock).toHaveBeenCalledWith(order);
+  });
+
+  it('shows fallback snackbar when received order is missing', async () => {
+    fetchOrdersMock.mockResolvedValue([]);
+
+    const store = useNotificationsStore();
+    let provider: (
+      type: NotificationType
+    ) => Iterable<NotificationHandler<unknown>> = () => [];
+    const notificationsService = new NotificationsService();
+    vi.spyOn(notificationsService, 'setHandlerProvider').mockImplementation(
+      (p) => {
+        provider = p;
+      }
+    );
+    vi.spyOn(notificationsService, 'start').mockResolvedValue(undefined);
+
+    await store.initialize(notificationsService, {} as OrderService);
+    const [handler] = Array.from(provider(NotificationType.ORDER_RECEIVED));
+
+    await handler({
+      type: NotificationType.ORDER_RECEIVED,
+      timestamp: new Date().toISOString(),
+      payload: { orderId: 'missing-order' },
+    });
+
+    expect(showSnackbarMock).toHaveBeenCalledWith(
+      'Package received requiring signature/action',
+      'light',
+      'Notification received!',
+      15000,
+      expect.objectContaining({ label: 'View orders/applications' })
+    );
+  });
+});

--- a/web/tests/stores/OrderStore.test.ts
+++ b/web/tests/stores/OrderStore.test.ts
@@ -278,6 +278,32 @@ describe('OrdersStore', () => {
     });
   });
 
+  describe('fetchOrders return value', () => {
+    it('returns orders returned by service', async () => {
+      (
+        mockOrderService.getOrders as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce(mockOrders);
+
+      const result = await store.fetchOrders(mockOrderService as OrderService);
+
+      expect(result).toEqual(mockOrders);
+    });
+
+    it('returns empty array when service throws', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      (
+        mockOrderService.getOrders as ReturnType<typeof vi.fn>
+      ).mockRejectedValueOnce(new Error('API Error'));
+
+      const result = await store.fetchOrders(mockOrderService as OrderService);
+
+      expect(result).toEqual([]);
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
   describe('reset', () => {
     it('should reset all state to initial values', () => {
       // Set some data first

--- a/web/tests/stores/SnackbarStore.test.ts
+++ b/web/tests/stores/SnackbarStore.test.ts
@@ -1,12 +1,12 @@
-import { setActivePinia, createPinia } from 'pinia'
 import { useSnackbarStore } from '@/stores/SnackbarStore';
+import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('SnackBarStore', () => {
   let store: ReturnType<typeof useSnackbarStore>;
 
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createPinia());
     store = useSnackbarStore();
   });
 
@@ -16,6 +16,8 @@ describe('SnackBarStore', () => {
     expect(store.color).toBe('success');
     expect(store.title).toBe('');
     expect(store.timeout).toBe(undefined);
+    expect(store.actionLabel).toBe('');
+    expect(store.actionHandler).toBeNull();
   });
 
   it('shows snackbar with given arguments', () => {
@@ -34,5 +36,32 @@ describe('SnackBarStore', () => {
     expect(store.color).toBe('success');
     expect(store.title).toBe('');
     expect(store.timeout).toBe(15000);
+    expect(store.actionLabel).toBe('');
+    expect(store.actionHandler).toBeNull();
+  });
+
+  it('stores snackbar action when provided', () => {
+    const onClick = () => undefined;
+
+    store.showSnackbar('Message', 'info', 'Title', 5000, {
+      label: 'View package',
+      onClick,
+    });
+
+    expect(store.actionLabel).toBe('View package');
+    expect(store.actionHandler).toBe(onClick);
+  });
+
+  it('clears snackbar action when hidden', () => {
+    store.showSnackbar('Message', 'info', 'Title', 5000, {
+      label: 'View package',
+      onClick: () => undefined,
+    });
+
+    store.hideSnackbar();
+
+    expect(store.isVisible).toBe(false);
+    expect(store.actionLabel).toBe('');
+    expect(store.actionHandler).toBeNull();
   });
 });

--- a/web/tests/utils/orderDetails.test.ts
+++ b/web/tests/utils/orderDetails.test.ts
@@ -1,4 +1,3 @@
-import shared from '@/components/shared';
 import { Order } from '@/types';
 import {
   viewOrderDetails,
@@ -6,13 +5,23 @@ import {
 } from '@/utils/orderDetails';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { openOrderDocumentsMock, getCourtClassLabelMock, isCriminalMock } =
+  vi.hoisted(() => ({
+    openOrderDocumentsMock: vi.fn(),
+    getCourtClassLabelMock: vi.fn(),
+    isCriminalMock: vi.fn(),
+  }));
+
 vi.mock('@/components/shared', () => ({
   default: {
-    openOrderDocuments: vi.fn(),
+    openOrderDocuments: openOrderDocumentsMock,
   },
 }));
 
-const openOrderDocumentsMock = vi.mocked(shared.openOrderDocuments);
+vi.mock('@/utils/utils', () => ({
+  getCourtClassLabel: getCourtClassLabelMock,
+  isCourtClassLabelCriminal: isCriminalMock,
+}));
 
 const createOrder = (overrides: Partial<Order> = {}): Order =>
   ({
@@ -42,7 +51,6 @@ describe('orderDetails', () => {
   describe('viewOrderDetails', () => {
     it('opens the referred package document with its type description', () => {
       const order = createOrder({
-        packageDocumentId: '100',
         packageDocuments: [
           {
             documentId: 100,
@@ -56,6 +64,8 @@ describe('orderDetails', () => {
           },
         ],
       });
+      getCourtClassLabelMock.mockReturnValue('Criminal');
+      isCriminalMock.mockReturnValue(true);
 
       viewOrderDetails(order);
 
@@ -74,7 +84,6 @@ describe('orderDetails', () => {
 
     it('leaves the document description undefined when no referred document matches', () => {
       const order = createOrder({
-        packageDocumentId: '100',
         courtClass: 'F',
         packageDocuments: [
           {
@@ -84,6 +93,8 @@ describe('orderDetails', () => {
           },
         ],
       });
+      getCourtClassLabelMock.mockReturnValue('Civil');
+      isCriminalMock.mockReturnValue(false);
 
       viewOrderDetails(order);
 
@@ -102,7 +113,6 @@ describe('orderDetails', () => {
 
     it('matches package documents by string-coerced document id', () => {
       const order = createOrder({
-        packageDocumentId: '100',
         packageDocuments: [
           {
             documentId: 100,
@@ -120,6 +130,73 @@ describe('orderDetails', () => {
         expect.arrayContaining([
           expect.objectContaining({
             documentDescription: 'Matched By Coercion',
+          }),
+        ])
+      );
+    });
+
+    it('maps order fields and opens order document for criminal files', () => {
+      const order = createOrder({
+        id: 'order-1',
+        packageDocumentId: 'doc-1',
+        packageName: 'Order package',
+        courtClass: 'CC',
+        courtFileNumber: 'CF-1234',
+        physicalFileId: 'file-1',
+        packageDocuments: [
+          {
+            documentId: 'doc-1',
+            documentTypeDesc: 'Order package',
+            referredDocument: true,
+          },
+        ],
+      });
+      getCourtClassLabelMock.mockReturnValue('Criminal');
+      isCriminalMock.mockReturnValue(true);
+
+      viewOrderDetails(order);
+
+      expect(getCourtClassLabelMock).toHaveBeenCalledWith('CC');
+      expect(isCriminalMock).toHaveBeenCalledWith('Criminal');
+      expect(openOrderDocumentsMock).toHaveBeenCalledWith(
+        'order-1',
+        'CF-1234',
+        expect.arrayContaining([
+          expect.objectContaining({
+            courtClass: 'CC',
+            fileId: 'file-1',
+            fileNumberText: 'CF-1234',
+            documentId: 'doc-1',
+            documentDescription: 'Order package',
+            isCriminal: true,
+            orderId: 'order-1',
+          }),
+        ])
+      );
+    });
+
+    it('sets isCriminal to false for non-criminal files', () => {
+      const order = createOrder({
+        id: 'order-2',
+        courtListType: 'Civil List',
+        packageDocumentId: 'doc-2',
+        packageName: 'Civil order package',
+        courtClass: 'CV',
+        courtFileNumber: 'CV-4321',
+        physicalFileId: 'file-2',
+      });
+      getCourtClassLabelMock.mockReturnValue('Civil');
+      isCriminalMock.mockReturnValue(false);
+
+      viewOrderDetails(order);
+
+      expect(openOrderDocumentsMock).toHaveBeenCalledWith(
+        'order-2',
+        'CV-4321',
+        expect.arrayContaining([
+          expect.objectContaining({
+            isCriminal: false,
+            orderId: 'order-2',
           }),
         ])
       );
@@ -149,6 +226,8 @@ describe('orderDetails', () => {
           },
         ],
       });
+      getCourtClassLabelMock.mockReturnValue('Civil');
+      isCriminalMock.mockReturnValue(false);
 
       viewOrderSupportingDocuments(order);
 
@@ -188,7 +267,6 @@ describe('orderDetails', () => {
             referredDocument: true,
           },
         ],
-        relevantCeisDocuments: [],
       });
 
       viewOrderSupportingDocuments(order);
@@ -202,12 +280,7 @@ describe('orderDetails', () => {
     });
 
     it('passes an empty array when there are no supporting documents', () => {
-      const order = createOrder({
-        packageDocuments: [],
-        relevantCeisDocuments: [],
-      });
-
-      viewOrderSupportingDocuments(order);
+      viewOrderSupportingDocuments(createOrder());
 
       expect(openOrderDocumentsMock).toHaveBeenCalledWith(
         'ORDER1',
@@ -227,6 +300,8 @@ describe('orderDetails', () => {
           },
         ],
       });
+      getCourtClassLabelMock.mockReturnValue('Criminal');
+      isCriminalMock.mockReturnValue(true);
 
       viewOrderSupportingDocuments(order);
 


### PR DESCRIPTION

# Pull Request for JIRA Ticket: ----**JASPER-376**----    

## Issue ticket number and link  
JASPER-376

## Description

Display a snackbar message when an order notification is received (via websocket). This message provides a link to the order for convenience.

Fixes # (issue)  

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by sending an artificial order via postman to pcsstest user, and validating that the vue frontend displayed a message.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   