### PR TITLE
JASPER-817 ensure civil document type code mapped from judicial binder document.

### DIFF
--- a/api/Processors/JudicialBinderProcessor.cs
+++ b/api/Processors/JudicialBinderProcessor.cs
@@ -80,11 +80,18 @@ public class JudicialBinderProcessor : BinderProcessorBase
 
             // Retrieve the full document details for the documents in the binder
             var fileDocuments = await _civilFilesService.GetDocumentsByIds(fileId, binderDocumentIds);
+            var transcriptDocuments = this.Binder.Documents
+                .Where(d => d.DocumentType == Scv.Models.Document.DocumentType.Transcript)
+                .Select(d =>
+                {
+                    d.Category = Scv.Models.Document.DocumentType.Transcript.ToString();
+                    return d;
+                });
 
             var mappedDocuments = _mapper.Map<List<BinderDocumentDto>>(fileDocuments);
 
             // Apply the original ordering
-            this.Binder.Documents = [.. mappedDocuments.OrderBy(d => documentOrder.TryGetValue(d.DocumentId, out var index) ? index : int.MaxValue)];
+            this.Binder.Documents = [.. mappedDocuments.OrderBy(d => documentOrder.TryGetValue(d.DocumentId, out var index) ? index : int.MaxValue), .. transcriptDocuments];
 
             return OperationResult.Success();
         }

--- a/api/Services/BinderService.cs
+++ b/api/Services/BinderService.cs
@@ -420,25 +420,36 @@ public class BinderService(
                 .Where(d => d.DocumentType != DocumentType.File || d.ImageId != null)
                 // Default ordering is dictated by category, then the document's Order property
                 .OrderBy(d => GetCategoryOrder(d.Category))
-                .Select(d => new PdfDocumentRequest
+                .Select(d =>
                 {
-                    Type = d.DocumentType,
-                    Data = new PdfDocumentRequestDetails
+                    var documentId = d.DocumentId;
+                    if (d.DocumentType == DocumentType.File)
                     {
-                        PartId = binder.Labels.GetValue(LabelConstants.PARTICIPANT_ID),
-                        ProfSeqNo = binder.Labels.GetValue(LabelConstants.PROF_SEQ_NUMBER),
-                        CourtLevelCd = binder.Labels.GetValue(LabelConstants.COURT_LEVEL_CD),
-                        CourtClassCd = binder.Labels.GetValue(LabelConstants.COURT_CLASS_CD),
-                        FileId = binder.Labels.GetValue(LabelConstants.PHYSICAL_FILE_ID),
-                        AppearanceId = isCriminal
-                            ? binder.Labels.GetValue(LabelConstants.APPEARANCE_ID)
-                            : d.DocumentId,
-                        IsCriminal = isCriminal,
-                        CorrelationId = correlationId.ToString(),
-                        DocumentId = d.DocumentType == DocumentType.File
-                            ? WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(d.DocumentId))
-                            : d.DocumentId
+                        if (d.Category == "REF")
+                        {
+                            documentId = d.ImageId;
+                        }
+                        documentId = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(documentId));
                     }
+
+                    return new PdfDocumentRequest
+                    {
+                        Type = d.DocumentType,
+                        Data = new PdfDocumentRequestDetails
+                        {
+                            PartId = binder.Labels.GetValue(LabelConstants.PARTICIPANT_ID),
+                            ProfSeqNo = binder.Labels.GetValue(LabelConstants.PROF_SEQ_NUMBER),
+                            CourtLevelCd = binder.Labels.GetValue(LabelConstants.COURT_LEVEL_CD),
+                            CourtClassCd = binder.Labels.GetValue(LabelConstants.COURT_CLASS_CD),
+                            FileId = binder.Labels.GetValue(LabelConstants.PHYSICAL_FILE_ID),
+                            AppearanceId = isCriminal
+                                ? binder.Labels.GetValue(LabelConstants.APPEARANCE_ID)
+                                : d.DocumentId,
+                            IsCriminal = isCriminal,
+                            CorrelationId = correlationId.ToString(),
+                            DocumentId = documentId
+                        }
+                    };
                 });
             bundleRequests.AddRange(binderDocRequests);
         }

--- a/api/Services/BinderService.cs
+++ b/api/Services/BinderService.cs
@@ -228,7 +228,7 @@ public class BinderService(
                 }
 
                 // Exclude documents that does not have ImageId because there is no document to view, and sort by category
-                binder.Documents = [.. binder.Documents.Where(d => d.ImageId != null).OrderBy(d => GetCategoryOrder(d.Category))];
+                binder.Documents = [.. binder.Documents.Where(d => d.ImageId != null || d.OrderId != null).OrderBy(d => GetCategoryOrder(d.Category))];
             }
 
             return OperationResult<DocumentBundleResponse>.Success(new DocumentBundleResponse
@@ -447,7 +447,8 @@ public class BinderService(
                                 : d.DocumentId,
                             IsCriminal = isCriminal,
                             CorrelationId = correlationId.ToString(),
-                            DocumentId = documentId
+                            DocumentId = documentId,
+                            OrderId = d.OrderId
                         }
                     };
                 });

--- a/tests/api/Processors/JudicialBinderProcessorTests.cs
+++ b/tests/api/Processors/JudicialBinderProcessorTests.cs
@@ -198,6 +198,8 @@ public class JudicialBinderProcessorTests
         var redactedDetail = new RedactedCivilFileDetailResponse { Document = [] };
 
         SetupFileClientMocks(fileDetail, fileContent);
