### PR TITLE
unflatten transistory documents and passthrough outlines.

### DIFF
--- a/api/Documents/DefaultPdfMergePreparationStrategy.cs
+++ b/api/Documents/DefaultPdfMergePreparationStrategy.cs
@@ -1,0 +1,13 @@
+using Scv.Models.Document;
+
+namespace Scv.Api.Documents;
+
+public class DefaultPdfMergePreparationStrategy : IPdfMergePreparationStrategy
+{
+    public PdfMergePreparationMode PreparationMode => PdfMergePreparationMode.Flatten;
+
+    public bool CanHandle(PdfDocumentRequest documentRequest)
+    {
+        return documentRequest?.Type != DocumentType.TransitoryDocument;
+    }
+}

--- a/api/Documents/DocumentMerger.cs
+++ b/api/Documents/DocumentMerger.cs
@@ -13,6 +13,7 @@ namespace Scv.Api.Documents;
 
 public class DocumentMerger(
     IDocumentRetriever documentRetriever,
+    IPdfMergePreparationStrategyResolver preparationStrategyResolver,
     ILogger<DocumentMerger> logger,
     IConfiguration configuration) : IDocumentMerger
 {
@@ -20,6 +21,7 @@ public class DocumentMerger(
     private const string RetrieveBatchSizeKey = "DOCUMENT_RETRIEVAL_BATCH_SIZE";
 
     private readonly IDocumentRetriever documentRetriever = documentRetriever;
+    private readonly IPdfMergePreparationStrategyResolver preparationStrategyResolver = preparationStrategyResolver;
     private readonly ILogger<DocumentMerger> logger = logger;
     private readonly IConfiguration configuration = configuration;
 
@@ -129,8 +131,8 @@ public class DocumentMerger(
                 pageRanges.Add(new PageRange { Start = currentPage, End = currentPage + pageCount });
                 currentPage += pageCount;
 
-                FlattenPdfContent(pdf, documentRequests[i], i);
-                streamsForMerge.Add(SaveFlattenedPdfToStream(pdf, documentRequests[i], i));
+                PreparePdfForMerge(pdf, documentRequests[i], i);
+                streamsForMerge.Add(SavePdfToStream(pdf, documentRequests[i], i));
             }
             finally
             {
@@ -138,6 +140,22 @@ public class DocumentMerger(
                 docStream.Dispose();
                 streamsToMerge[i] = null!;
             }
+        }
+    }
+
+    private void PreparePdfForMerge(GdPicturePDF pdf, PdfDocumentRequest documentRequest, int index)
+    {
+        var preparationMode = preparationStrategyResolver.Resolve(documentRequest);
+
+        switch (preparationMode)
+        {
+            case PdfMergePreparationMode.None:
+                return;
+            case PdfMergePreparationMode.Flatten:
+                FlattenPdfContent(pdf, documentRequest, index);
+                return;
+            default:
+                throw new InvalidOperationException($"Unsupported PDF merge preparation mode: {preparationMode}");
         }
     }
 
@@ -262,16 +280,16 @@ public class DocumentMerger(
         }
     }
 
-    private MemoryStream SaveFlattenedPdfToStream(
+    private MemoryStream SavePdfToStream(
         GdPicturePDF pdf,
         PdfDocumentRequest documentRequest,
         int index)
     {
-        var flattenedDocStream = new MemoryStream();
-        var saveStatus = pdf.SaveToStream(flattenedDocStream);
+        var docStream = new MemoryStream();
+        var saveStatus = pdf.SaveToStream(docStream);
         if (saveStatus != GdPictureStatus.OK)
         {
-            flattenedDocStream.Dispose();
+            docStream.Dispose();
             logger.LogError(
                 "GdPicture failed to save flattened stream {Index} (Type: {Type}) with status: {Status}",
                 index, documentRequest.Type, saveStatus);
@@ -279,8 +297,8 @@ public class DocumentMerger(
                 $"Failed to save flattened document stream {index} (Type: {documentRequest.Type}): {saveStatus}");
         }
 
-        flattenedDocStream.Position = 0;
-        return flattenedDocStream;
+        docStream.Position = 0;
+        return docStream;
     }
 
     private MemoryStream MergeStreams(GdPictureDocumentConverter gdpictureConverter, List<MemoryStream> streamsForMerge)

--- a/api/Documents/IPdfMergePreparationStrategy.cs
+++ b/api/Documents/IPdfMergePreparationStrategy.cs
@@ -1,0 +1,10 @@
+using Scv.Models.Document;
+
+namespace Scv.Api.Documents;
+
+public interface IPdfMergePreparationStrategy
+{
+    bool CanHandle(PdfDocumentRequest documentRequest);
+
+    PdfMergePreparationMode PreparationMode { get; }
+}

--- a/api/Documents/IPdfMergePreparationStrategyResolver.cs
+++ b/api/Documents/IPdfMergePreparationStrategyResolver.cs
@@ -1,0 +1,8 @@
+using Scv.Models.Document;
+
+namespace Scv.Api.Documents;
+
+public interface IPdfMergePreparationStrategyResolver
+{
+    PdfMergePreparationMode Resolve(PdfDocumentRequest documentRequest);
+}

--- a/api/Documents/PdfMergePreparationMode.cs
+++ b/api/Documents/PdfMergePreparationMode.cs
@@ -1,0 +1,7 @@
+namespace Scv.Api.Documents;
+
+public enum PdfMergePreparationMode
+{
+    None,
+    Flatten,
+}

--- a/api/Documents/PdfMergePreparationStrategyResolver.cs
+++ b/api/Documents/PdfMergePreparationStrategyResolver.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Scv.Models.Document;
+
+namespace Scv.Api.Documents;
+
+public class PdfMergePreparationStrategyResolver(
+    IEnumerable<IPdfMergePreparationStrategy> strategies) : IPdfMergePreparationStrategyResolver
+{
+    private readonly IEnumerable<IPdfMergePreparationStrategy> _strategies = strategies;
+
+    public PdfMergePreparationMode Resolve(PdfDocumentRequest documentRequest)
+    {
+        ArgumentNullException.ThrowIfNull(documentRequest);
+
+        var matches = _strategies
+            .Where(strategy => strategy.CanHandle(documentRequest))
+            .ToList();
+
+        return matches.Count switch
+        {
+            1 => matches[0].PreparationMode,
+            0 => throw new InvalidOperationException($"No PDF merge preparation strategy is registered for document type {documentRequest.Type}."),
+            _ => throw new InvalidOperationException($"Multiple PDF merge preparation strategies are registered for document type {documentRequest.Type}.")
+        };
+    }
+}

--- a/api/Documents/Strategies/FileStrategy.cs
+++ b/api/Documents/Strategies/FileStrategy.cs
@@ -47,7 +47,25 @@ public class FileStrategy : IDocumentStrategy
             true,
             documentRequest.CorrelationId);
 
+        if (response?.Stream == null)
+        {
+            throw new InvalidOperationException(
+                $"File document response stream is null for DocumentId {documentId}, FileId {documentRequest.FileId}");
+        }
+
+        if (response.Stream.CanSeek)
+        {
+            response.Stream.Position = 0;
+        }
+
         await response.Stream.CopyToAsync(documentResponseStreamCopy);
+        documentResponseStreamCopy.Position = 0;
+
+        if (documentResponseStreamCopy.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"File document stream is empty for DocumentId {documentId}, FileId {documentRequest.FileId}");
+        }
 
         return documentResponseStreamCopy;
     }

