### PR TITLE
Enable Snowplow in PROD environment only

### DIFF
--- a/.github/workflows/publish-web-select.yml
+++ b/.github/workflows/publish-web-select.yml
@@ -97,7 +97,6 @@ jobs:
             NGINX_RUNTIME_SRC=../../docker/nginx-runtime
             VUE_ON_NGINX_SRC=../../docker/vue-on-nginx
             WEB_SRC=../../web
-            VITE_ENV=${{ github.event.inputs.environment }}
 
   deploy2env:
     name: Deploy to ENV

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -92,7 +92,6 @@ jobs:
             NGINX_RUNTIME_SRC=../../docker/nginx-runtime
             VUE_ON_NGINX_SRC=../../docker/vue-on-nginx
             WEB_SRC=../../web
-            VITE_ENV=${{ github.event.inputs.environment }}
 
   deploy2dev:
     name: Deploy to DEV

--- a/docker/vue-on-nginx/s2i/bin/fix-base-url
+++ b/docker/vue-on-nginx/s2i/bin/fix-base-url
@@ -13,4 +13,17 @@ do
 	printf "%s" "$tmp" > "$f";
 done
 
+# Conditionally inject the Snowplow analytics <script> tag into index.html.
+# The vite build always emits the "<!-- S2I_INJECT_SNOWPLOW -->" placeholder
+# and always ships snowplow.js in the bundle. The runtime wires up the
+# script only when ENABLE_SNOWPLOW=true; otherwise the placeholder is stripped.
+if [ "${ENABLE_SNOWPLOW}" = "true" ]; then
+    SNOWPLOW_TAG='<script src="/snowplow.js" charset="UTF-8"></script>'
+    echo "---> ENABLE_SNOWPLOW=true: injecting snowplow.js into index.html..."
+else
+    SNOWPLOW_TAG=''
+    echo "---> ENABLE_SNOWPLOW!=true: stripping snowplow placeholder from index.html..."
+fi
+sed -i "s|<!-- S2I_INJECT_SNOWPLOW -->|${SNOWPLOW_TAG}|" /tmp/app/dist/index.html
+
 /usr/libexec/s2i/run

--- a/docker/web/Dockerfile.release
+++ b/docker/web/Dockerfile.release
@@ -66,7 +66,6 @@ FROM registry.access.redhat.com/ubi9/nodejs-${NODE_VERSION} AS artifacts
 ARG NODE_VERSION
 ARG WEB_SRC
 ARG NPM_INSTALL_ARGS
-ARG VITE_ENV
 
 USER root
 WORKDIR /opt/app-root/src
@@ -79,9 +78,6 @@ RUN npm ci ${NPM_INSTALL_ARGS} --ignore-scripts
 
 # Copy the rest of the code
 COPY ${WEB_SRC} .
-
-# Set VITE_ENV as an environment variable for the build
-ENV VITE_ENV=${VITE_ENV}
 
 RUN npm run build 
 

--- a/infrastructure/cloud/environments/lz-dev/main.tf
+++ b/infrastructure/cloud/environments/lz-dev/main.tf
@@ -114,14 +114,14 @@ module "tg_web" {
 }
 
 module "tg_api" {
-  source            = "../../modules/TargetGroup"
-  environment       = var.environment
-  app_name          = var.app_name
-  name              = "api"
-  port              = 5000
-  health_check_path = "/api/test/headers"
-  vpc_id            = data.aws_vpc.vpc.id
-  protocol          = "HTTP"
+  source                     = "../../modules/TargetGroup"
+  environment                = var.environment
+  app_name                   = var.app_name
+  name                       = "api"
+  port                       = 5000
+  health_check_path          = "/api/test/headers"
+  vpc_id                     = data.aws_vpc.vpc.id
+  protocol                   = "HTTP"
   stickiness_enabled         = true
   stickiness_cookie_duration = 36000
 }
@@ -262,6 +262,12 @@ module "ecs_web_td" {
   log_group_name         = module.ecs_web_td_log_group.log_group.name
   cpu                    = var.web_ecs_config.cpu
   memory_size            = var.web_ecs_config.memory_size
+  env_variables = [
+    {
+      name  = "ENABLE_SNOWPLOW"
+      value = "true"
+    }
+  ]
 }
 
 # SNS Topic for ECS Alerts

