### PR TITLE
Update TF RDS script to match engine version in AWS

### DIFF
--- a/infrastructure/cloud/modules/RDS/main.tf
+++ b/infrastructure/cloud/modules/RDS/main.tf
@@ -12,7 +12,7 @@ resource "aws_db_instance" "postgres_db_instance" {
   allocated_storage                   = 20
   storage_type                        = "gp2"
   engine                              = "postgres"
-  engine_version                      = "16.8"
+  engine_version                      = "16.13"
   instance_class                      = "db.t3.micro"
   db_name                             = "${var.app_name}postgresdb${replace(var.environment, "-", "")}"
   username                            = var.db_username


### PR DESCRIPTION
Current TF code is failing because the engine version is outdated (`16.8`). Updating it to `16.13` to match what is deployed in AWS.