--- a/api/Documents/Strategies/TranscriptStrategy.cs
+++ b/api/Documents/Strategies/TranscriptStrategy.cs
@@ -44,6 +44,11 @@ public class TranscriptStrategy(
 
             var documentStream = new MemoryStream();
 
+            if (response.Stream.CanSeek)
+            {
+                response.Stream.Position = 0;
+            }
+
             // Copy the stream completely before disposing the response
             await response.Stream.CopyToAsync(documentStream);
             response.Dispose();

--- a/api/Documents/Strategies/TransitoryDocumentStrategy.cs
+++ b/api/Documents/Strategies/TransitoryDocumentStrategy.cs
@@ -22,8 +22,25 @@ public class TransitoryDocumentStrategy(
 
         var fileResponse = await _transitoryDocumentsService.DownloadFile(documentRequest.Path);
 
+        if (fileResponse?.Stream == null)
+        {
+            throw new InvalidOperationException(
+                $"Transitory document response stream is null for Path {documentRequest.Path}");
+        }
+
+        if (fileResponse.Stream.CanSeek)
+        {
+            fileResponse.Stream.Position = 0;
+        }
+
         await fileResponse.Stream.CopyToAsync(documentResponseStreamCopy); // follows existing pattern.
         documentResponseStreamCopy.Position = 0;
+
+        if (documentResponseStreamCopy.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"Transitory document stream is empty for Path {documentRequest.Path}");
+        }
 
         var looksLikePdf = HasPdfSignature(documentResponseStreamCopy);
         var headerHex = ReadHeaderHex(documentResponseStreamCopy);

--- a/api/Documents/TransitoryDocumentPdfMergePreparationStrategy.cs
+++ b/api/Documents/TransitoryDocumentPdfMergePreparationStrategy.cs
@@ -1,0 +1,13 @@
+using Scv.Models.Document;
+
+namespace Scv.Api.Documents;
+
+public class TransitoryDocumentPdfMergePreparationStrategy : IPdfMergePreparationStrategy
+{
+    public PdfMergePreparationMode PreparationMode => PdfMergePreparationMode.None;
+
+    public bool CanHandle(PdfDocumentRequest documentRequest)
+    {
+        return documentRequest?.Type == DocumentType.TransitoryDocument;
+    }
+}

--- a/api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/api/Infrastructure/ServiceCollectionExtensions.cs
@@ -84,6 +84,9 @@ namespace Scv.Api.Infrastructure
             services.AddScoped<IDocumentMerger, DocumentMerger>();
             services.AddScoped<IDocumentRetriever, DocumentRetriever>();
             services.AddScoped<IDocumentConverter, DocumentConverter>();
+            services.AddScoped<IPdfMergePreparationStrategyResolver, PdfMergePreparationStrategyResolver>();
+            services.AddScoped<IPdfMergePreparationStrategy, TransitoryDocumentPdfMergePreparationStrategy>();
+            services.AddScoped<IPdfMergePreparationStrategy, DefaultPdfMergePreparationStrategy>();
             services.AddScoped<IDocumentStrategy, FileStrategy>();
             services.AddScoped<IDocumentStrategy, ROPStrategy>();
             services.AddScoped<IDocumentStrategy, ReportStrategy>();

--- a/api/Services/PcssSyncService.cs
+++ b/api/Services/PcssSyncService.cs
@@ -22,6 +22,7 @@ namespace Scv.Api.Services
         IGroupService groupService,
         IJudgeService judgeService,
         IRepositoryBase<Group> groupRepo,
+        IRepositoryBase<Role> roleRepo,
         IRoleService roleService,
         ILogger<PcssSyncService> logger) : IPcssSyncService
     {
@@ -29,6 +30,7 @@ namespace Scv.Api.Services
         private readonly IGroupService _groupService = groupService;
         private readonly IJudgeService _judgeService = judgeService;
         private readonly IRepositoryBase<Group> _groupRepo = groupRepo;
+        private readonly IRepositoryBase<Role> _roleRepo = roleRepo;
         private readonly IRoleService _roleService = roleService;
         private readonly ILogger<PcssSyncService> _logger = logger;
 
@@ -77,12 +79,16 @@ namespace Scv.Api.Services
                     var testingGroupId = (await _groupRepo.FindAsync(g => g.Name == Group.TESTING))
                         .FirstOrDefault()
                         ?.Id;
+                    var developerRoleId = (await roleRepo.FindAsync(g => g.Name == Role.DEVELOPER))
+                        .FirstOrDefault()
+                        ?.Id;
 
-                    if (!string.IsNullOrWhiteSpace(testingGroupId)
+                    if (!string.IsNullOrWhiteSpace(testingGroupId) && !string.IsNullOrWhiteSpace(developerRoleId)
                         && currentGroupIds.Contains(testingGroupId)
                         && !groupIds.Contains(testingGroupId))
                     {
                         groupIds.Add(testingGroupId);
+                        roleIds.Add(developerRoleId);
                     }
                 }
 

--- a/api/Services/PcssSyncService.cs
+++ b/api/Services/PcssSyncService.cs
@@ -79,7 +79,7 @@ namespace Scv.Api.Services
                     var testingGroupId = (await _groupRepo.FindAsync(g => g.Name == Group.TESTING))
                         .FirstOrDefault()
                         ?.Id;
-                    var developerRoleId = (await roleRepo.FindAsync(g => g.Name == Role.DEVELOPER))
+                    var developerRoleId = (await _roleRepo.FindAsync(g => g.Name == Role.DEVELOPER))
                         .FirstOrDefault()
                         ?.Id;
 

--- a/tests/api/Documents/DocumentMergerTests.cs
+++ b/tests/api/Documents/DocumentMergerTests.cs
@@ -1,16 +1,24 @@
 using System;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using GdPicture14;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Scv.Api.Documents;
+using Scv.Api.Documents.Strategies;
+using Scv.Api.Services;
+using Scv.Models;
 using Scv.Models.Document;
 using tests.api.Services;
 using Xunit;
+
+using ScvDocumentType = Scv.Models.Document.DocumentType;
 
 namespace tests.api.Documents;
 
@@ -20,9 +28,10 @@ public class DocumentMergerTest : ServiceTestBase
     public async Task MergeDocuments_RetrievesDocumentsInBatches()
     {
         var retrieverMock = new Mock<IDocumentRetriever>();
+        var preparationStrategyResolverMock = new Mock<IPdfMergePreparationStrategyResolver>();
         var loggerMock = new Mock<ILogger<DocumentMerger>>();
         var configuration = new ConfigurationBuilder().Build();
-        var merger = new DocumentMerger(retrieverMock.Object, loggerMock.Object, configuration);
+        var merger = new DocumentMerger(retrieverMock.Object, preparationStrategyResolverMock.Object, loggerMock.Object, configuration);
 
         var activeRequests = 0;
         var maxConcurrentRequests = 0;
@@ -43,7 +52,7 @@ public class DocumentMergerTest : ServiceTestBase
         var requests = Enumerable.Range(1, 25)
             .Select(index => new PdfDocumentRequest
             {
-                Type = DocumentType.File,
+                Type = ScvDocumentType.File,
                 Data = new PdfDocumentRequestDetails
                 {
                     DocumentId = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes($"doc{index}")),
@@ -62,9 +71,10 @@ public class DocumentMergerTest : ServiceTestBase
     public async Task MergeDocuments_ThrowsInvalidOperationException_WhenStreamUnreadable()
     {
         var retrieverMock = new Mock<IDocumentRetriever>();
+        var preparationStrategyResolverMock = new Mock<IPdfMergePreparationStrategyResolver>();
         var loggerMock = new Mock<ILogger<DocumentMerger>>();
         var configuration = new ConfigurationBuilder().Build();
-        var merger = new DocumentMerger(retrieverMock.Object, loggerMock.Object, configuration);
+        var merger = new DocumentMerger(retrieverMock.Object, preparationStrategyResolverMock.Object, loggerMock.Object, configuration);
         var docId = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes("doc1"));
         var request = new PdfDocumentRequest
         {
@@ -82,6 +92,108 @@ public class DocumentMergerTest : ServiceTestBase
         });
     }
 
+    [Fact]
+    public void PreparePdfForMerge_ThrowsForUnsupportedPreparationMode()
+    {
+        var retrieverMock = new Mock<IDocumentRetriever>();
+        var preparationStrategyResolverMock = new Mock<IPdfMergePreparationStrategyResolver>();
+        var loggerMock = new Mock<ILogger<DocumentMerger>>();
+        var configuration = new ConfigurationBuilder().Build();
+        var merger = new DocumentMerger(retrieverMock.Object, preparationStrategyResolverMock.Object, loggerMock.Object, configuration);
+
+        preparationStrategyResolverMock
+            .Setup(x => x.Resolve(It.IsAny<PdfDocumentRequest>()))
+            .Returns((PdfMergePreparationMode)999);
+
+        var request = new PdfDocumentRequest
+        {
+            Type = ScvDocumentType.TransitoryDocument,
+            Data = new PdfDocumentRequestDetails { Path = "path/to/document.pdf" }
+        };
+
+        using var pdf = new GdPicturePDF();
+        var method = typeof(DocumentMerger).GetMethod("PreparePdfForMerge", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        var exception = Assert.Throws<TargetInvocationException>(() => method!.Invoke(merger, [pdf, request, 0]));
+
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Equal("Unsupported PDF merge preparation mode: 999", exception.InnerException!.Message);
+    }
+
+    [Fact]
+    public async Task MergeDocuments_PreservesBookmarks_ForTransitoryDocuments()
+    {
+        var transitoryDocumentsServiceMock = new Mock<ITransitoryDocumentsService>();
+        var transitoryStrategyLoggerMock = new Mock<ILogger<TransitoryDocumentStrategy>>();
+        var documentRetrieverLoggerMock = new Mock<ILogger<DocumentRetriever>>();
+        var documentMergerLoggerMock = new Mock<ILogger<DocumentMerger>>();
+        var configuration = new ConfigurationBuilder().Build();
+        const string documentPath = "path/to/document.pdf";
+        const string bookmarkTitle = "Transitory Bookmark";
+
+        transitoryDocumentsServiceMock
+            .Setup(x => x.DownloadFile(documentPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new FileStreamResponse(
+                CreatePdfWithBookmark(bookmarkTitle, 2),
+                "transitory.pdf",
+                "application/pdf"));
+
+        var documentRetriever = new DocumentRetriever(
+            [new TransitoryDocumentStrategy(transitoryDocumentsServiceMock.Object, transitoryStrategyLoggerMock.Object)],
+            documentRetrieverLoggerMock.Object);
+        var preparationStrategyResolver = new PdfMergePreparationStrategyResolver(
+            [new DefaultPdfMergePreparationStrategy(), new TransitoryDocumentPdfMergePreparationStrategy()]);
+        var merger = new DocumentMerger(documentRetriever, preparationStrategyResolver, documentMergerLoggerMock.Object, configuration);
+
+        var response = await merger.MergeDocuments([
+            new PdfDocumentRequest
+            {
+                Type = ScvDocumentType.TransitoryDocument,
+                Data = new PdfDocumentRequestDetails
+                {
+                    Path = documentPath,
+                }
+            }
+        ]);
+
+        using var mergedStream = new MemoryStream(Convert.FromBase64String(response.Base64Pdf));
+        using var mergedPdf = new GdPicturePDF();
+        Assert.Equal(GdPictureStatus.OK, mergedPdf.LoadFromStream(mergedStream, true));
+        Assert.Equal(2, mergedPdf.GetPageCount());
+        Assert.Single(response.PageRanges);
+        Assert.Equal(0, response.PageRanges[0].Start);
+        Assert.Equal(2, response.PageRanges[0].End);
+        Assert.Equal(1, mergedPdf.GetBookmarkCount());
+
+        var bookmarkId = mergedPdf.GetBookmarkRootID();
+        Assert.True(bookmarkId > 0);
+        Assert.Equal(bookmarkTitle, mergedPdf.GetBookmarkTitle(bookmarkId));
+
+        var actionId = mergedPdf.GetBookmarkActionID(bookmarkId);
+        Assert.True(actionId > 0);
+
+        var destinationType = PdfDestinationType.DestinationTypeXYZ;
+        var destinationPage = 0;
+        var left = 0f;
+        var bottom = 0f;
+        var right = 0f;
+        var top = 0f;
+        var zoom = 0f;
+
+        Assert.Equal(
+            GdPictureStatus.OK,
+            mergedPdf.GetActionPageDestination(
+                actionId,
+                ref destinationType,
+                ref destinationPage,
+                ref left,
+                ref bottom,
+                ref right,
+                ref top,
+                ref zoom));
+        Assert.Equal(2, destinationPage);
+    }
+
     private static void UpdateMaxConcurrentRequests(ref int maxConcurrentRequests, int current)
     {
         int observedMax;
@@ -93,5 +205,25 @@ public class DocumentMergerTest : ServiceTestBase
                 return;
         }
         while (Interlocked.CompareExchange(ref maxConcurrentRequests, current, observedMax) != observedMax);
+    }
+
+    private static MemoryStream CreatePdfWithBookmark(string bookmarkTitle, int destinationPage)
+    {
+        using var pdf = new GdPicturePDF();
+        Assert.Equal(GdPictureStatus.OK, pdf.NewPDF());
+        Assert.Equal(GdPictureStatus.OK, pdf.NewPage(8.5f, 11f));
+        Assert.Equal(GdPictureStatus.OK, pdf.NewPage(8.5f, 11f));
+
+        var bookmarkId = pdf.NewBookmark(0, bookmarkTitle);
+        Assert.True(bookmarkId > 0);
+
+        var actionId = pdf.NewActionGoTo(PdfDestinationType.DestinationTypeXYZ, destinationPage, 0, 0, 0, 0, 1);
+        Assert.True(actionId > 0);
+        Assert.Equal(GdPictureStatus.OK, pdf.SetBookmarkAction(bookmarkId, actionId));
+
+        var stream = new MemoryStream();
+        Assert.Equal(GdPictureStatus.OK, pdf.SaveToStream(stream));
+        stream.Position = 0;
+        return stream;
     }
 }

--- a/tests/api/Documents/PdfMergePreparationStrategyResolverTests.cs
+++ b/tests/api/Documents/PdfMergePreparationStrategyResolverTests.cs
@@ -1,0 +1,84 @@
+using System;
+using Moq;
+using Scv.Api.Documents;
+using Scv.Models.Document;
+using Xunit;
+
+namespace tests.api.Documents;
+
+public class PdfMergePreparationStrategyResolverTests
+{
+    [Fact]
+    public void Resolve_ReturnsNone_ForTransitoryDocuments()
+    {
+        var resolver = CreateResolver();
+
+        var mode = resolver.Resolve(new PdfDocumentRequest
+        {
+            Type = DocumentType.TransitoryDocument,
+            Data = new PdfDocumentRequestDetails { Path = "path/to/document.pdf" }
+        });
+
+        Assert.Equal(PdfMergePreparationMode.None, mode);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsFlatten_ForNonTransitoryDocuments()
+    {
+        var resolver = CreateResolver();
+
+        var mode = resolver.Resolve(new PdfDocumentRequest
+        {
+            Type = DocumentType.File,
+            Data = new PdfDocumentRequestDetails { DocumentId = "doc-id", FileId = "file-id" }
+        });
+
+        Assert.Equal(PdfMergePreparationMode.Flatten, mode);
+    }
+
+    [Fact]
+    public void Resolve_Throws_WhenNoStrategyMatches()
+    {
+        var resolver = new PdfMergePreparationStrategyResolver([]);
+
+        Assert.Throws<InvalidOperationException>(() => resolver.Resolve(new PdfDocumentRequest
+        {
+            Type = DocumentType.File,
+            Data = new PdfDocumentRequestDetails { DocumentId = "doc-id" }
+        }));
+    }
+
+    [Fact]
+    public void Resolve_Throws_WhenMultipleStrategiesMatch()
+    {
+        var overlappingStrategyMock = new Mock<IPdfMergePreparationStrategy>();
+        overlappingStrategyMock
+            .SetupGet(s => s.PreparationMode)
+            .Returns(PdfMergePreparationMode.Flatten);
+        overlappingStrategyMock
+            .Setup(s => s.CanHandle(It.IsAny<PdfDocumentRequest>()))
+            .Returns<PdfDocumentRequest>(documentRequest => documentRequest?.Type == DocumentType.File);
+
+        var overlappingStrategies = new IPdfMergePreparationStrategy[]
+        {
+            new DefaultPdfMergePreparationStrategy(),
+            overlappingStrategyMock.Object,
+        };
+        var resolver = new PdfMergePreparationStrategyResolver(overlappingStrategies);
+
+        Assert.Throws<InvalidOperationException>(() => resolver.Resolve(new PdfDocumentRequest
+        {
+            Type = DocumentType.File,
+            Data = new PdfDocumentRequestDetails { DocumentId = "doc-id" }
+        }));
+    }
+
+    private static PdfMergePreparationStrategyResolver CreateResolver()
+    {
+        return new PdfMergePreparationStrategyResolver(
+        [
+            new TransitoryDocumentPdfMergePreparationStrategy(),
+            new DefaultPdfMergePreparationStrategy(),
+        ]);
+    }
+}

--- a/tests/api/Documents/PdfMergePreparationStrategyTests.cs
+++ b/tests/api/Documents/PdfMergePreparationStrategyTests.cs
@@ -1,0 +1,34 @@
+using Scv.Api.Documents;
+using Scv.Models.Document;
+using Xunit;
+
+namespace tests.api.Documents;
+
+public class PdfMergePreparationStrategyTests
+{
+    [Fact]
+    public void DefaultStrategy_ReturnsFlatten_AndSkipsTransitoryDocuments()
+    {
+        var strategy = new DefaultPdfMergePreparationStrategy();
+
+        var fileRequest = new PdfDocumentRequest { Type = DocumentType.File };
+        var transitoryRequest = new PdfDocumentRequest { Type = DocumentType.TransitoryDocument };
+
+        Assert.Equal(PdfMergePreparationMode.Flatten, strategy.PreparationMode);
+        Assert.True(strategy.CanHandle(fileRequest));
+        Assert.False(strategy.CanHandle(transitoryRequest));
+    }
+
+    [Fact]
+    public void TransitoryStrategy_ReturnsNone_AndOnlyHandlesTransitoryDocuments()
+    {
+        var strategy = new TransitoryDocumentPdfMergePreparationStrategy();
+
+        var transitoryRequest = new PdfDocumentRequest { Type = DocumentType.TransitoryDocument };
+        var fileRequest = new PdfDocumentRequest { Type = DocumentType.File };
+
+        Assert.Equal(PdfMergePreparationMode.None, strategy.PreparationMode);
+        Assert.True(strategy.CanHandle(transitoryRequest));
+        Assert.False(strategy.CanHandle(fileRequest));
+    }
+}

--- a/tests/api/Documents/Strategies/FileStrategyTest.cs
+++ b/tests/api/Documents/Strategies/FileStrategyTest.cs
@@ -94,6 +94,47 @@ public class FileStrategyTest : ServiceTestBase
     }
 
     [Fact]
+    public async Task Invoke_RewindsSourceStreamBeforeCopying()
+    {
+        var fakeDocumentId = "test-document-id";
+        var encodedDocumentId = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(fakeDocumentId));
+        var fakeFileId = "file-id";
+        var fakeCorrelationId = "correlation-id";
+        var sourceStream = new MemoryStream(_fakeContentBytes);
+        sourceStream.Position = sourceStream.Length;
+
+        _mockFileServicesClient.Setup(c => c.FilesDocumentAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<bool>(),
+            It.IsAny<string>()))
+            .ReturnsAsync(new FileResponse(
+                200,
+                new Dictionary<string, IEnumerable<string>>(),
+                sourceStream,
+                null,
+                null
+            ));
+
+        var documentRequest = new PdfDocumentRequestDetails
+        {
+            DocumentId = encodedDocumentId,
+            FileId = fakeFileId,
+            CorrelationId = fakeCorrelationId
+        };
+        var strategy = new FileStrategy(_mockFileServicesClient.Object, _mockUser, _mockConfiguration.Object);
+
+        var resultStream = await strategy.Invoke(documentRequest);
+
+        Assert.NotNull(resultStream);
+        Assert.Equal(_fakeContentBytes, resultStream.ToArray());
+    }
+
+    [Fact]
     public void Type_ReturnsFile()
     {
         var strategy = new FileStrategy(_mockFileServicesClient.Object, _mockUser, _mockConfiguration.Object);

--- a/tests/api/Documents/Strategies/TransitoryDocumentStrategyTests.cs
+++ b/tests/api/Documents/Strategies/TransitoryDocumentStrategyTests.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Scv.Api.Documents.Strategies;
+using Scv.Api.Services;
+using Scv.Models;
+using Scv.Models.Document;
+using Xunit;
+
+namespace tests.api.Documents.Strategies;
+
+public class TransitoryDocumentStrategyTests
+{
+    [Fact]
+    public async Task Invoke_RewindsSourceStreamBeforeCopying()
+    {
+        var contentBytes = Encoding.UTF8.GetBytes("%PDF-test-content");
+        var sourceStream = new MemoryStream(contentBytes);
+        sourceStream.Position = sourceStream.Length;
+        var transitoryDocumentsServiceMock = new Mock<ITransitoryDocumentsService>();
+        var loggerMock = new Mock<ILogger<TransitoryDocumentStrategy>>();
+
+        transitoryDocumentsServiceMock
+            .Setup(x => x.DownloadFile("path/to/document.pdf", default))
+            .ReturnsAsync(new FileStreamResponse(
+                sourceStream,
+                "document.pdf",
+                "application/pdf"));
+
+        var strategy = new TransitoryDocumentStrategy(
+            transitoryDocumentsServiceMock.Object,
+            loggerMock.Object);
+
+        var result = await strategy.Invoke(new PdfDocumentRequestDetails
+        {
+            Path = "path/to/document.pdf",
+        });
+
+        Assert.Equal(contentBytes, result.ToArray());
+    }
+}

--- a/tests/api/Infrastructure/ServiceCollectionExtensionsTests.cs
+++ b/tests/api/Infrastructure/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using GdPicture14;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Scv.Api.Documents;
+using Scv.Api.Infrastructure;
+using Xunit;
+
+namespace tests.api.Infrastructure;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddNutrient_RegistersPdfMergePreparationServices()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+            [
+                new KeyValuePair<string, string>("NUTRIENT_BE_LICENSE_KEY", string.Empty)
+            ])
+            .Build();
+
+        services.AddNutrient(configuration);
+
+        Assert.Contains(
+            services,
+            descriptor => descriptor.ServiceType == typeof(IPdfMergePreparationStrategyResolver)
+                && descriptor.ImplementationType == typeof(PdfMergePreparationStrategyResolver)
+                && descriptor.Lifetime == ServiceLifetime.Scoped);
+
+        var strategyRegistrations = services
+            .Where(descriptor => descriptor.ServiceType == typeof(IPdfMergePreparationStrategy))
+            .ToList();
+
+        Assert.Contains(
+            strategyRegistrations,
+            descriptor => descriptor.ImplementationType == typeof(TransitoryDocumentPdfMergePreparationStrategy)
+                && descriptor.Lifetime == ServiceLifetime.Scoped);
+        Assert.Contains(
+            strategyRegistrations,
+            descriptor => descriptor.ImplementationType == typeof(DefaultPdfMergePreparationStrategy)
+                && descriptor.Lifetime == ServiceLifetime.Scoped);
+    }
+}

