### PR TITLE
JASPER-826: Signing and Digital Workflow: Provide 2 different counts for Priority and Regular Orders in the header

### DIFF
--- a/web/src/assets/colors.css
+++ b/web/src/assets/colors.css
@@ -26,6 +26,8 @@
   --bg-purple-300: #ae81be;
   --bg-purple-500: #79368f;
 
+  --bg-red-500: #db1e05;
+
   --bg-white-500: #ffffff;
   --bg-white-600: #f9f9f9;
 

--- a/web/src/components/shared/AppBar.vue
+++ b/web/src/components/shared/AppBar.vue
@@ -26,7 +26,7 @@
       <v-tab value="orders" to="/orders" v-if="showOrders">
         <v-badge
           v-if="priorityPendingOrdersCount > 0 && regularPendingOrdersCount > 0"
-          data-testid="order-badge"
+          data-testid="order-combo-badge"
           :class="{
             'badge-pulse': badgePulseActive,
             'order-combo-badge': true,
@@ -52,7 +52,7 @@
         </v-badge>
         <v-badge
           v-else-if="priorityPendingOrdersCount > 0"
-          data-testid="order-badge"
+          data-testid="priority-badge"
           :content="priorityPendingOrdersCount"
           :class="{ 'badge-pulse': badgePulseActive }"
           color="var(--bg-red-500)"
@@ -64,7 +64,7 @@
         </v-badge>
         <v-badge
           v-else-if="regularPendingOrdersCount > 0"
-          data-testid="order-badge"
+          data-testid="regular-badge"
           :content="regularPendingOrdersCount"
           :class="{ 'badge-pulse': badgePulseActive }"
           color="var(--bg-green-500)"
@@ -107,6 +107,8 @@
         </v-btn>
       </div>
     </v-tabs>
+    {{ regularPendingOrdersCount }}
+    {{ priorityPendingOrdersCount }}
   </v-app-bar>
 </template>
 

--- a/web/src/components/shared/AppBar.vue
+++ b/web/src/components/shared/AppBar.vue
@@ -25,11 +25,42 @@
       >
       <v-tab value="orders" to="/orders" v-if="showOrders">
         <v-badge
+          v-if="priorityPendingOrdersCount > 0 && regularPendingOrdersCount > 0"
           data-testid="order-badge"
-          v-if="pendingOrdersCount > 0"
-          :content="pendingOrdersCount"
+          :class="{
+            'badge-pulse': badgePulseActive,
+            'order-combo-badge': true,
+          }"
+          offset-x="0"
+          offset-y="-10"
+        >
+          <template #badge>
+            <span class="capsule-half priority">
+              {{ priorityPendingOrdersCount }}
+            </span>
+            <span class="capsule-half regular">
+              {{ regularPendingOrdersCount }}
+            </span>
+          </template>
+          For Signing
+        </v-badge>
+        <v-badge
+          v-else-if="priorityPendingOrdersCount > 0"
+          data-testid="order-badge"
+          :content="priorityPendingOrdersCount"
+          :class="{ 'badge-pulse': badgePulseActive, 'priority-badge': true }"
+          color="var(--bg-red-500)"
+          offset-x="-10"
+          offset-y="-10"
+        >
+          For Signing
+        </v-badge>
+        <v-badge
+          v-else-if="regularPendingOrdersCount > 0"
+          data-testid="order-badge"
+          :content="regularPendingOrdersCount"
           :class="{ 'badge-pulse': badgePulseActive }"
-          color="error"
+          color="var(--bg-green-500)"
           offset-x="-10"
           offset-y="-10"
         >
@@ -80,7 +111,11 @@
   import { useNotificationsStore } from '@/stores/NotificationsStore';
   import { useOrdersStore } from '@/stores/OrdersStore';
   import { PersonSearchItem } from '@/types';
-  import { OrderReviewStatus, RolesEnum } from '@/types/common';
+  import {
+    OrderPriorityEnum,
+    OrderReviewStatus,
+    RolesEnum,
+  } from '@/types/common';
   import { mdiAccountCircle } from '@mdi/js';
   import { computed, inject, nextTick, onMounted, ref, watch } from 'vue';
   import { useRoute } from 'vue-router';
@@ -103,6 +138,7 @@
   const judges = ref<PersonSearchItem[]>([]);
   // Only users with Admin role can see Orders tab for now.
   const requiredOrderRoles = [RolesEnum.Admin] as const;