--- a/infrastructure/cloud/environments/lz-dev/main.tf
+++ b/infrastructure/cloud/environments/lz-dev/main.tf
@@ -262,12 +262,6 @@ module "ecs_web_td" {
   log_group_name         = module.ecs_web_td_log_group.log_group.name
   cpu                    = var.web_ecs_config.cpu
   memory_size            = var.web_ecs_config.memory_size
-  env_variables = [
-    {
-      name  = "ENABLE_SNOWPLOW"
-      value = "true"
-    }
-  ]
 }
 
 # SNS Topic for ECS Alerts

--- a/infrastructure/cloud/environments/lz-prod/main.tf
+++ b/infrastructure/cloud/environments/lz-prod/main.tf
@@ -114,14 +114,14 @@ module "tg_web" {
 }
 
 module "tg_api" {
-  source            = "../../modules/TargetGroup"
-  environment       = var.environment
-  app_name          = var.app_name
-  name              = "api"
-  port              = 5000
-  health_check_path = "/api/test/headers"
-  vpc_id            = data.aws_vpc.vpc.id
-  protocol          = "HTTP"
+  source                     = "../../modules/TargetGroup"
+  environment                = var.environment
+  app_name                   = var.app_name
+  name                       = "api"
+  port                       = 5000
+  health_check_path          = "/api/test/headers"
+  vpc_id                     = data.aws_vpc.vpc.id
+  protocol                   = "HTTP"
   stickiness_enabled         = true
   stickiness_cookie_duration = 36000
 }
@@ -262,6 +262,12 @@ module "ecs_web_td" {
   log_group_name         = module.ecs_web_td_log_group.log_group.name
   cpu                    = var.web_ecs_config.cpu
   memory_size            = var.web_ecs_config.memory_size
+  env_variables = [
+    {
+      name  = "ENABLE_SNOWPLOW"
+      value = "true"
+    }
+  ]
 }
 
 # SNS Topic for ECS Alerts

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -15,34 +15,31 @@ console.log('[vite] VITE_WS_PROXY_ORIGIN:', wsProxyOrigin);
 console.log('[vite] VITE_WS_PROXY_INSECURE:', wsProxyInsecure);
 
 export default defineConfig(({ mode }) => {
-  const isProd = Boolean(process.env.VITE_ENV?.includes('prod'));
-
-  // Base plugins array
-  const plugins = [vue(), svgLoader(), Components({}), basicSsl()];
-
-  // Conditionally static copy prod-only files
-  if (isProd) {
-    plugins.push(
-      viteStaticCopy({
-        targets: [
-          {
-            src: path.resolve(__dirname, 'snowplow.js'),
-            dest: '.',
-          },
-        ],
-      }),
-      // Inject snowplow script tag in HTML for prod builds
-      {
-        name: 'inject-snowplow',
-        transformIndexHtml(html) {
-          return html.replace(
-            '</head>',
-            '    <script src="/snowplow.js" charset="UTF-8"></script>\n  </head>'
-          );
+  const plugins = [
+    vue(),
+    svgLoader(),
+    Components({}),
+    basicSsl(),
+    viteStaticCopy({
+      targets: [
+        {
+          src: path.resolve(__dirname, 'snowplow.js'),
+          dest: '.',
         },
-      }
-    );
-  }
+      ],
+    }),
+    // Inject a placeholder for the Snowplow script, which will be replaced by the backend with the actual script tag.
+    // This allows us to load the Snowplow script from a dynamic URL, which is necessary for S2I.
+    {
+      name: 'inject-snowplow-placeholder',
+      transformIndexHtml(html) {
+        return html.replace(
+          '</head>',
+          '    <!-- S2I_INJECT_SNOWPLOW -->\n  </head>'
+        );
+      },
+    },
+  ];
 
   return {
     base:


### PR DESCRIPTION
When the [Deploy Web](https://github.com/bcgov/jasper/actions/workflows/publish-web.yml) pipeline runs, web analytics isn't active in production. Snowplow was being injected at build time but the pipeline builds a single image and promotes it to all three environments so the previous implementation can't target PROD only.

This PR moves the logic to runtime:
- vite.config.js always ships snowplow.js and emits a placeholder in index.html.
- The nginx entrypoint replaces the placeholder with the `<script>` tag only when `ENABLE_SNOWPLOW=true`.
- Terraform sets `ENABLE_SNOWPLOW=true` on the `lz-prod` web task only; DEV/TEST are unaffected.