--- a/tests/api/Services/PcssSyncServiceTests.cs
+++ b/tests/api/Services/PcssSyncServiceTests.cs
@@ -11,6 +11,7 @@ using Scv.Db.Models;
 using Scv.Db.Repositories;
 using Scv.Models.AccessControlManagement;
 using Xunit;
+using Role = Scv.Db.Models.Role;
 
 namespace Scv.Api.Tests.Services
 {
@@ -21,6 +22,7 @@ namespace Scv.Api.Tests.Services
         private readonly Mock<IJudgeService> _judgeServiceMock;
         private readonly Mock<IRepositoryBase<Group>> _groupRepoMock;
         private readonly Mock<IRoleService> _roleServiceMock;
+        private readonly Mock<IRepositoryBase<Role>> _roleRepoMock;
         private readonly Mock<ILogger<PcssSyncService>> _loggerMock;
         private readonly PcssSyncService _pcssSyncService;
 
@@ -31,6 +33,7 @@ namespace Scv.Api.Tests.Services
             _groupServiceMock = new Mock<IGroupService>();
             _judgeServiceMock = new Mock<IJudgeService>();
             _roleServiceMock = new Mock<IRoleService>();
+            _roleRepoMock = new Mock<IRepositoryBase<Role>>();
             _loggerMock = new Mock<ILogger<PcssSyncService>>();
             _groupRepoMock = new Mock<IRepositoryBase<Group>>();
 
@@ -39,6 +42,7 @@ namespace Scv.Api.Tests.Services
                 _groupServiceMock.Object,
                 _judgeServiceMock.Object,
                 _groupRepoMock.Object,
+                _roleRepoMock.Object,
                 _roleServiceMock.Object,
                 _loggerMock.Object);
         }