+  const priorityOrderTypes = new Set<string>(Object.values(OrderPriorityEnum));
 
   if (!judgeService || !orderService || !notificationsService) {
     throw new Error('Service is not available!');
@@ -145,7 +181,7 @@
   );
 
   const canInitializeNotifications = computed(
-    () => !commonStore.isInitializing && !!commonStore.userInfo
+    () => !commonStore.isInitialized && !!commonStore.userInfo
   );
 
   const canInitializeOrderFeatures = computed(
@@ -187,16 +223,29 @@
       judges.value.length > 0
   );
 
-  const pendingOrdersCount = computed(
+  const priorityPendingOrdersCount = computed(
     () =>
-      ordersStore.orders.filter((o) => o.status === OrderReviewStatus.Pending)
-        .length
+      // ordersStore.orders.filter(
+      //   (o) =>
+      //     o.status === OrderReviewStatus.Pending &&
+      //     priorityOrderTypes.has(o.priorityType)
+      // ).length
+      0
+  );
+
+  const regularPendingOrdersCount = computed(
+    () =>
+      ordersStore.orders.filter(
+        (o) =>
+          o.status === OrderReviewStatus.Pending &&
+          !priorityOrderTypes.has(o.priorityType)
+      ).length
   );
 
   const badgePulseActive = ref(false);
 
   const triggerBadgePulse = async () => {
-    if (pendingOrdersCount.value === 0) {
+    if (priorityPendingOrdersCount.value === 0) {
       return;
     }
 
@@ -215,7 +264,7 @@
     }
   );
 
-  watch(pendingOrdersCount, (newCount, oldCount) => {
+  watch(priorityPendingOrdersCount, (newCount, oldCount) => {
     if (newCount === oldCount || newCount === 0) {
       return;
     }
@@ -248,6 +297,38 @@
 
   .badge-pulse :deep(.v-badge__badge) {
     animation: badge-pop 0.35s ease-out;
+  }
+
+  .order-combo-badge :deep(.v-badge__badge) {
+    padding: 0;
+    min-width: auto;
+    height: 18px;
+    overflow: hidden;
+    background: transparent;
+  }
+
+  .order-combo-badge :deep(.v-badge__badge) .capsule-half {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 100%;
+    padding: 0 6px;
+    font-size: 0.75rem;
+    line-height: 1;
+    color: var(--bg-white-500);
+  }
+
+  .order-combo-badge :deep(.v-badge__badge) .capsule-half.priority {
+    background-color: var(--bg-red-500);
+  }
+
+  .order-combo-badge :deep(.v-badge__badge) .capsule-half.regular {
+    background-color: var(--bg-green-500);
+  }
+
+  .regular-badge {
+    background-color: var(--bg-green-500);
   }
 
   @keyframes badge-pop {

--- a/web/src/components/shared/AppBar.vue
+++ b/web/src/components/shared/AppBar.vue
@@ -35,10 +35,16 @@
           offset-y="-10"
         >
           <template #badge>
-            <span class="capsule-half priority">
+            <span
+              class="capsule-half priority"
+              :title="`${priorityPendingOrdersCount} priority orders pending`"
+            >
               {{ priorityPendingOrdersCount }}
             </span>
-            <span class="capsule-half regular">
+            <span
+              class="capsule-half regular"
+              :title="`${regularPendingOrdersCount} regular orders pending`"
+            >
               {{ regularPendingOrdersCount }}
             </span>
           </template>
@@ -48,8 +54,9 @@
           v-else-if="priorityPendingOrdersCount > 0"
           data-testid="order-badge"
           :content="priorityPendingOrdersCount"
-          :class="{ 'badge-pulse': badgePulseActive, 'priority-badge': true }"
+          :class="{ 'badge-pulse': badgePulseActive }"
           color="var(--bg-red-500)"
+          :title="`${priorityPendingOrdersCount} priority orders pending`"
           offset-x="-10"
           offset-y="-10"
         >
@@ -61,6 +68,7 @@
           :content="regularPendingOrdersCount"
           :class="{ 'badge-pulse': badgePulseActive }"
           color="var(--bg-green-500)"
+          :title="`${regularPendingOrdersCount} regular orders pending`"
           offset-x="-10"
           offset-y="-10"
         >
@@ -181,7 +189,7 @@
   );
 
   const canInitializeNotifications = computed(
-    () => !commonStore.isInitialized && !!commonStore.userInfo
+    () => commonStore.isInitialized && !!commonStore.userInfo
   );
 
   const canInitializeOrderFeatures = computed(
@@ -225,12 +233,11 @@
 
   const priorityPendingOrdersCount = computed(
     () =>
-      // ordersStore.orders.filter(
-      //   (o) =>
-      //     o.status === OrderReviewStatus.Pending &&
-      //     priorityOrderTypes.has(o.priorityType)
-      // ).length
-      0
+      ordersStore.orders.filter(
+        (o) =>
+          o.status === OrderReviewStatus.Pending &&
+          priorityOrderTypes.has(o.priorityType)
+      ).length
   );
 
   const regularPendingOrdersCount = computed(
@@ -245,7 +252,10 @@
   const badgePulseActive = ref(false);
 
   const triggerBadgePulse = async () => {
-    if (priorityPendingOrdersCount.value === 0) {
+    if (
+      priorityPendingOrdersCount.value === 0 ||
+      regularPendingOrdersCount.value === 0
+    ) {
       return;
     }
 
@@ -264,11 +274,7 @@
     }
   );
 
-  watch(priorityPendingOrdersCount, (newCount, oldCount) => {
-    if (newCount === oldCount || newCount === 0) {
-      return;
-    }
-
+  watch([priorityPendingOrdersCount, regularPendingOrdersCount], () => {
     void triggerBadgePulse();
   });
 </script>
@@ -324,10 +330,6 @@
   }
 
   .order-combo-badge :deep(.v-badge__badge) .capsule-half.regular {
-    background-color: var(--bg-green-500);
-  }
-
-  .regular-badge {
     background-color: var(--bg-green-500);
   }
 

--- a/web/src/types/common/index.ts
+++ b/web/src/types/common/index.ts
@@ -182,6 +182,12 @@ export enum OrderReviewStatus {
   AwaitingDocumentation = 'AwaitingDocumentation',
 }
 
+export enum OrderPriorityEnum {
+  ProtectionOrders = 'PRO',
+  CourtDirected = 'CRTD',
+  Other = 'OTHR',
+}
+
 export enum RolesEnum {
   Admin = 'System Administrator',
   Trainer = 'Trainer',

--- a/web/tests/components/shared/AppBar.test.ts
+++ b/web/tests/components/shared/AppBar.test.ts
@@ -1,4 +1,4 @@
-import { useCommonStore, useDarsStore } from '@/stores';
+import { useCommonStore, useDarsStore, useOrdersStore } from '@/stores';
 import { ApplicationConfigurationKey } from '@/stores/CommonStore';
 import { PersonSearchItem } from '@/types';
 import {
@@ -13,6 +13,7 @@ import { flushPromises, mount } from '@vue/test-utils';
 import AppBar from 'CMP/shared/AppBar.vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
 import { createRouter, createWebHistory } from 'vue-router';
 
 // Mock the JudgeSelector component
@@ -305,6 +306,36 @@ describe('AppBar.vue', () => {
       expect((wrapper.vm as any).showOrders).toBe(true);
     });
 
+    it('should display priority pending orders badge when there are priority pending orders', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
+
+      const mockOrders = [
+        generateOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.ProtectionOrders
+        ),
+        generateOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.CourtDirected
+        ),
+        generateOrder(OrderReviewStatus.Approved),
+      ];
+
+      mockOrderService.getOrders.mockResolvedValue(mockOrders);
+      const orderStore = useOrdersStore();
+      orderStore.orders = mockOrders;
+
+      const wrapper = createWrapper();
+      await flushPromises();
+
+      const badge = wrapper.find('[data-testid="priority-badge"]');
+
+      expect(badge.exists()).toBe(true);
+      expect(badge.attributes('content')).toBe('2');
+      expect((wrapper.vm as any).priorityPendingOrdersCount).toBe(2);
+    });
+
     it('should display regular pending orders badge when there are non-priority pending orders', async () => {
       const commonStore = useCommonStore();
       commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
@@ -316,11 +347,13 @@ describe('AppBar.vue', () => {
       ];
 
       mockOrderService.getOrders.mockResolvedValue(mockOrders);
+      const orderStore = useOrdersStore();
+      orderStore.orders = mockOrders;
 
       const wrapper = createWrapper();
       await flushPromises();
 
-      const badge = wrapper.find('[data-testid="order-badge"]');
+      const badge = wrapper.find('[data-testid="regular-badge"]');
 
       expect(badge.exists()).toBe(true);
       expect(badge.attributes('content')).toBe('2');
@@ -343,7 +376,7 @@ describe('AppBar.vue', () => {
       expect(wrapper.find('[data-testid="order-badge"]').exists()).toBe(false);
     });
 
-    it('should classify priority order types using OrderPriorityEnum', async () => {
+    it('should show order-combo-badge element when there are both priority and regular pending orders', async () => {
       const commonStore = useCommonStore();
       commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
 
@@ -361,11 +394,14 @@ describe('AppBar.vue', () => {
 
       mockOrderService.getOrders.mockResolvedValue(mockOrders);
 
+      const orderStore = useOrdersStore();
+      orderStore.orders = mockOrders;
+
       const wrapper = createWrapper();
       await flushPromises();
 
-      // Only non-priority pending orders count toward regular badge.
-      expect((wrapper.vm as any).regularPendingOrdersCount).toBe(1);
+      const comboBadge = wrapper.find('[data-testid="order-combo-badge"]');
+      expect(comboBadge.exists()).toBe(true);
     });
   });
 

--- a/web/tests/components/shared/AppBar.test.ts
+++ b/web/tests/components/shared/AppBar.test.ts
@@ -3,6 +3,7 @@ import { ApplicationConfigurationKey } from '@/stores/CommonStore';
 import { PersonSearchItem } from '@/types';
 import {
   ApplicationInfo,
+  OrderPriorityEnum,
   OrderReviewStatus,
   RolesEnum,
   UserInfo,
@@ -62,15 +63,20 @@ const generateUserInfo = (overrides: Partial<UserInfo> = {}): UserInfo => ({
   ...overrides,
 });
 
-const generateOrder = (status: OrderReviewStatus) => ({
+const generateOrder = (
+  status: OrderReviewStatus,
+  priorityType: string = 'NONPRIORITY'
+) => ({
   id: faker.string.uuid(),
   status,
+  priorityType,
   packageId: faker.number.int({ min: 1000, max: 99999 }),
   packageDocumentId: faker.string.uuid(),
   packageName: faker.lorem.word(),
   receivedDate: faker.date.past().toISOString().split('T')[0],
   processedDate: faker.date.past().toISOString().split('T')[0],
   courtClass: faker.helpers.arrayElement(['CC', 'CV']),
+  courtListType: faker.helpers.arrayElement(['Daily', 'Weekly']),
   courtFileNumber: faker.string.alphanumeric({ length: 10 }).toUpperCase(),
   styleOfCause: `${faker.person.lastName()} v ${faker.person.lastName()}`,
   physicalFileId: faker.number.int().toString(),
@@ -299,7 +305,7 @@ describe('AppBar.vue', () => {
       expect((wrapper.vm as any).showOrders).toBe(true);
     });
 
-    it('should display pending orders badge when there are pending orders', async () => {
+    it('should display regular pending orders badge when there are non-priority pending orders', async () => {
       const commonStore = useCommonStore();
       commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
 
@@ -318,6 +324,7 @@ describe('AppBar.vue', () => {
 
       expect(badge.exists()).toBe(true);
       expect(badge.attributes('content')).toBe('2');
+      expect((wrapper.vm as any).regularPendingOrdersCount).toBe(2);
     });
 
     it('should not display badge when there are no pending orders', async () => {
@@ -331,7 +338,34 @@ describe('AppBar.vue', () => {
       const wrapper = createWrapper();
       await flushPromises();
 
-      expect((wrapper.vm as any).pendingOrdersCount).toBe(0);
+      expect((wrapper.vm as any).regularPendingOrdersCount).toBe(0);
+      expect((wrapper.vm as any).priorityPendingOrdersCount).toBe(0);
+      expect(wrapper.find('[data-testid="order-badge"]').exists()).toBe(false);
+    });
+
+    it('should classify priority order types using OrderPriorityEnum', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
+
+      const mockOrders = [
+        generateOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.ProtectionOrders
+        ),
+        generateOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.CourtDirected
+        ),
+        generateOrder(OrderReviewStatus.Pending),
+      ];
+
+      mockOrderService.getOrders.mockResolvedValue(mockOrders);
+
+      const wrapper = createWrapper();
+      await flushPromises();
+
+      // Only non-priority pending orders count toward regular badge.
+      expect((wrapper.vm as any).regularPendingOrdersCount).toBe(1);
     });
   });
 


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-826

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-826

## Description
Show different badge for Priority, Regular and Mixed pendings orders.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Local  

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screenshots
<img width="628" height="338" alt="image" src="https://github.com/user-attachments/assets/8b53fbb4-d6bd-40d9-aef1-ace081f16c86" />