+        SetupFileServiceMocks(fileDetail, fileContent, DocumentCategories.BAIL);
+        SetupFileServiceMocks(fileDetail, fileContent, DocumentCategories.BAIL);
 
         _mockMapper
             .Setup(x => x.Map<RedactedCivilFileDetailResponse>(It.IsAny<CivilFileDetailResponse>()))
@@ -505,6 +507,70 @@ public class JudicialBinderProcessorTests
         Assert.True(result.Succeeded);
         Assert.Single(processor.Binder.Documents);
         Assert.Equal("ref-1", processor.Binder.Documents[0].DocumentId);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_Should_Set_Transcript_Category_From_DocumentType()
+    {
+        // Arrange
+        var fileDetail = new CivilFileDetailResponse
+        {
+            Appearance = [],
+            Document = [],
+            ReferenceDocument = []
+        };
+
+        var fileContent = new CivilFileContent
+        {
+            CivilFile =
+            [
+                new CvfcCivilFile
+                {
+                    PhysicalFileID = _fileId
+                }
+            ]
+        };
+
+        var redactedDetail = new RedactedCivilFileDetailResponse { Document = [] };
+
+        SetupFileClientMocks(fileDetail, fileContent);
+        SetupFileServiceMocks(fileDetail, fileContent, DocumentCategories.BAIL);
+
+        _mockMapper
+            .Setup(x => x.Map<RedactedCivilFileDetailResponse>(It.IsAny<CivilFileDetailResponse>()))
+            .Returns(redactedDetail);
+
+        _mockMapper
+            .Setup(x => x.Map<List<BinderDocumentDto>>(It.IsAny<IEnumerable<CivilDocument>>()))
+            .Returns([]);
+
+        var dto = new BinderDto
+        {
+            Labels = new Dictionary<string, string>
+            {
+                { LabelConstants.PHYSICAL_FILE_ID, _fileId }
+            },
+            Documents =
+            [
+                new BinderDocumentDto
+                {
+                    DocumentId = "transcript-1",
+                    DocumentType = DocumentType.Transcript,
+                    Order = 0,
+                    OrderId = "123"
+                }
+            ]
+        };
+
+        var processor = CreateProcessor(dto);
+
+        // Act
+        var result = await processor.ProcessAsync();
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.Single(processor.Binder.Documents);
+        Assert.Equal(DocumentType.Transcript.ToString(), processor.Binder.Documents[0].Category);
     }
 
     [Fact]

--- a/web/src/components/civil/CivilAppearanceDetails.vue
+++ b/web/src/components/civil/CivilAppearanceDetails.vue
@@ -167,7 +167,9 @@
             civilDocumentId: doc.documentId,
             category: doc.category,
             documentTypeCd: doc.category,
-            imageId: doc.imageId,
+            imageId:
+              doc.documentType == 'Transcript' ? doc.documentId : doc.imageId,
+            transcriptOrderId: doc.orderId,
             documentTypeDescription: doc.fileName,
             fileSeqNo: doc.fileSeqNo,
             filedBy: doc.filedBy,

--- a/web/src/components/civil/CivilAppearanceDetails.vue
+++ b/web/src/components/civil/CivilAppearanceDetails.vue
@@ -166,6 +166,7 @@
           ({
             civilDocumentId: doc.documentId,
             category: doc.category,
+            documentTypeCd: doc.category,
             imageId: doc.imageId,
             documentTypeDescription: doc.fileName,
             fileSeqNo: doc.fileSeqNo,

--- a/web/src/components/documents/DocumentUtils.ts
+++ b/web/src/components/documents/DocumentUtils.ts
@@ -60,6 +60,7 @@ export const prepareCivilDocumentData = (data: civilDocumentType) => {
   const civilFileStore = useCivilFileStore();
   const isLitigantDocument =
     data.category?.toLowerCase() === 'reference' ||
+    data.category?.toLowerCase() === 'ref' || // TODO: fix for civil binder documents having the documentTypeCd saving to the category on the backend (see BinderMapping).
     data.category?.toLowerCase() === 'litigant';
   const documentData: DocumentData = {
     appearanceDate: beautifyDate(data.lastAppearanceDt),

--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -1,7 +1,7 @@
 import {
-  usePDFViewerStore,
   useCriminalDocumentBundleStore,
   useJudicialBinderStore,
+  usePDFViewerStore,
 } from '@/stores';
 import { AppearanceDocumentRequest } from '@/types/AppearanceDocumentRequest';
 import { BinderDocumentRequest } from '@/types/BinderDocumentRequest';
@@ -468,6 +468,11 @@ export default {
     )?.name;
 
     const documentType = getCivilDocumentType(document);
+    if (documentType === CourtDocumentType.Transcript) {
+      document.category ??= CourtDocumentType[CourtDocumentType.Transcript]; // backwards compatibility with older judicial binders.
+      documentData.documentId = document.imageId;
+      documentData.orderId = document.transcriptOrderId;
+    }
     this.openDocumentsPdf(documentType, documentData);
   },
 };

--- a/web/src/types/civil/jsonTypes/index.ts
+++ b/web/src/types/civil/jsonTypes/index.ts
@@ -98,6 +98,7 @@ export interface civilDocumentType {
   issue: civilDocumentIssueType[];
   civilDocumentId: string;
   imageId: string;
+  transcriptOrderId: string;
   fileSeqNo: string;
   documentTypeCd: string;
   affidavitNo: string;


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**jasper-817**----    

## Issue ticket number and link  
jasper-817

## Description

Court and reference documents not opening from judicial binder. Likely affects transcripts as well. Root cause is that the civil document type cd field was not being populated.

Fixes # (issue)  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Validated court reference document, transcript able to be opened from within court list judicial binder tab.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   