--- a/web/src/components/courtlist/TransitoryDocumentsDialog.vue
+++ b/web/src/components/courtlist/TransitoryDocumentsDialog.vue
@@ -175,12 +175,6 @@
     { title: 'Extension', key: 'extension', sortable: true },
     { title: 'Created', key: 'createdUtc', sortable: true },
     { title: 'Size', key: 'sizeBytes', sortable: true },
-    {
-      title: 'Actions',
-      key: 'actions',
-      sortable: false,
-      align: 'center' as const,
-    },
   ];
 
   const formatFileSize = (bytes: number): string => {

--- a/web/src/components/documents/FileViewer.vue
+++ b/web/src/components/documents/FileViewer.vue
@@ -16,9 +16,9 @@
 </template>
 
 <script setup lang="ts">
-  import { OrderService } from '@/services';
+  import type { OrderService } from '@/services';
   import { useCommonStore } from '@/stores';
-  import { OrderReview } from '@/types';
+  import type { OrderReview } from '@/types';
   import { OrderReviewStatus } from '@/types/common';
   import { arrayBufferToBase64 } from '@/utils/utils';
   import {
@@ -29,19 +29,17 @@
   import { computed, inject, onMounted, onUnmounted, ref } from 'vue';
   import { useRoute } from 'vue-router';
   import ReviewModal from './ReviewModal.vue';
-  import {
+  import type { AnyPDFViewerStrategy } from './strategies/PDFStrategyFactory';
+  import type {
+    EmbeddedOutlineAwarePDFViewerStrategy,
     OutlineItem,
     PDFViewerInformationContext,
-    PDFViewerStrategy,
   } from './strategies/PDFViewerTypes';
 
-  // Declare NutrientViewer global
-  declare global {
-    const NutrientViewer: any;
-  }
-
   // Props for the generic component
-  interface Props<TStrategy extends PDFViewerStrategy = PDFViewerStrategy> {
+  interface Props<
+    TStrategy extends AnyPDFViewerStrategy = AnyPDFViewerStrategy,
+  > {
     strategy: TStrategy;
   }
 
@@ -57,6 +55,7 @@
 
     return typeof value === 'string' && value.length > 0 ? value : undefined;
   });
+  const nutrientViewer = globalThis.NutrientViewer as any;
 
   const orderService = inject<OrderService>('orderService');
   if (!orderService) {
@@ -104,11 +103,7 @@
 
       loading.value = false;
 
-      // Create outline and load PDF viewer
-      const outline = props.strategy.createOutline(rawData, apiResponse);
       const base64Pdf = props.strategy.extractBase64PDF(apiResponse);
-
-      const nutrientOutline = createNutrientOutline(outline);
 
       const openInfoItem: ToolbarItem = {
         type: 'custom',
@@ -142,16 +137,33 @@
         },
       };
 
-      instance = await NutrientViewer.load({
+      instance = await nutrientViewer.load({
         ...configuration,
         document: `data:application/pdf;base64,${base64Pdf}`,
       });
 
-      instance.setDocumentOutline(nutrientOutline);
+      if (supportsEmbeddedOutline(props.strategy)) {
+        const outline = props.strategy.createOutlineWithEmbeddedOutline(
+          rawData,
+          apiResponse,
+          await getEmbeddedOutline()
+        );
+
+        if (outline?.length) {
+          const nutrientOutline = createNutrientOutline(outline);
+          instance.setDocumentOutline(nutrientOutline);
+        }
+      } else {
+        const outline =
+          props.strategy.createOutline(rawData, apiResponse) ?? [];
+        const nutrientOutline = createNutrientOutline(outline);
+        instance.setDocumentOutline(nutrientOutline);
+      }
+
       instance.setViewState((viewState) =>
         viewState.set(
           'sidebarMode',
-          NutrientViewer.SidebarMode.DOCUMENT_OUTLINE
+          nutrientViewer.SidebarMode.DOCUMENT_OUTLINE
         )
       );
       instance.setToolbarItems((items: ToolbarItem[]) => {
@@ -181,7 +193,7 @@
   };
 
   const createNutrientOutline = (outlineData: OutlineItem[]): any => {
-    return NutrientViewer.Immutable.List(
+    return nutrientViewer.Immutable.List(
       outlineData.map((item) => createOutlineElement(item))
     );
   };
@@ -278,26 +290,90 @@
   const getString = (value: unknown): string | undefined =>
     typeof value === 'string' && value.length > 0 ? value : undefined;
 
+  const supportsEmbeddedOutline = (
+    strategy: AnyPDFViewerStrategy
+  ): strategy is AnyPDFViewerStrategy &
+    EmbeddedOutlineAwarePDFViewerStrategy<unknown, unknown> => {
+    return (
+      typeof (strategy as { createOutlineWithEmbeddedOutline?: unknown })
+        .createOutlineWithEmbeddedOutline === 'function'
+    );
+  };
+
+  const getEmbeddedOutline = async (): Promise<OutlineItem[] | undefined> => {
+    if (typeof instance.getDocumentOutline !== 'function') {
+      console.warn(
+        'Embedded outline API is unavailable; continuing without embedded outline.'
+      );
+      return undefined;
+    }
+
+    try {
+      const embeddedOutline = await instance.getDocumentOutline();
+      const outlineItems = convertOutlineListToItems(embeddedOutline);
+
+      return outlineItems.length > 0 ? outlineItems : undefined;
+    } catch (error) {
+      console.warn(
+        'Failed to extract embedded outline; continuing without embedded outline.',
+        error
+      );
+      return undefined;
+    }
+  };
+
+  const convertOutlineListToItems = (outlineList: any): OutlineItem[] => {
+    const outlineElements = Array.isArray(outlineList)
+      ? outlineList
+      : (outlineList?.toArray?.() ?? Array.from(outlineList ?? []));
+
+    return outlineElements.map((element: any) =>
+      convertOutlineElementToItem(element)
+    );
+  };
+
+  const convertOutlineElementToItem = (element: any): OutlineItem => {
+    if (!element || typeof element.title !== 'string') {
+      throw new TypeError('Embedded outline element is malformed.');
+    }
+
+    const childItems = convertOutlineListToItems(element.children);
+    const actionPageIndex = element.action?.pageIndex;
+
+    return {
+      title: element.title,
+      pageIndex:
+        typeof actionPageIndex === 'number' ? actionPageIndex : undefined,
+      isExpanded: element.isExpanded,
+      children: childItems.length > 0 ? childItems : undefined,
+    };
+  };
+
   const createOutlineElement = (item: OutlineItem): any => {
     const baseElement = {
       title: item.title,
-      action:
-        item.pageIndex !== undefined
-          ? new NutrientViewer.Actions.GoToAction({ pageIndex: item.pageIndex })
-          : undefined,
+      action: createOutlineAction(item.pageIndex),
     };
 
     if (item.children?.length) {
-      return new NutrientViewer.OutlineElement({
+      return new nutrientViewer.OutlineElement({
         ...baseElement,
         isExpanded: item.isExpanded ?? true,
-        children: NutrientViewer.Immutable.List(
+        children: nutrientViewer.Immutable.List(
           item.children.map((child) => createOutlineElement(child))
         ),
       });
     }
 
-    return new NutrientViewer.OutlineElement(baseElement);
+    return new nutrientViewer.OutlineElement(baseElement);
+  };
+
+  const createOutlineAction = (pageIndex: number | undefined): any => {
+    if (pageIndex === undefined) {
+      return undefined;
+    }
+
+    return new nutrientViewer.Actions.GoToAction({ pageIndex });
   };
 
   const reviewOrder = async (orderReview: OrderReview) => {
@@ -320,8 +396,8 @@
   });
 
   onUnmounted(() => {
-    if (NutrientViewer) {
-      NutrientViewer.unload('.pdf-container');
+    if (nutrientViewer) {
+      nutrientViewer.unload('.pdf-container');
     }
     if (props.strategy.cleanup) {
       props.strategy.cleanup(sessionId.value);

--- a/web/src/components/documents/strategies/PDFViewerTypes.ts
+++ b/web/src/components/documents/strategies/PDFViewerTypes.ts
@@ -1,6 +1,14 @@
 import { OrderReview } from '@/types';
 import { ToolbarItem } from '@nutrient-sdk/viewer';
 
+export interface EmbeddedOutlineAwarePDFViewerStrategy<TRawData, TApiResponse> {
+  createOutlineWithEmbeddedOutline(
+    rawData: TRawData,
+    apiResponse: TApiResponse,
+    embeddedOutline?: OutlineItem[]
+  ): OutlineItem[] | undefined;
+}
+
 export interface PDFViewerStrategy<
   TRawData = unknown,
   TProcessedData = unknown,
@@ -22,7 +30,10 @@ export interface PDFViewerStrategy<
     apiResponse: TApiResponse
   ): Array<{ start: number; end?: number }> | undefined;
 
-  createOutline(rawData: TRawData, apiResponse: TApiResponse): OutlineItem[];
+  createOutline(
+    rawData: TRawData,
+    apiResponse: TApiResponse
+  ): OutlineItem[] | undefined;
 
   resolveInformationContext?(
     rawData: TRawData

--- a/web/src/components/documents/strategies/TransitoryBundleStrategy.ts
+++ b/web/src/components/documents/strategies/TransitoryBundleStrategy.ts
@@ -1,21 +1,25 @@
-import { OutlineItem, PDFViewerStrategy } from './PDFViewerTypes';
-import { TransitoryDocumentsService } from '@/services/TransitoryDocumentsService';
+import type { TransitoryDocumentsService } from '@/services/TransitoryDocumentsService';
 import {
-  FileMetadataDto,
-  TransitoryMergeContext,
-  TransitoryViewerPayload,
+  type FileMetadataDto,
+  type TransitoryMergeContext,
+  type TransitoryViewerPayload,
 } from '@/types/transitory-documents';
+import type {
+  EmbeddedOutlineAwarePDFViewerStrategy,
+  OutlineItem,
+  PDFViewerStrategy,
+} from './PDFViewerTypes';
 
 interface MergedPdfResponse {
   base64Pdf: string;
   pageRanges: Array<{ start: number; end?: number }>;
 }
 
-export class TransitoryBundleStrategy implements PDFViewerStrategy<
-  FileMetadataDto[],
-  FileMetadataDto[],
-  MergedPdfResponse
-> {
+export class TransitoryBundleStrategy
+  implements
+    PDFViewerStrategy<FileMetadataDto[], FileMetadataDto[], MergedPdfResponse>,
+    EmbeddedOutlineAwarePDFViewerStrategy<FileMetadataDto[], MergedPdfResponse>
+{
   private readonly transitoryDocumentsService: TransitoryDocumentsService;
   private readonly storageKey: string;
   private documentsData: FileMetadataDto[] = [];
@@ -96,12 +100,89 @@ export class TransitoryBundleStrategy implements PDFViewerStrategy<
   createOutline(
     rawData: FileMetadataDto[],
     apiResponse: MergedPdfResponse
+  ): OutlineItem[] | undefined {
+    return this.createOutlineWithEmbeddedOutline(rawData, apiResponse);
+  }
+
+  createOutlineWithEmbeddedOutline(
+    rawData: FileMetadataDto[],
+    apiResponse: MergedPdfResponse,
+    embeddedOutline?: OutlineItem[]
+  ): OutlineItem[] | undefined {
+    return rawData.map((doc, index) => {
+      const pageRange = apiResponse.pageRanges?.[index];
+      const pageStart = pageRange?.start;
+      const pageEnd =
+        pageRange?.end ?? apiResponse.pageRanges?.[index + 1]?.start;
+
+      return {
+        title: doc.fileName,
+        pageIndex: pageStart,
+        isExpanded: true,
+        children: this.filterEmbeddedOutlineForRange(
+          embeddedOutline,
+          pageStart,
+          pageEnd
+        ),
+      };
+    });
+  }
+
+  private filterEmbeddedOutlineForRange(
+    embeddedOutline: OutlineItem[] | undefined,
+    pageStart: number | undefined,
+    pageEnd: number | undefined
+  ): OutlineItem[] | undefined {
+    if (!embeddedOutline?.length || pageStart === undefined) {
+      return undefined;
+    }
+
+    const matchingItems = embeddedOutline.flatMap((item) =>
+      this.filterOutlineItemForRange(item, pageStart, pageEnd)
+    );
+
+    return matchingItems.length > 0 ? matchingItems : undefined;
+  }
+
+  private filterOutlineItemForRange(
+    item: OutlineItem,
+    pageStart: number,
+    pageEnd: number | undefined
   ): OutlineItem[] {
-    return rawData.map((doc, index) => ({
-      title: doc.fileName,
-      pageIndex: apiResponse.pageRanges?.[index]?.start || index * 10,
-      isExpanded: false,
-    }));
+    const filteredChildren = item.children?.flatMap((child) =>
+      this.filterOutlineItemForRange(child, pageStart, pageEnd)
+    );
+    const hasPageTarget = item.pageIndex !== undefined;
+    const isInRange =
+      hasPageTarget &&
+      item.pageIndex >= pageStart &&
+      (pageEnd === undefined || item.pageIndex < pageEnd);
+
+    if (isInRange) {
+      return [
+        {
+          ...item,
+          isExpanded: true,
+          children: filteredChildren?.length ? filteredChildren : undefined,
+        },
+      ];
+    }
+
+    if (!filteredChildren?.length) {
+      return [];
+    }
+
+    if (hasPageTarget) {
+      return filteredChildren;
+    }
+
+    return [
+      {
+        ...item,
+        isExpanded: true,
+        children: filteredChildren,
+      },
+    ];
   }
 
   cleanup(): void {

--- a/web/tests/components/courtList/TransitoryDocumentsDialog.test.ts
+++ b/web/tests/components/courtList/TransitoryDocumentsDialog.test.ts
@@ -875,7 +875,6 @@ describe('TransitoryDocumentsDialog', () => {
         { title: 'Extension', key: 'extension', sortable: true },
         { title: 'Created', key: 'createdUtc', sortable: true },
         { title: 'Size', key: 'sizeBytes', sortable: true },
-        { title: 'Actions', key: 'actions', sortable: false, align: 'center' },
       ]);
     });
   });

--- a/web/tests/components/documents/FileViewer.test.ts
+++ b/web/tests/components/documents/FileViewer.test.ts
@@ -140,7 +140,7 @@ describe('FileViewer.vue', () => {
       extractBase64PDF: (apiResponse: { base64Pdf: string }) =>
         apiResponse.base64Pdf,
       extractPageRanges: () => [{ start: 1, end: 2 }],
-      createOutline: () => [],
+      createOutline: () => undefined,
       cleanup: vi.fn(),
     };
 
@@ -240,6 +240,147 @@ describe('FileViewer.vue', () => {
     expect(createOutline).toHaveBeenCalledWith(
       [{ fileName: 'normal-document.pdf' }],
       { base64Pdf: 'base64pdf', pageRanges: [{ start: 0, end: 2 }] }
+    );
+  });
+
+  it('does not override embedded outline when embedded-outline-aware strategy returns no custom outline', async () => {
+    const createOutlineWithEmbeddedOutline = vi.fn().mockReturnValue(undefined);
+    const strategy = {
+      hasData: () => true,
+      getRawData: () => [{ fileName: 'embedded-outline.pdf' }],
+      processDataForAPI: (rawData: unknown) => rawData,
+      generatePDF: vi.fn().mockResolvedValue({
+        base64Pdf: 'base64pdf',
+        pageRanges: [{ start: 1, end: 2 }],
+      }),
+      extractBase64PDF: (apiResponse: { base64Pdf: string }) =>
+        apiResponse.base64Pdf,
+      extractPageRanges: () => [{ start: 1, end: 2 }],
+      createOutline: vi.fn(),
+      createOutlineWithEmbeddedOutline,
+      cleanup: vi.fn(),
+    };
+
+    await mountViewer(strategy);
+
+    expect(createOutlineWithEmbeddedOutline).toHaveBeenCalledOnce();
+    expect(mockInstance.setDocumentOutline).not.toHaveBeenCalled();
+  });
+
+  it('passes embedded Nutrient outline to the strategy before overriding it', async () => {
+    const createOutlineWithEmbeddedOutline = vi
+      .fn()
+      .mockReturnValue([{ title: 'wrapped-document', pageIndex: 0 }]);
+
+    mockInstance.getDocumentOutline.mockResolvedValue([
+      {
+        title: 'existing-outline-item',
+        isExpanded: true,
+        action: { pageIndex: 2 },
+        children: [],
+      },
+    ]);
+
+    const strategy = {
+      hasData: () => true,
+      getRawData: () => [{ fileName: 'embedded-outline.pdf' }],
+      processDataForAPI: (rawData: unknown) => rawData,
+      generatePDF: vi.fn().mockResolvedValue({
+        base64Pdf: 'base64pdf',
+        pageRanges: [{ start: 0, end: 2 }],
+      }),
+      extractBase64PDF: (apiResponse: { base64Pdf: string }) =>
+        apiResponse.base64Pdf,
+      extractPageRanges: () => [{ start: 0, end: 2 }],
+      createOutline: vi.fn(),
+      createOutlineWithEmbeddedOutline,
+      cleanup: vi.fn(),
+    };
+
+    await mountViewer(strategy);
+
+    expect(createOutlineWithEmbeddedOutline).toHaveBeenCalledWith(
+      [{ fileName: 'embedded-outline.pdf' }],
+      { base64Pdf: 'base64pdf', pageRanges: [{ start: 0, end: 2 }] },
+      [
+        {
+          title: 'existing-outline-item',
+          pageIndex: 2,
+          isExpanded: true,
+          children: undefined,
+        },
+      ]
+    );
+    expect(mockInstance.setDocumentOutline).toHaveBeenCalledOnce();
+  });
+
+  it('falls back when embedded outline extraction fails for transitory strategies', async () => {
+    const createOutlineWithEmbeddedOutline = vi.fn().mockReturnValue(undefined);
+
+    mockInstance.getDocumentOutline.mockRejectedValue(
+      new Error('outline load failed')
+    );
+
+    const strategy = {
+      hasData: () => true,
+      getRawData: () => [{ fileName: 'embedded-outline.pdf' }],
+      processDataForAPI: (rawData: unknown) => rawData,
+      generatePDF: vi.fn().mockResolvedValue({
+        base64Pdf: 'base64pdf',
+        pageRanges: [{ start: 0, end: 2 }],
+      }),
+      extractBase64PDF: (apiResponse: { base64Pdf: string }) =>
+        apiResponse.base64Pdf,
+      extractPageRanges: () => [{ start: 0, end: 2 }],
+      createOutline: vi.fn(),
+      createOutlineWithEmbeddedOutline,
+      cleanup: vi.fn(),
+    };
+
+    await mountViewer(strategy);
+
+    expect(createOutlineWithEmbeddedOutline).toHaveBeenCalledWith(
+      [{ fileName: 'embedded-outline.pdf' }],
+      { base64Pdf: 'base64pdf', pageRanges: [{ start: 0, end: 2 }] },
+      undefined
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to extract embedded outline; continuing without embedded outline.',
+      expect.any(Error)
+    );
+  });
+
+  it('falls back when embedded outline data is malformed for transitory strategies', async () => {
+    const createOutlineWithEmbeddedOutline = vi.fn().mockReturnValue(undefined);
+
+    mockInstance.getDocumentOutline.mockResolvedValue([{ title: 123 }]);
+
+    const strategy = {
+      hasData: () => true,
+      getRawData: () => [{ fileName: 'embedded-outline.pdf' }],
+      processDataForAPI: (rawData: unknown) => rawData,
+      generatePDF: vi.fn().mockResolvedValue({
+        base64Pdf: 'base64pdf',
+        pageRanges: [{ start: 0, end: 2 }],
+      }),
+      extractBase64PDF: (apiResponse: { base64Pdf: string }) =>
+        apiResponse.base64Pdf,
+      extractPageRanges: () => [{ start: 0, end: 2 }],
+      createOutline: vi.fn(),
+      createOutlineWithEmbeddedOutline,
+      cleanup: vi.fn(),
+    };
+
+    await mountViewer(strategy);
+
+    expect(createOutlineWithEmbeddedOutline).toHaveBeenCalledWith(
+      [{ fileName: 'embedded-outline.pdf' }],
+      { base64Pdf: 'base64pdf', pageRanges: [{ start: 0, end: 2 }] },
+      undefined
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to extract embedded outline; continuing without embedded outline.',
+      expect.any(TypeError)
     );
   });
 

--- a/web/tests/components/documents/strategies/TransitoryBundleStrategy.test.ts
+++ b/web/tests/components/documents/strategies/TransitoryBundleStrategy.test.ts
@@ -1,0 +1,264 @@
+import { TransitoryBundleStrategy } from '@/components/documents/strategies/TransitoryBundleStrategy';
+import { TransitoryDocumentsService } from '@/services/TransitoryDocumentsService';
+import { FileMetadataDto } from '@/types/transitory-documents';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockTransitoryDocumentsService: Pick<
+  TransitoryDocumentsService,
+  'mergePdfs'
+> = {
+  mergePdfs: vi.fn(),
+};
+
+describe('TransitoryBundleStrategy', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('wraps embedded outline items under the matching document header', () => {
+    const rawData: FileMetadataDto[] = [
+      {
+        fileName: 'Document A.pdf',
+        extension: 'pdf',
+        sizeBytes: 100,
+        createdUtc: '2026-06-04T00:00:00Z',
+        relativePath: 'a.pdf',
+        matchedRoomFolder: null,
+      },
+      {
+        fileName: 'Document B.pdf',
+        extension: 'pdf',
+        sizeBytes: 200,
+        createdUtc: '2026-06-04T00:00:00Z',
+        relativePath: 'b.pdf',
+        matchedRoomFolder: null,
+      },
+    ];
+
+    sessionStorage.setItem(
+      'transitoryDocuments:test-key',
+      JSON.stringify({ files: rawData, context: undefined })
+    );
+
+    const strategy = new TransitoryBundleStrategy(
+      mockTransitoryDocumentsService,
+      'test-key'
+    );
+
+    const outline = strategy.createOutlineWithEmbeddedOutline(
+      rawData,
+      {
+        base64Pdf: 'base64pdf',
+        pageRanges: [
+          { start: 0, end: 2 },
+          { start: 2, end: 4 },
+        ],
+      },
+      [
+        {
+          title: 'Section A',
+          pageIndex: 0,
+          children: [
+            {
+              title: 'Section A.1',
+              pageIndex: 1,
+            },
+          ],
+        },
+        {
+          title: 'Section B',
+          pageIndex: 2,
+        },
+      ]
+    );
+
+    expect(outline).toEqual([
+      {
+        title: 'Document A.pdf',
+        pageIndex: 0,
+        isExpanded: true,
+        children: [
+          {
+            title: 'Section A',
+            pageIndex: 0,
+            isExpanded: true,
+            children: [
+              {
+                title: 'Section A.1',
+                pageIndex: 1,
+                isExpanded: true,
+                children: undefined,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Document B.pdf',
+        pageIndex: 2,
+        isExpanded: true,
+        children: [
+          {
+            title: 'Section B',
+            pageIndex: 2,
+            isExpanded: true,
+            children: undefined,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('preserves wrapper parents without page targets and drops out-of-range parents with page targets', () => {
+    const rawData: FileMetadataDto[] = [
+      {
+        fileName: 'Document A.pdf',
+        extension: 'pdf',
+        sizeBytes: 100,
+        createdUtc: '2026-06-04T00:00:00Z',
+        relativePath: 'a.pdf',
+        matchedRoomFolder: null,
+      },
+      {
+        fileName: 'Document B.pdf',
+        extension: 'pdf',
+        sizeBytes: 200,
+        createdUtc: '2026-06-04T00:00:00Z',
+        relativePath: 'b.pdf',
+        matchedRoomFolder: null,
+      },
+    ];
+
+    sessionStorage.setItem(
+      'transitoryDocuments:test-key',
+      JSON.stringify({ files: rawData, context: undefined })
+    );
+
+    const strategy = new TransitoryBundleStrategy(
+      mockTransitoryDocumentsService,
+      'test-key'
+    );
+
+    const outline = strategy.createOutlineWithEmbeddedOutline(
+      rawData,
+      {
+        base64Pdf: 'base64pdf',
+        pageRanges: [
+          { start: 0, end: 2 },
+          { start: 2, end: 5 },
+        ],
+      },
+      [
+        {
+          title: 'Wrapper Parent',
+          children: [
+            {
+              title: 'In Range Child',
+              pageIndex: 3,
+            },
+          ],
+        },
+        {
+          title: 'Out-of-Range Parent',
+          pageIndex: 8,
+          children: [
+            {
+              title: 'Nested In Range Child',
+              pageIndex: 4,
+            },
+          ],
+        },
+      ]
+    );
+
+    expect(outline?.[1]).toEqual({
+      title: 'Document B.pdf',
+      pageIndex: 2,
+      isExpanded: true,
+      children: [
+        {
+          title: 'Wrapper Parent',
+          isExpanded: true,
+          children: [
+            {
+              title: 'In Range Child',
+              pageIndex: 3,
+              isExpanded: true,
+              children: undefined,
+            },
+          ],
+        },
+        {
+          title: 'Nested In Range Child',
+          pageIndex: 4,
+          isExpanded: true,
+          children: undefined,
+        },
+      ],
+    });
+  });
+
+  it('uses explicit pageRange end boundaries and keeps the last document open-ended', () => {
+    const rawData: FileMetadataDto[] = [
+      {
+        fileName: 'Document A.pdf',
+        extension: 'pdf',
+        sizeBytes: 100,
+        createdUtc: '2026-06-04T00:00:00Z',
+        relativePath: 'a.pdf',
+        matchedRoomFolder: null,
+      },
+      {
+        fileName: 'Document B.pdf',
+        extension: 'pdf',
+        sizeBytes: 200,
+        createdUtc: '2026-06-04T00:00:00Z',
+        relativePath: 'b.pdf',
+        matchedRoomFolder: null,
+      },
+    ];
+
+    sessionStorage.setItem(
+      'transitoryDocuments:test-key',
+      JSON.stringify({ files: rawData, context: undefined })
+    );
+
+    const strategy = new TransitoryBundleStrategy(
+      mockTransitoryDocumentsService,
+      'test-key'
+    );
+
+    const outline = strategy.createOutlineWithEmbeddedOutline(
+      rawData,
+      {
+        base64Pdf: 'base64pdf',
+        pageRanges: [{ start: 0, end: 1 }, { start: 5 }],
+      },
+      [
+        {
+          title: 'Boundary Item',
+          pageIndex: 1,
+        },
+        {
+          title: 'Last Document Item',
+          pageIndex: 9,
+        },
+      ]
+    );
+
+    expect(outline?.[0]?.children).toBeUndefined();
+    expect(outline?.[1]).toEqual({
+      title: 'Document B.pdf',
+      pageIndex: 5,
+      isExpanded: true,
+      children: [
+        {
+          title: 'Last Document Item',
+          pageIndex: 9,
+          isExpanded: true,
+          children: undefined,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**jasper-642**----    


## Description

Do not flatten transitory documents. Add original pdf outline below per-file outline generated by JASPER.
NOTE: this is dependent on my other PR that refactors outline generation.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Tested existing judiciary binder functionality from court list, and file
opened files individually on court list and file.
opened multiple transitory documents at same time
opened single transitory documents
confirmed outline matches between original file and nutrient display of file.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

