### PR TITLE
jasper-811 - only delete cases after insert succeeds, use transaction.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,5 +49,13 @@
   "containerEnv": {
     "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
   },
+  "runArgs": [
+    "--network",
+    "jasper_default",
+    "--network-alias",
+    "scv-web-devcontainer",
+    "--add-host",
+    "host.docker.internal:host-gateway"
+  ],
   "forwardPorts": [9006]
 }

--- a/api/Jobs/SyncAssignedCasesJob.cs
+++ b/api/Jobs/SyncAssignedCasesJob.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Hangfire;
 using JCCommon.Clients.FileServices;
 using LazyCache;
 using MapsterMapper;
@@ -36,6 +37,13 @@ public class SyncAssignedCasesJob(
     ILambdaInvokerService lambdaInvokerService = null)
     : RecurringJobBase<SyncAssignedCasesJob>(configuration, cache, mapper, logger)
 {
+    private const string ReservedJudgementsSourceName = "ReservedJudgements";
+    private const string AppearanceReasonCodesSourceName = "AppearanceReasonCodes";
+    private const string SeizedContinuationCasesSourceName = "ScheduledCasesSeizedContinuations";
+    private const string SeizedOtherCasesSourceName = "ScheduledCasesSeizedOthers";
+    private const string AssignedContinuationCasesSourceName = "ScheduledCasesAssignedContinuations";
+    private const string AssignedOtherCasesSourceName = "ScheduledCasesAssignedOthers";
+
     private readonly IEmailService _emailService = emailService;
     private readonly ICsvParser _csvParser = csvParser;
     private readonly IJudgeService _judgeService = judgeService;
@@ -52,47 +60,66 @@ public class SyncAssignedCasesJob(
     public override string CronSchedule =>
         this.Configuration.GetValue<string>("JOBS:SYNC_ASSIGNED_CASES_SCHEDULE") ?? base.CronSchedule;
 
+    [DisableConcurrentExecution(timeoutInSeconds: 3600)]
     public override async Task Execute()
     {
         try
         {
-            // Capture the current cases so they can be removed only after the replacement set is stored.
-            var existingCaseIds = (await _caseService.GetAllAsync())
-                .Select(existingCase => existingCase.Id)
-                .Where(id => !string.IsNullOrWhiteSpace(id))
-                .ToList();
-
-            // Retrieve every replacement case before attempting the transactional swap.
-            var retrievedCases = new List<CaseDto>();
+            var retrievalResults = new List<IRetrievalStepResult>();
 
             // RJs
-            retrievedCases.AddRange(await this.ProcessReservedJudgements());
+            var reservedJudgementsResult = await this.ProcessReservedJudgements();
+            reservedJudgementsResult.ThrowIfFailed(this.Logger);
+            retrievalResults.Add(reservedJudgementsResult);
 
             // Get appearance reason codes excluding CNT, DEC and ACT.
-            var apprReasonCodes = await GetAppearanceReasonCodes(CaseService.ContinuationReasonCodes);
+            var appearanceReasonCodesResult = await GetAppearanceReasonCodes(CaseService.ContinuationReasonCodes);
+            var apprReasonCodes = appearanceReasonCodesResult.GetRequiredPayload(this.Logger);
+            retrievalResults.Add(appearanceReasonCodesResult);
 
             // Get Seized scheduled CNTs, DECs and ACTs.
-            retrievedCases.AddRange(await this.ProcessScheduledCases(
+            var seizedContinuationCasesResult = await this.ProcessScheduledCases(
+                SeizedContinuationCasesSourceName,
                 string.Join(",", CaseService.ContinuationReasonCodes),
-                CaseService.SEIZED_RESTRICTION_CD));
+                CaseService.SEIZED_RESTRICTION_CD);
+            seizedContinuationCasesResult.ThrowIfFailed(this.Logger);
+            retrievalResults.Add(seizedContinuationCasesResult);
 
             // Get Other Seized
-            retrievedCases.AddRange(await this.ProcessScheduledCases(
+            var seizedOtherCasesResult = await this.ProcessScheduledCases(
+                SeizedOtherCasesSourceName,
                 apprReasonCodes,
-                CaseService.SEIZED_RESTRICTION_CD));
+                CaseService.SEIZED_RESTRICTION_CD);
+            seizedOtherCasesResult.ThrowIfFailed(this.Logger);
+            retrievalResults.Add(seizedOtherCasesResult);
 
             // Get Future Assigned - CNTs, DECs and ACTs.
-            retrievedCases.AddRange(await this.ProcessScheduledCases(
+            var assignedContinuationCasesResult = await this.ProcessScheduledCases(
+                AssignedContinuationCasesSourceName,
                 string.Join(",", CaseService.ContinuationReasonCodes),
-                CaseService.ASSIGNED_RESTRICTION_CD));
+                CaseService.ASSIGNED_RESTRICTION_CD);
+            assignedContinuationCasesResult.ThrowIfFailed(this.Logger);
+            retrievalResults.Add(assignedContinuationCasesResult);
 
             // Get Future Assigned - Others
-            retrievedCases.AddRange(await this.ProcessScheduledCases(
+            var assignedOtherCasesResult = await this.ProcessScheduledCases(
+                AssignedOtherCasesSourceName,
                 apprReasonCodes,
-                CaseService.ASSIGNED_RESTRICTION_CD));
+                CaseService.ASSIGNED_RESTRICTION_CD);
+            assignedOtherCasesResult.ThrowIfFailed(this.Logger);
+            retrievalResults.Add(assignedOtherCasesResult);
+
+            LogRetrievalCounts(retrievalResults);
+
+            var retrievedCases = reservedJudgementsResult.Payload
+                .Concat(seizedContinuationCasesResult.Payload)
+                .Concat(seizedOtherCasesResult.Payload)
+                .Concat(assignedContinuationCasesResult.Payload)
+                .Concat(assignedOtherCasesResult.Payload)
+                .ToList();
 
             // Store the new set and delete the old rows in one transactional replace operation.
-            var replaceResult = await _caseService.ReplaceAllAsync(existingCaseIds, retrievedCases);
+            var replaceResult = await _caseService.ReplaceAllAssignedCasesAsync(retrievedCases);
             if (!replaceResult.Succeeded)
             {
                 throw new InvalidOperationException("Failed to replace assigned cases.");
@@ -108,26 +135,35 @@ public class SyncAssignedCasesJob(
 
     #region Reserved Judgements Methods
 
-    private async Task<List<CaseDto>> ProcessReservedJudgements()
+    private async Task<RetrievalStepResult<List<CaseDto>>> ProcessReservedJudgements()
     {
+        const string sourceName = ReservedJudgementsSourceName;
+
         this.Logger.LogInformation("Starting to process today's reserved judgements.");
 
-        var newRJs = await GetNewReservedJudgements();
-        if (newRJs.Length == 0)
+        try
         {
-            this.Logger.LogInformation("No RJs have been processed");
-            return [];
+            var newRJs = await GetNewReservedJudgements();
+            if (newRJs.Length == 0)
+            {
+                this.Logger.LogInformation("No RJs have been processed");
+                return RetrievalStepResult<List<CaseDto>>.Success(sourceName, [], 0);
+            }
+
+            var validRJs = newRJs.Where(rj => rj.AppearanceId != null).ToList();
+            var failedCount = newRJs.Length - validRJs.Count;
+
+            var newRJsDtos = this.Mapper.Map<List<CaseDto>>(validRJs);
+
+            this.Logger.LogInformation("Received {AllRJsCount} RJs. Successfully processed {ValidRJsCount}. Failed: {FailedCount}.",
+                newRJs.Length, newRJsDtos.Count, failedCount);
+
+            return RetrievalStepResult<List<CaseDto>>.Success(sourceName, newRJsDtos, newRJsDtos.Count);
         }
-
-        var validRJs = newRJs.Where(rj => rj.AppearanceId != null).ToList();
-        var failedCount = newRJs.Length - validRJs.Count;
-
-        var newRJsDtos = this.Mapper.Map<List<CaseDto>>(validRJs);
-
-        this.Logger.LogInformation("Received {AllRJsCount} RJs. Successfully processed {ValidRJsCount}. Failed: {FailedCount}.",
-            newRJs.Length, newRJsDtos.Count, failedCount);
-
-        return newRJsDtos;
+        catch (Exception ex)
+        {
+            return RetrievalStepResult<List<CaseDto>>.Failure(sourceName, ex.Message);
+        }
     }
 
     private async Task<Db.Models.Case[]> GetNewReservedJudgements()
@@ -149,8 +185,7 @@ public class SyncAssignedCasesJob(
         var attachments = await _emailService.GetAttachmentsAsStreamsAsync(mailbox, recentMessage.Id, filename);
         if (attachments.Count == 0 || !attachments.ContainsKey(filename))
         {
-            this.Logger.LogWarning("No attachment found with filename: {Filename}", filename);
-            return [];
+            throw new InvalidOperationException($"Reserved judgements attachment {filename} was not found.");
         }
 
         this.Logger.LogInformation("Parsing the CSV file content.");
@@ -347,50 +382,57 @@ public class SyncAssignedCasesJob(
 
     #region Scheduled Cases (Decisions and Continuations) Methods
 
-    private async Task<List<CaseDto>> ProcessScheduledCases(string apprReasonCodes, string restrictionCode)
+    private async Task<RetrievalStepResult<List<CaseDto>>> ProcessScheduledCases(string sourceName, string apprReasonCodes, string restrictionCode)
     {
-        this.Logger.LogInformation("Starting to retrieve scheduled cases for {ApprReasonCodes} and {RestrictionCode}", apprReasonCodes, restrictionCode);
-
-        var scheduledCases = await this.GetScheduledCases(apprReasonCodes, restrictionCode);
-        if (scheduledCases.Count == 0)
+        try
         {
-            this.Logger.LogInformation(
-                "No data found for {ApprReasonCodes} and {RestrictionCode}.",
-                apprReasonCodes,
-                restrictionCode);
-            return [];
+            this.Logger.LogInformation("Starting to retrieve scheduled cases for {ApprReasonCodes} and {RestrictionCode}", apprReasonCodes, restrictionCode);
+
+            var scheduledCases = await this.GetScheduledCases(sourceName, apprReasonCodes, restrictionCode);
+            if (scheduledCases.Count == 0)
+            {
+                this.Logger.LogInformation(
+                    "No data found for {ApprReasonCodes} and {RestrictionCode}.",
+                    apprReasonCodes,
+                    restrictionCode);
+                return RetrievalStepResult<List<CaseDto>>.Success(sourceName, [], 0);
+            }
+
+            var scheduledData = await PopulateCaseInfoWithThrottling(
+                scheduledCases,
+                async c =>
+                {
+                    try
+                    {
+                        return await PopulateMissingInfoForScheduledCase(c);
+                    }
+                    catch
+                    {
+                        return PopulateScheduledCaseWithDefaults(c);
+                    }
+                },
+                c => $"{c.FileNumberTxt} (PhysicalFileId: {c.PhysicalFileId})",
+                "case");
+
+            var retrievedCases = scheduledData
+                .Select(c =>
+                {
+                    c.RestrictionCode = restrictionCode;
+                    return c;
+                })
+                .ToList();
+
+            this.Logger.LogInformation("Processed {ScheduledCasesCount} scheduled cases for {RestrictionCode}", scheduledData.Length, restrictionCode);
+
+            return RetrievalStepResult<List<CaseDto>>.Success(sourceName, retrievedCases, retrievedCases.Count);
         }
-
-        var scheduledData = await PopulateCaseInfoWithThrottling(
-            scheduledCases,
-            async c =>
-            {
-                try
-                {
-                    return await PopulateMissingInfoForScheduledCase(c);
-                }
-                catch
-                {
-                    return PopulateScheduledCaseWithDefaults(c);
-                }
-            },
-            c => $"{c.FileNumberTxt} (PhysicalFileId: {c.PhysicalFileId})",
-            "case");
-
-        var retrievedCases = scheduledData
-            .Select(c =>
-            {
-                c.RestrictionCode = restrictionCode;
-                return c;
-            })
-            .ToList();
-
-        this.Logger.LogInformation("Processed {ScheduledCasesCount} scheduled cases for {RestrictionCode}", scheduledData.Length, restrictionCode);
-
-        return retrievedCases;
+        catch (Exception ex)
+        {
+            return RetrievalStepResult<List<CaseDto>>.Failure(sourceName, ex.Message);
+        }
     }
 
-    private async Task<ICollection<Case>> GetScheduledCases(string apprReasonCodes, string restrictionCode)
+    private async Task<ICollection<Case>> GetScheduledCases(string sourceName, string apprReasonCodes, string restrictionCode)
     {
         // Retrieve the Scheduled Cases by invoking a lambda function to avoid API Gateway's timeout.
         // The endpoint is expected to take a while to get the data specially in PROD.
@@ -409,14 +451,26 @@ public class SyncAssignedCasesJob(
 
             if (response == null || !response.Success)
             {
-                this.Logger.LogError("Failed to retrieve scheduled cases from Lambda: {Error}", response?.Error);
-                return Array.Empty<Case>();
+                var errorMessage = response?.Error ?? "No response was returned.";
+                this.Logger.LogError("Failed to retrieve scheduled cases from Lambda for source {SourceName}: {Error}", sourceName, errorMessage);
+                throw new InvalidOperationException($"Failed to retrieve scheduled cases for source {sourceName}: {errorMessage}");
+            }
+
+            if (response.Data == null)
+            {
+                throw new InvalidOperationException($"Scheduled cases response for source {sourceName} did not contain data.");
             }
 
             return response.Data;
         }
 
-        return await _jcServiceClient.GetUpcomingSeizedAssignedCasesAsync(apprReasonCodes, restrictionCode);
+        var scheduledCases = await _jcServiceClient.GetUpcomingSeizedAssignedCasesAsync(apprReasonCodes, restrictionCode);
+        if (scheduledCases == null)
+        {
+            throw new InvalidOperationException($"Scheduled cases source {sourceName} returned null.");
+        }
+
+        return scheduledCases;
     }
 
     private async Task<CaseDto> PopulateMissingInfoForScheduledCase(PCSSCommon.Models.Case @case)
@@ -505,32 +559,107 @@ public class SyncAssignedCasesJob(
         return caseDto;
     }
 
-    private async Task<string> GetAppearanceReasonCodes(IEnumerable<string> excludeApprCodes)
+    private async Task<RetrievalStepResult<string>> GetAppearanceReasonCodes(IEnumerable<string> excludeApprCodes)
     {
-        async Task<ICollection<AppearanceReason>> CriminalAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsCriminalAsync();
-        async Task<ICollection<AppearanceReason>> CivilAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsCivilAsync();
-        async Task<ICollection<AppearanceReason>> FamilyAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsFamilyAsync();
-        async Task<ICollection<AppearanceReason>> JustinAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsJustinAsync();
-        async Task<ICollection<AppearanceReason>> CeisAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsCeisAsync();
+        const string sourceName = AppearanceReasonCodesSourceName;
 
-        var criminalTask = this.Cache.GetOrAddAsync("CriminalAppearanceReasons", CriminalAppearanceReasons);
-        var civilTask = this.Cache.GetOrAddAsync("CivilAppearanceReasons", CivilAppearanceReasons);
-        var familyTask = this.Cache.GetOrAddAsync("FamilyAppearanceReasons", FamilyAppearanceReasons);
-        var justinTask = this.Cache.GetOrAddAsync("JustinAppearanceReasons", JustinAppearanceReasons);
-        var ceisTask = this.Cache.GetOrAddAsync("CeisAppearanceReasons", CeisAppearanceReasons);
+        try
+        {
+            async Task<ICollection<AppearanceReason>> CriminalAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsCriminalAsync();
+            async Task<ICollection<AppearanceReason>> CivilAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsCivilAsync();
+            async Task<ICollection<AppearanceReason>> FamilyAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsFamilyAsync();
+            async Task<ICollection<AppearanceReason>> JustinAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsJustinAsync();
+            async Task<ICollection<AppearanceReason>> CeisAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsCeisAsync();
 
-        await Task.WhenAll(criminalTask, civilTask, familyTask, justinTask, ceisTask);
+            var criminalTask = this.Cache.GetOrAddAsync("CriminalAppearanceReasons", CriminalAppearanceReasons);
+            var civilTask = this.Cache.GetOrAddAsync("CivilAppearanceReasons", CivilAppearanceReasons);
+            var familyTask = this.Cache.GetOrAddAsync("FamilyAppearanceReasons", FamilyAppearanceReasons);
+            var justinTask = this.Cache.GetOrAddAsync("JustinAppearanceReasons", JustinAppearanceReasons);
+            var ceisTask = this.Cache.GetOrAddAsync("CeisAppearanceReasons", CeisAppearanceReasons);
 
-        var appearanceReasons = criminalTask.Result
-            .Concat(civilTask.Result)
-            .Concat(familyTask.Result)
-            .Concat(justinTask.Result)
-            .Concat(ceisTask.Result)
-            .OrderBy(a => a.Code);
+            await Task.WhenAll(criminalTask, civilTask, familyTask, justinTask, ceisTask);
 
-        var commaDelimitedCodes = string.Join(",", appearanceReasons.Select(a => a.Code).Except(excludeApprCodes).Distinct());
+            var appearanceReasonCodes = criminalTask.Result
+                .Concat(civilTask.Result)
+                .Concat(familyTask.Result)
+                .Concat(justinTask.Result)
+                .Concat(ceisTask.Result)
+                .Select(a => a.Code)
+                .Except(excludeApprCodes)
+                .Where(code => !string.IsNullOrWhiteSpace(code))
+                .Distinct()
+                .OrderBy(code => code)
+                .ToList();
 
-        return commaDelimitedCodes;
+            if (appearanceReasonCodes.Count == 0)
+            {
+                return RetrievalStepResult<string>.Failure(sourceName, "No appearance reason codes were returned for the required scheduled-case sources.");
+            }
+
+            return RetrievalStepResult<string>.Success(sourceName, string.Join(",", appearanceReasonCodes), appearanceReasonCodes.Count);
+        }
+        catch (Exception ex)
+        {
+            return RetrievalStepResult<string>.Failure(sourceName, ex.Message);
+        }
+    }
+
+    private void LogRetrievalCounts(IEnumerable<IRetrievalStepResult> retrievalResults)
+    {
+        foreach (var retrievalResult in retrievalResults)
+        {
+            this.Logger.LogInformation(
+                "Retrieval source {SourceName} completed successfully with {ItemCount} item(s).",
+                retrievalResult.SourceName,
+                retrievalResult.Count);
+        }
+    }
+
+    private interface IRetrievalStepResult
+    {
+        string SourceName { get; }
+
+        bool Succeeded { get; }
+
+        int Count { get; }
+
+        string ErrorMessage { get; }
+    }
+
+    private sealed record RetrievalStepResult<TPayload>(
+        string SourceName,
+        bool Succeeded,
+        int Count,
+        TPayload Payload,
+        string ErrorMessage = null) : IRetrievalStepResult
+    {
+        public TPayload GetRequiredPayload(ILogger logger)
+        {
+            ThrowIfFailed(logger);
+            return this.Payload;
+        }
+
+        public void ThrowIfFailed(ILogger logger)
+        {
+            if (this.Succeeded)
+            {
+                return;
+            }
+
+            logger.LogError(
+                "Assigned case retrieval failed for source {SourceName}: {ErrorMessage}",
+                this.SourceName,
+                this.ErrorMessage);
+
+            throw new InvalidOperationException(
+                $"Assigned case retrieval failed for source {this.SourceName}: {this.ErrorMessage}");
+        }
+
+        public static RetrievalStepResult<TPayload> Success(string sourceName, TPayload payload, int count)
+            => new(sourceName, true, count, payload);
+
+        public static RetrievalStepResult<TPayload> Failure(string sourceName, string errorMessage)
+            => new(sourceName, false, 0, default, errorMessage);
     }
 
     #endregion Scheduled Cases

--- a/api/Jobs/SyncAssignedCasesJob.cs
+++ b/api/Jobs/SyncAssignedCasesJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -56,27 +56,47 @@ public class SyncAssignedCasesJob(
     {
         try
         {
-            // Delete all existing cases before processing new ones.
-            var existingCases = await _caseService.GetAllAsync();
-            await _caseService.DeleteRangeAsync([.. existingCases.Select(rj => rj.Id)]);
+            // Capture the current cases so they can be removed only after the replacement set is stored.
+            var existingCaseIds = (await _caseService.GetAllAsync())
+                .Select(existingCase => existingCase.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .ToList();
+
+            // Retrieve every replacement case before attempting the transactional swap.
+            var retrievedCases = new List<CaseDto>();
 
             // RJs
-            await this.ProcessReservedJudgements();
+            retrievedCases.AddRange(await this.ProcessReservedJudgements());
 
             // Get appearance reason codes excluding CNT, DEC and ACT.
             var apprReasonCodes = await GetAppearanceReasonCodes(CaseService.ContinuationReasonCodes);
 
             // Get Seized scheduled CNTs, DECs and ACTs.
-            await this.ProcessScheduledCases(string.Join(",", CaseService.ContinuationReasonCodes), CaseService.SEIZED_RESTRICTION_CD);
+            retrievedCases.AddRange(await this.ProcessScheduledCases(
+                string.Join(",", CaseService.ContinuationReasonCodes),
+                CaseService.SEIZED_RESTRICTION_CD));
 
             // Get Other Seized
-            await this.ProcessScheduledCases(apprReasonCodes, CaseService.SEIZED_RESTRICTION_CD);
+            retrievedCases.AddRange(await this.ProcessScheduledCases(
+                apprReasonCodes,
+                CaseService.SEIZED_RESTRICTION_CD));
 
             // Get Future Assigned - CNTs, DECs and ACTs.
-            await this.ProcessScheduledCases(string.Join(",", CaseService.ContinuationReasonCodes), CaseService.ASSIGNED_RESTRICTION_CD);
+            retrievedCases.AddRange(await this.ProcessScheduledCases(
+                string.Join(",", CaseService.ContinuationReasonCodes),
+                CaseService.ASSIGNED_RESTRICTION_CD));
 
             // Get Future Assigned - Others
-            await this.ProcessScheduledCases(apprReasonCodes, CaseService.ASSIGNED_RESTRICTION_CD);
+            retrievedCases.AddRange(await this.ProcessScheduledCases(
+                apprReasonCodes,
+                CaseService.ASSIGNED_RESTRICTION_CD));
+
+            // Store the new set and delete the old rows in one transactional replace operation.
+            var replaceResult = await _caseService.ReplaceAllAsync(existingCaseIds, retrievedCases);
+            if (!replaceResult.Succeeded)
+            {
+                throw new InvalidOperationException("Failed to replace assigned cases.");
+            }
 
             this.Logger.LogInformation("SyncAssignedCasesJob completed successfully.");
         }
@@ -88,7 +108,7 @@ public class SyncAssignedCasesJob(
 
     #region Reserved Judgements Methods
 
-    private async Task ProcessReservedJudgements()
+    private async Task<List<CaseDto>> ProcessReservedJudgements()
     {
         this.Logger.LogInformation("Starting to process today's reserved judgements.");
 
@@ -96,17 +116,18 @@ public class SyncAssignedCasesJob(
         if (newRJs.Length == 0)
         {
             this.Logger.LogInformation("No RJs have been processed");
-            return;
+            return [];
         }
 
         var validRJs = newRJs.Where(rj => rj.AppearanceId != null).ToList();
         var failedCount = newRJs.Length - validRJs.Count;
 
         var newRJsDtos = this.Mapper.Map<List<CaseDto>>(validRJs);
-        await _caseService.AddRangeAsync(newRJsDtos);
 
         this.Logger.LogInformation("Received {AllRJsCount} RJs. Successfully processed {ValidRJsCount}. Failed: {FailedCount}.",
             newRJs.Length, newRJsDtos.Count, failedCount);
+
+        return newRJsDtos;
     }
 
     private async Task<Db.Models.Case[]> GetNewReservedJudgements()
@@ -326,7 +347,7 @@ public class SyncAssignedCasesJob(
 
     #region Scheduled Cases (Decisions and Continuations) Methods
 
-    private async Task ProcessScheduledCases(string apprReasonCodes, string restrictionCode)
+    private async Task<List<CaseDto>> ProcessScheduledCases(string apprReasonCodes, string restrictionCode)
     {
         this.Logger.LogInformation("Starting to retrieve scheduled cases for {ApprReasonCodes} and {RestrictionCode}", apprReasonCodes, restrictionCode);
 
@@ -337,7 +358,7 @@ public class SyncAssignedCasesJob(
                 "No data found for {ApprReasonCodes} and {RestrictionCode}.",
                 apprReasonCodes,
                 restrictionCode);
-            return;
+            return [];
         }
 
         var scheduledData = await PopulateCaseInfoWithThrottling(
@@ -356,14 +377,17 @@ public class SyncAssignedCasesJob(
             c => $"{c.FileNumberTxt} (PhysicalFileId: {c.PhysicalFileId})",
             "case");
 
-        await _caseService.AddRangeAsync([.. scheduledData
-            .Select(c => {
+        var retrievedCases = scheduledData
+            .Select(c =>
+            {
                 c.RestrictionCode = restrictionCode;
                 return c;
             })
-        ]);
+            .ToList();
 
         this.Logger.LogInformation("Processed {ScheduledCasesCount} scheduled cases for {RestrictionCode}", scheduledData.Length, restrictionCode);
+
+        return retrievedCases;
     }
 
     private async Task<ICollection<Case>> GetScheduledCases(string apprReasonCodes, string restrictionCode)
@@ -391,10 +415,8 @@ public class SyncAssignedCasesJob(
 
             return response.Data;
         }
-        else
-        {
-            return await _jcServiceClient.GetUpcomingSeizedAssignedCasesAsync(apprReasonCodes, restrictionCode);
-        }
+
+        return await _jcServiceClient.GetUpcomingSeizedAssignedCasesAsync(apprReasonCodes, restrictionCode);
     }
 
     private async Task<CaseDto> PopulateMissingInfoForScheduledCase(PCSSCommon.Models.Case @case)
@@ -411,11 +433,8 @@ public class SyncAssignedCasesJob(
         {
             CourtClassCd.A or CourtClassCd.Y or CourtClassCd.T
                 => await PopulateCriminalCaseInfo(caseDto, @case),
-
             CourtClassCd.C or CourtClassCd.F or CourtClassCd.L or CourtClassCd.M
                 => await PopulateCivilCaseInfo(caseDto, @case),
-
-
             _ => HandleUnsupportedCourtClass(caseDto, @case)
         };
     }
@@ -494,11 +513,11 @@ public class SyncAssignedCasesJob(
         async Task<ICollection<AppearanceReason>> JustinAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsJustinAsync();
         async Task<ICollection<AppearanceReason>> CeisAppearanceReasons() => await _lookupServicesClient.GetAppearanceReasonsCeisAsync();
 
-        var criminalTask = this.Cache.GetOrAddAsync($"CriminalAppearanceReasons", CriminalAppearanceReasons);
-        var civilTask = this.Cache.GetOrAddAsync($"CivilAppearanceReasons", CivilAppearanceReasons);
-        var familyTask = this.Cache.GetOrAddAsync($"FamilyAppearanceReasons", FamilyAppearanceReasons);
-        var justinTask = this.Cache.GetOrAddAsync($"JustinAppearanceReasons", JustinAppearanceReasons);
-        var ceisTask = this.Cache.GetOrAddAsync($"CeisAppearanceReasons", CeisAppearanceReasons);
+        var criminalTask = this.Cache.GetOrAddAsync("CriminalAppearanceReasons", CriminalAppearanceReasons);
+        var civilTask = this.Cache.GetOrAddAsync("CivilAppearanceReasons", CivilAppearanceReasons);
+        var familyTask = this.Cache.GetOrAddAsync("FamilyAppearanceReasons", FamilyAppearanceReasons);
+        var justinTask = this.Cache.GetOrAddAsync("JustinAppearanceReasons", JustinAppearanceReasons);
+        var ceisTask = this.Cache.GetOrAddAsync("CeisAppearanceReasons", CeisAppearanceReasons);
 
         await Task.WhenAll(criminalTask, civilTask, familyTask, justinTask, ceisTask);
 

--- a/api/Services/CaseService.cs
+++ b/api/Services/CaseService.cs
@@ -5,9 +5,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using LazyCache;
 using MapsterMapper;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Scv.Core.Helpers.Extensions;
 using Scv.Core.Infrastructure;
+using Scv.Db.Contexts;
 using Scv.Db.Models;
 using Scv.Db.Repositories;
 using Scv.Models;
@@ -17,18 +19,22 @@ namespace Scv.Api.Services;
 public interface ICaseService : ICrudService<CaseDto>
 {
     Task<OperationResult<CaseResponse>> GetAssignedCasesAsync(int judgeId);
+    Task<OperationResult> ReplaceAllAsync(List<string> existingIds, List<CaseDto> newCases);
 }
 
 public class CaseService(
     IAppCache cache,
     IMapper mapper,
     ILogger<CaseService> logger,
-    IRepositoryBase<Case> judgementRepo) : CrudServiceBase<IRepositoryBase<Case>, Case, CaseDto>(
+    IRepositoryBase<Case> judgementRepo,
+    JasperDbContext dbContext) : CrudServiceBase<IRepositoryBase<Case>, Case, CaseDto>(
         cache,
         mapper,
         logger,
         judgementRepo), ICaseService
 {
+    private readonly JasperDbContext _dbContext = dbContext;
+
     public override string CacheName => "GetCasesAsync";
 
     public const string DECISION_APPR_REASON_CD = "DEC";
@@ -48,6 +54,44 @@ public class CaseService(
 
     public override Task<OperationResult<CaseDto>> ValidateAsync(CaseDto dto, bool isEdit = false)
         => Task.FromResult(OperationResult<CaseDto>.Success(dto));
+
+    public async Task<OperationResult> ReplaceAllAsync(List<string> existingIds, List<CaseDto> newCases)
+    {
+        try
+        {
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync();
+
+            if (newCases.Count > 0)
+            {
+                var newEntities = this.Mapper.Map<List<Case>>(newCases);
+                await _dbContext.Cases.AddRangeAsync(newEntities);
+            }
+
+            if (existingIds.Count > 0)
+            {
+                var existingEntities = await _dbContext.Cases
+                    .Where(c => existingIds.Contains(c.Id))
+                    .ToListAsync();
+
+                if (existingEntities.Count > 0)
+                {
+                    _dbContext.Cases.RemoveRange(existingEntities);
+                }
+            }
+
+            await _dbContext.SaveChangesAsync();
+            await transaction.CommitAsync();
+
+            this.InvalidateCache(this.CacheName);
+
+            return OperationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            this.Logger.LogError(ex, "Error replacing cases: {Message}", ex.Message);
+            return OperationResult.Failure("Error replacing cases.");
+        }
+    }
 
     public async Task<OperationResult<CaseResponse>> GetAssignedCasesAsync(int judgeId)
     {

--- a/api/Services/CaseService.cs
+++ b/api/Services/CaseService.cs
@@ -19,7 +19,7 @@ namespace Scv.Api.Services;
 public interface ICaseService : ICrudService<CaseDto>
 {
     Task<OperationResult<CaseResponse>> GetAssignedCasesAsync(int judgeId);
-    Task<OperationResult> ReplaceAllAsync(List<string> existingIds, List<CaseDto> newCases);
+    Task<OperationResult> ReplaceAllAssignedCasesAsync(List<CaseDto> replacementCases);
 }
 
 public class CaseService(
@@ -33,6 +33,8 @@ public class CaseService(
         logger,
         judgementRepo), ICaseService
 {
+    private const int ReplaceDeleteBatchSize = 500;
+
     private readonly JasperDbContext _dbContext = dbContext;
 
     public override string CacheName => "GetCasesAsync";
@@ -55,31 +57,33 @@ public class CaseService(
     public override Task<OperationResult<CaseDto>> ValidateAsync(CaseDto dto, bool isEdit = false)
         => Task.FromResult(OperationResult<CaseDto>.Success(dto));
 
-    public async Task<OperationResult> ReplaceAllAsync(List<string> existingIds, List<CaseDto> newCases)
+    public async Task<OperationResult> ReplaceAllAssignedCasesAsync(List<CaseDto> replacementCases)
     {
         try
         {
-            await using var transaction = await _dbContext.Database.BeginTransactionAsync();
+            var existingIds = await _dbContext.Cases
+                .Select(@case => @case.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .ToListAsync();
 
-            if (newCases.Count > 0)
-            {
-                var newEntities = this.Mapper.Map<List<Case>>(newCases);
-                await _dbContext.Cases.AddRangeAsync(newEntities);
-            }
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync();
 
             if (existingIds.Count > 0)
             {
-                var existingEntities = await _dbContext.Cases
-                    .Where(c => existingIds.Contains(c.Id))
-                    .ToListAsync();
-
-                if (existingEntities.Count > 0)
+                foreach (var batch in existingIds.Chunk(ReplaceDeleteBatchSize))
                 {
-                    _dbContext.Cases.RemoveRange(existingEntities);
+                    _dbContext.Cases.RemoveRange(batch.Select(id => new Case { Id = id }));
+                    await _dbContext.SaveChangesAsync();
                 }
             }
 
-            await _dbContext.SaveChangesAsync();
+            if (replacementCases.Count > 0)
+            {
+                var replacementEntities = this.Mapper.Map<List<Case>>(replacementCases);
+                await _dbContext.Cases.AddRangeAsync(replacementEntities);
+                await _dbContext.SaveChangesAsync();
+            }
+
             await transaction.CommitAsync();
 
             this.InvalidateCache(this.CacheName);

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -312,13 +312,52 @@ services:
 
   db-mongo:
     image: mongo:latest
+    command: >
+      bash -c "
+        if [ ! -f /data/configdb/keyfile ]; then
+          openssl rand -base64 756 > /data/configdb/keyfile;
+          chmod 400 /data/configdb/keyfile;
+          chown 999:999 /data/configdb/keyfile;
+        fi;
+        exec mongod --replSet rs0 --bind_ip_all --keyFile /data/configdb/keyfile
+      "
     ports:
       - 27017:27017
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGODB_USER}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_PASSWORD}
     volumes:
-      - ${LOCAL_WORKSPACE_FOLDER-.}/tmp-mongo:/tmp-mongo
+      - ${LOCAL_WORKSPACE_FOLDER-.}/tmp-mongo:/data/db
+      - mongo-keyfile:/data/configdb
+
+  db-mongo-init:
+    image: mongo:latest
+    depends_on:
+      - db-mongo
+    restart: 'no'
+    environment:
+      MONGODB_USER: ${MONGODB_USER}
+      MONGODB_PASSWORD: ${MONGODB_PASSWORD}
+    entrypoint: >
+      bash -c '
+        until mongosh --host db-mongo:27017 -u "$${MONGODB_USER}" -p "$${MONGODB_PASSWORD}" --authenticationDatabase admin --eval "db.adminCommand(\"ping\")" > /dev/null 2>&1;
+        do
+          sleep 2;
+        done;
+
+        mongosh --host db-mongo:27017 -u "$${MONGODB_USER}" -p "$${MONGODB_PASSWORD}" --authenticationDatabase admin --eval "
+          try {
+            rs.status();
+          } catch (e) {
+            rs.initiate({
+              _id: \"rs0\",
+              members: [
+                { _id: 0, host: \"db-mongo:27017\" }
+              ]
+            });
+          }
+        "
+      '
 
   clamav:
     image: clamav/clamav@sha256:c6eb128c7bd57bb0c533491198753a2130b471c517605ad8d289174a56c450a8 # v1.5.2
@@ -338,3 +377,4 @@ volumes:
   clamav-db:
   transitory-documents-api-dev-bin:
   transitory-documents-api-dev-obj:
+  mongo-keyfile:

--- a/docker/manage
+++ b/docker/manage
@@ -61,8 +61,8 @@ exit 1
 # -----------------------------------------------------------------------------------------------------------------
 # Default Settings:
 # -----------------------------------------------------------------------------------------------------------------
-RUNTIME_CONTAINERS="db-pg db-mongo clamav api web transitory-documents-api"
-DEBUG_CONTAINERS="db-pg db-mongo clamav api web-dev transitory-documents-api"
+RUNTIME_CONTAINERS="db-pg db-mongo db-mongo-init clamav api web transitory-documents-api"
+DEBUG_CONTAINERS="db-pg db-mongo db-mongo-init clamav api web-dev transitory-documents-api"
 # -----------------------------------------------------------------------------------------------------------------
 # Functions:
 # -----------------------------------------------------------------------------------------------------------------

--- a/tests/api/Jobs/SyncAssignedCasesJobTests.cs
+++ b/tests/api/Jobs/SyncAssignedCasesJobTests.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Bogus;
+using Hangfire;
 using LazyCache;
 using LazyCache.Providers;
 using Mapster;
@@ -150,18 +152,9 @@ public class SyncAssignedCasesJobTests
     }
 
     [Fact]
-    public async Task Execute_DeletesPreExistingCases_AfterSavingRetrievedCases()
+    public async Task Execute_ReplacesExistingCases_AfterSavingRetrievedCases()
     {
         SetupBasicMocks();
-        var firstExistingCaseId = _faker.Random.AlphaNumeric(24);
-        var secondExistingCaseId = _faker.Random.AlphaNumeric(24);
-        var existingCases = new List<CaseDto>
-        {
-            new() { Id = firstExistingCaseId },
-            new() { Id = secondExistingCaseId }
-        };
-
-        _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync(existingCases);
         SetupNoReservedJudgements();
 
         _mockJcServiceClient.SetupSequence(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
@@ -170,11 +163,7 @@ public class SyncAssignedCasesJobTests
             .ReturnsAsync([])
             .ReturnsAsync([]);
 
-        _mockCaseService.Setup(s => s.ReplaceAllAsync(
-                It.Is<List<string>>(ids =>
-                    ids.Count == 2
-                    && ids[0] == firstExistingCaseId
-                    && ids[1] == secondExistingCaseId),
+        _mockCaseService.Setup(s => s.ReplaceAllAssignedCasesAsync(
                 It.Is<List<CaseDto>>(cases =>
                 cases.Count == 1
                 && cases[0].RestrictionCode == CaseService.SEIZED_RESTRICTION_CD
@@ -184,23 +173,17 @@ public class SyncAssignedCasesJobTests
 
         await _job.Execute();
 
-        _mockCaseService.Verify(s => s.ReplaceAllAsync(It.Is<List<string>>(ids =>
-            ids.Count == 2
-            && ids[0] == firstExistingCaseId
-            && ids[1] == secondExistingCaseId), It.IsAny<List<CaseDto>>()), Times.Once);
+        _mockCaseService.Verify(s => s.ReplaceAllAssignedCasesAsync(It.Is<List<CaseDto>>(cases =>
+            cases.Count == 1
+            && cases[0].RestrictionCode == CaseService.SEIZED_RESTRICTION_CD
+            && cases[0].Reason == CaseService.DECISION_APPR_REASON_CD)), Times.Once);
+        _mockCaseService.Verify(s => s.GetAllAsync(), Times.Never);
     }
 
     [Fact]
-    public async Task Execute_DeletesAllPreExistingCases_WhenRetrievalSucceedsWithNoNewCases()
+    public async Task Execute_ReplacesExistingCases_WhenRetrievalSucceedsWithNoNewCases()
     {
         SetupBasicMocks();
-        var existingCases = new List<CaseDto>
-        {
-            new() { Id = _faker.Random.AlphaNumeric(24) },
-            new() { Id = _faker.Random.AlphaNumeric(24) }
-        };
-
-        _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync(existingCases);
         SetupNoReservedJudgements();
 
         _mockJcServiceClient.Setup(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
@@ -208,10 +191,7 @@ public class SyncAssignedCasesJobTests
 
         await _job.Execute();
 
-        _mockCaseService.Verify(s => s.ReplaceAllAsync(It.Is<List<string>>(ids =>
-            ids.Count == 2
-            && ids[0] == existingCases[0].Id
-            && ids[1] == existingCases[1].Id), It.Is<List<CaseDto>>(cases => cases.Count == 0)), Times.Once);
+        _mockCaseService.Verify(s => s.ReplaceAllAssignedCasesAsync(It.Is<List<CaseDto>>(cases => cases.Count == 0)), Times.Once);
     }
 
     [Fact]
@@ -311,7 +291,10 @@ public class SyncAssignedCasesJobTests
                 It.IsAny<bool>()))
             .ReturnsAsync([]);
 
-        _mockJcServiceClient.Setup(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+        _mockJcServiceClient.SetupSequence(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([])
+            .ReturnsAsync([])
+            .ReturnsAsync([])
             .ReturnsAsync([]);
 
         await _job.Execute();
@@ -429,8 +412,8 @@ public class SyncAssignedCasesJobTests
             });
 
         List<CaseDto> capturedCases = null;
-        _mockCaseService.Setup(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()))
-            .Callback<List<string>, List<CaseDto>>((_, cases) => capturedCases = cases)
+        _mockCaseService.Setup(s => s.ReplaceAllAssignedCasesAsync(It.IsAny<List<CaseDto>>()))
+            .Callback<List<CaseDto>>(cases => capturedCases = cases)
             .ReturnsAsync(OperationResult.Success());
 
         await _job.Execute();
@@ -490,8 +473,8 @@ public class SyncAssignedCasesJobTests
             });
 
         List<CaseDto> capturedCases = null;
-        _mockCaseService.Setup(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()))
-            .Callback<List<string>, List<CaseDto>>((_, cases) => capturedCases = cases)
+        _mockCaseService.Setup(s => s.ReplaceAllAssignedCasesAsync(It.IsAny<List<CaseDto>>()))
+            .Callback<List<CaseDto>>(cases => capturedCases = cases)
             .ReturnsAsync(OperationResult.Success());
 
         await _job.Execute();
@@ -534,8 +517,11 @@ public class SyncAssignedCasesJobTests
             }
         };
 
-        _mockJcServiceClient.Setup(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(scheduledCases);
+        _mockJcServiceClient.SetupSequence(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(scheduledCases)
+            .ReturnsAsync([])
+            .ReturnsAsync([])
+            .ReturnsAsync([]);
 
         _courtListServiceFixture.MockCourtListService
             .Setup(c => c.GetJudgeCourtListAppearances(It.IsAny<int>(), It.IsAny<DateTime>()))
@@ -553,7 +539,7 @@ public class SyncAssignedCasesJobTests
                 It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("No participants found")),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Exactly(4));
+            Times.Once);
     }
 
     [Fact]
@@ -561,15 +547,6 @@ public class SyncAssignedCasesJobTests
     {
         SetupBasicMocks();
         var existingCaseId = _faker.Random.AlphaNumeric(24);
-
-        _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync([
-            new CaseDto
-            {
-                Id = existingCaseId,
-                Reason = CaseService.DECISION_APPR_REASON_CD,
-                RestrictionCode = CaseService.SEIZED_RESTRICTION_CD
-            }
-        ]);
 
         SetupNoReservedJudgements();
 
@@ -579,9 +556,7 @@ public class SyncAssignedCasesJobTests
             .ReturnsAsync([])
             .ReturnsAsync([]);
 
-        _mockCaseService.Setup(s => s.ReplaceAllAsync(
-                It.Is<List<string>>(ids => ids.Count == 1 && ids[0] == existingCaseId),
-                It.IsAny<List<CaseDto>>()))
+        _mockCaseService.Setup(s => s.ReplaceAllAssignedCasesAsync(It.IsAny<List<CaseDto>>()))
             .ThrowsAsync(new Exception("Database error"));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => _job.Execute());
@@ -592,15 +567,6 @@ public class SyncAssignedCasesJobTests
     {
         SetupBasicMocks();
 
-        _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync([
-            new CaseDto
-            {
-                Id = _faker.Random.AlphaNumeric(24),
-                Reason = CaseService.DECISION_APPR_REASON_CD,
-                RestrictionCode = CaseService.SEIZED_RESTRICTION_CD
-            }
-        ]);
-
         SetupNoReservedJudgements();
 
         _mockJcServiceClient.Setup(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
@@ -608,17 +574,13 @@ public class SyncAssignedCasesJobTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => _job.Execute());
 
-        _mockCaseService.Verify(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()), Times.Never);
+        _mockCaseService.Verify(s => s.ReplaceAllAssignedCasesAsync(It.IsAny<List<CaseDto>>()), Times.Never);
     }
 
     [Fact]
     public async Task Execute_DoesNotDeletePreExistingCases_WhenSaveFails()
     {
         SetupBasicMocks();
-
-        _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync([
-            new CaseDto { Id = _faker.Random.AlphaNumeric(24) }
-        ]);
 
         SetupNoReservedJudgements();
 
@@ -628,12 +590,23 @@ public class SyncAssignedCasesJobTests
             .ReturnsAsync([])
             .ReturnsAsync([]);
 
-        _mockCaseService.Setup(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()))
+        _mockCaseService.Setup(s => s.ReplaceAllAssignedCasesAsync(It.IsAny<List<CaseDto>>()))
             .ReturnsAsync(OperationResult.Failure("Save failed"));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => _job.Execute());
 
-        _mockCaseService.Verify(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()), Times.Once);
+        _mockCaseService.Verify(s => s.ReplaceAllAssignedCasesAsync(It.IsAny<List<CaseDto>>()), Times.Once);
+    }
+
+    [Fact]
+    public void Execute_HasDisableConcurrentExecutionAttribute()
+    {
+        var method = typeof(SyncAssignedCasesJob).GetMethod(nameof(SyncAssignedCasesJob.Execute));
+
+        var attribute = method?.GetCustomAttribute<DisableConcurrentExecutionAttribute>();
+
+        Assert.NotNull(attribute);
+        Assert.Equal(3600, attribute.TimeoutSec);
     }
 
     [Fact]
@@ -776,7 +749,7 @@ public class SyncAssignedCasesJobTests
                 It.IsAny<TimeSpan?>()))
             .ReturnsAsync(lambdaResponse);
 
-        await _job.Execute();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _job.Execute());
 
         _mockLogger.Verify(
             x => x.Log(
@@ -785,18 +758,42 @@ public class SyncAssignedCasesJobTests
                 It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("Failed to retrieve scheduled cases from Lambda")),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Exactly(4));
+            Times.Once);
+
+        _mockCaseService.Verify(s => s.ReplaceAllAssignedCasesAsync(It.IsAny<List<CaseDto>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_DoesNotReplaceExistingCases_WhenAppearanceReasonCodesAreUnavailable()
+    {
+        SetupBasicMocks();
+        SetupNoReservedJudgements();
+
+        _mockLookupServiceClient
+            .Setup(l => l.GetAppearanceReasonsCriminalAsync())
+            .ReturnsAsync([
+                new AppearanceReason { Code = CaseService.DECISION_APPR_REASON_CD },
+                new AppearanceReason { Code = CaseService.CONTINUATION_APPR_REASON_CD },
+                new AppearanceReason { Code = CaseService.ADDTL_CNT_TIME_APPR_REASON_CD },
+                new AppearanceReason { Code = CaseService.SENTENCE_HEARING_APPR_REASON_CD }
+            ]);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _job.Execute());
+
+        _mockCaseService.Verify(s => s.ReplaceAllAssignedCasesAsync(It.IsAny<List<CaseDto>>()), Times.Never);
     }
 
     private void SetupBasicMocks()
     {
         _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync([]);
-        _mockCaseService.Setup(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()))
+        _mockCaseService.Setup(s => s.ReplaceAllAssignedCasesAsync(It.IsAny<List<CaseDto>>()))
             .ReturnsAsync(OperationResult.Success());
 
         _mockLookupServiceClient
             .Setup(l => l.GetAppearanceReasonsCriminalAsync())
-            .ReturnsAsync([]);
+            .ReturnsAsync([
+                new AppearanceReason { Code = "OTH" }
+            ]);
         _mockLookupServiceClient
             .Setup(l => l.GetAppearanceReasonsCivilAsync())
             .ReturnsAsync([]);

--- a/tests/api/Jobs/SyncAssignedCasesJobTests.cs
+++ b/tests/api/Jobs/SyncAssignedCasesJobTests.cs
@@ -150,7 +150,48 @@ public class SyncAssignedCasesJobTests
     }
 
     [Fact]
-    public async Task Execute_DeletesExistingCases_BeforeProcessing()
+    public async Task Execute_DeletesPreExistingCases_AfterSavingRetrievedCases()
+    {
+        SetupBasicMocks();
+        var firstExistingCaseId = _faker.Random.AlphaNumeric(24);
+        var secondExistingCaseId = _faker.Random.AlphaNumeric(24);
+        var existingCases = new List<CaseDto>
+        {
+            new() { Id = firstExistingCaseId },
+            new() { Id = secondExistingCaseId }
+        };
+
+        _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync(existingCases);
+        SetupNoReservedJudgements();
+
+        _mockJcServiceClient.SetupSequence(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([CreateScheduledCase(CaseService.DECISION_APPR_REASON_CD)])
+            .ReturnsAsync([])
+            .ReturnsAsync([])
+            .ReturnsAsync([]);
+
+        _mockCaseService.Setup(s => s.ReplaceAllAsync(
+                It.Is<List<string>>(ids =>
+                    ids.Count == 2
+                    && ids[0] == firstExistingCaseId
+                    && ids[1] == secondExistingCaseId),
+                It.Is<List<CaseDto>>(cases =>
+                cases.Count == 1
+                && cases[0].RestrictionCode == CaseService.SEIZED_RESTRICTION_CD
+                && cases[0].Reason == CaseService.DECISION_APPR_REASON_CD)))
+            .ReturnsAsync(OperationResult.Success());
+
+
+        await _job.Execute();
+
+        _mockCaseService.Verify(s => s.ReplaceAllAsync(It.Is<List<string>>(ids =>
+            ids.Count == 2
+            && ids[0] == firstExistingCaseId
+            && ids[1] == secondExistingCaseId), It.IsAny<List<CaseDto>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_DeletesAllPreExistingCases_WhenRetrievalSucceedsWithNoNewCases()
     {
         SetupBasicMocks();
         var existingCases = new List<CaseDto>
@@ -160,24 +201,17 @@ public class SyncAssignedCasesJobTests
         };
 
         _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync(existingCases);
-        _mockCaseService.Setup(s => s.DeleteRangeAsync(It.IsAny<List<string>>()))
-            .ReturnsAsync(OperationResult.Success);
-
-        _mockEmailService
-            .Setup(s => s.GetFilteredEmailsAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<bool>()))
-            .ReturnsAsync([]);
+        SetupNoReservedJudgements();
 
         _mockJcServiceClient.Setup(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync([]);
 
         await _job.Execute();
 
-        _mockCaseService.Verify(s => s.DeleteRangeAsync(It.Is<List<string>>(ids =>
-            ids.Count == 2)), Times.Once);
+        _mockCaseService.Verify(s => s.ReplaceAllAsync(It.Is<List<string>>(ids =>
+            ids.Count == 2
+            && ids[0] == existingCases[0].Id
+            && ids[1] == existingCases[1].Id), It.Is<List<CaseDto>>(cases => cases.Count == 0)), Times.Once);
     }
 
     [Fact]
@@ -221,9 +255,6 @@ public class SyncAssignedCasesJobTests
 
         _mockJudgeService.Setup(s => s.GetJudges(null, null))
             .ReturnsAsync([]);
-
-        _mockCaseService.Setup(s => s.AddRangeAsync(It.IsAny<List<CaseDto>>()))
-            .ReturnsAsync(OperationResult<CaseDto>.Success(new()));
 
         _mockJcServiceClient.Setup(c => c
             .GetUpcomingSeizedAssignedCasesAsync(
@@ -328,8 +359,11 @@ public class SyncAssignedCasesJobTests
             }
         };
 
-        _mockJcServiceClient.Setup(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(scheduledCases);
+        _mockJcServiceClient.SetupSequence(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(scheduledCases)
+            .ReturnsAsync([])
+            .ReturnsAsync([])
+            .ReturnsAsync([]);
 
         await _job.Execute();
 
@@ -340,7 +374,7 @@ public class SyncAssignedCasesJobTests
                 It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("Unsupported CourtClass value")),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Exactly(4));
+            Times.Once);
     }
 
     [Fact]
@@ -380,8 +414,11 @@ public class SyncAssignedCasesJobTests
             }
         };
 
-        _mockJcServiceClient.Setup(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(scheduledCases);
+        _mockJcServiceClient.SetupSequence(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(scheduledCases)
+            .ReturnsAsync([])
+            .ReturnsAsync([])
+            .ReturnsAsync([]);
 
         // Mock court list but appearance won't be found, so participant logic is used
         _courtListServiceFixture.MockCourtListService
@@ -392,9 +429,9 @@ public class SyncAssignedCasesJobTests
             });
 
         List<CaseDto> capturedCases = null;
-        _mockCaseService.Setup(s => s.AddRangeAsync(It.IsAny<List<CaseDto>>()))
-            .Callback<List<CaseDto>>(cases => capturedCases = cases)
-            .ReturnsAsync(OperationResult<CaseDto>.Success(new()));
+        _mockCaseService.Setup(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()))
+            .Callback<List<string>, List<CaseDto>>((_, cases) => capturedCases = cases)
+            .ReturnsAsync(OperationResult.Success());
 
         await _job.Execute();
 
@@ -439,8 +476,11 @@ public class SyncAssignedCasesJobTests
             }
         };
 
-        _mockJcServiceClient.Setup(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(scheduledCases);
+        _mockJcServiceClient.SetupSequence(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(scheduledCases)
+            .ReturnsAsync([])
+            .ReturnsAsync([])
+            .ReturnsAsync([]);
 
         _courtListServiceFixture.MockCourtListService
             .Setup(c => c.GetJudgeCourtListAppearances(It.IsAny<int>(), It.IsAny<DateTime>()))
@@ -450,9 +490,9 @@ public class SyncAssignedCasesJobTests
             });
 
         List<CaseDto> capturedCases = null;
-        _mockCaseService.Setup(s => s.AddRangeAsync(It.IsAny<List<CaseDto>>()))
-            .Callback<List<CaseDto>>(cases => capturedCases = cases)
-            .ReturnsAsync(OperationResult<CaseDto>.Success(new()));
+        _mockCaseService.Setup(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()))
+            .Callback<List<string>, List<CaseDto>>((_, cases) => capturedCases = cases)
+            .ReturnsAsync(OperationResult.Success());
 
         await _job.Execute();
 
@@ -504,9 +544,6 @@ public class SyncAssignedCasesJobTests
                 Items = []
             });
 
-        _mockCaseService.Setup(s => s.AddRangeAsync(It.IsAny<List<CaseDto>>()))
-            .ReturnsAsync(OperationResult<CaseDto>.Success(new()));
-
         await _job.Execute();
 
         _mockLogger.Verify(
@@ -523,11 +560,80 @@ public class SyncAssignedCasesJobTests
     public async Task Execute_ThrowsException_WhenErrorOccurs()
     {
         SetupBasicMocks();
+        var existingCaseId = _faker.Random.AlphaNumeric(24);
 
-        _mockCaseService.Setup(s => s.DeleteRangeAsync(It.IsAny<List<string>>()))
+        _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync([
+            new CaseDto
+            {
+                Id = existingCaseId,
+                Reason = CaseService.DECISION_APPR_REASON_CD,
+                RestrictionCode = CaseService.SEIZED_RESTRICTION_CD
+            }
+        ]);
+
+        SetupNoReservedJudgements();
+
+        _mockJcServiceClient.SetupSequence(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([CreateScheduledCase(CaseService.DECISION_APPR_REASON_CD)])
+            .ReturnsAsync([])
+            .ReturnsAsync([])
+            .ReturnsAsync([]);
+
+        _mockCaseService.Setup(s => s.ReplaceAllAsync(
+                It.Is<List<string>>(ids => ids.Count == 1 && ids[0] == existingCaseId),
+                It.IsAny<List<CaseDto>>()))
             .ThrowsAsync(new Exception("Database error"));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => _job.Execute());
+    }
+
+    [Fact]
+    public async Task Execute_DoesNotDeleteExistingScheduledCases_WhenRetrievalFails()
+    {
+        SetupBasicMocks();
+
+        _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync([
+            new CaseDto
+            {
+                Id = _faker.Random.AlphaNumeric(24),
+                Reason = CaseService.DECISION_APPR_REASON_CD,
+                RestrictionCode = CaseService.SEIZED_RESTRICTION_CD
+            }
+        ]);
+
+        SetupNoReservedJudgements();
+
+        _mockJcServiceClient.Setup(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new Exception("Downstream failure"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _job.Execute());
+
+        _mockCaseService.Verify(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_DoesNotDeletePreExistingCases_WhenSaveFails()
+    {
+        SetupBasicMocks();
+
+        _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync([
+            new CaseDto { Id = _faker.Random.AlphaNumeric(24) }
+        ]);
+
+        SetupNoReservedJudgements();
+
+        _mockJcServiceClient.SetupSequence(c => c.GetUpcomingSeizedAssignedCasesAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([CreateScheduledCase(CaseService.DECISION_APPR_REASON_CD)])
+            .ReturnsAsync([])
+            .ReturnsAsync([])
+            .ReturnsAsync([]);
+
+        _mockCaseService.Setup(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()))
+            .ReturnsAsync(OperationResult.Failure("Save failed"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _job.Execute());
+
+        _mockCaseService.Verify(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()), Times.Once);
     }
 
     [Fact]
@@ -623,9 +729,6 @@ public class SyncAssignedCasesJobTests
             .Setup(c => c.GetJudgeCourtListAppearances(judgeId, appearanceDate))
             .ReturnsAsync(courtList);
 
-        _mockCaseService.Setup(s => s.AddRangeAsync(It.IsAny<List<CaseDto>>()))
-            .ReturnsAsync(OperationResult<CaseDto>.Success(new()));
-
         await _job.Execute();
 
         _mockLambdaInvokerService.Verify(s => s
@@ -688,7 +791,7 @@ public class SyncAssignedCasesJobTests
     private void SetupBasicMocks()
     {
         _mockCaseService.Setup(s => s.GetAllAsync()).ReturnsAsync([]);
-        _mockCaseService.Setup(s => s.DeleteRangeAsync(It.IsAny<List<string>>()))
+        _mockCaseService.Setup(s => s.ReplaceAllAsync(It.IsAny<List<string>>(), It.IsAny<List<CaseDto>>()))
             .ReturnsAsync(OperationResult.Success());
 
         _mockLookupServiceClient
@@ -706,5 +809,35 @@ public class SyncAssignedCasesJobTests
         _mockLookupServiceClient
             .Setup(l => l.GetAppearanceReasonsCeisAsync())
             .ReturnsAsync([]);
+    }
+
+    private void SetupNoReservedJudgements()
+    {
+        _mockEmailService.Setup(s => s
+            .GetFilteredEmailsAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync([]);
+    }
+
+    private Case CreateScheduledCase(string reason)
+    {
+        var appearanceDate = DateTime.Today.AddDays(1);
+
+        return new Case
+        {
+            NextApprId = _faker.Random.Double(1, 9999),
+            PhysicalFileId = _faker.Random.Double(1, 9999),
+            LastApprDt = appearanceDate.AddDays(-1).ToString("dd-MMM-yyyy"),
+            NextApprDt = appearanceDate.ToString("dd-MMM-yyyy"),
+            CourtClassCd = "Z",
+            FileNumberTxt = _faker.Random.AlphaNumeric(10),
+            NextApprReason = reason,
+            StyleOfCause = _faker.Random.Words(3),
+            JudgeId = _faker.Random.Int(1, 1000),
+            Participants = []
+        };
     }
 }

--- a/tests/api/Services/CaseServiceTests.cs
+++ b/tests/api/Services/CaseServiceTests.cs
@@ -9,10 +9,12 @@ using LazyCache.Providers;
 using Mapster;
 using MapsterMapper;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Scv.Api.Infrastructure.Mappings;
 using Scv.Api.Services;
+using Scv.Db.Contexts;
 using Scv.Db.Models;
 using Scv.Db.Repositories;
 using Xunit;
@@ -35,9 +37,10 @@ public class CaseServiceTests
         config.Apply(new AccessControlManagementMapping());
         var mapper = new Mapper(config);
         var logger = new Mock<ILogger<CaseService>>();
+        var dbContext = new JasperDbContext(new DbContextOptionsBuilder<JasperDbContext>().Options);
 
         _mockRepo = new Mock<IRepositoryBase<Case>>();
-        _caseService = new CaseService(cachingService, mapper, logger.Object, _mockRepo.Object);
+        _caseService = new CaseService(cachingService, mapper, logger.Object, _mockRepo.Object, dbContext);
 
         _testJudgeId = _faker.Random.Int();
     }

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -12,9 +12,9 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-		<PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
@@ -25,8 +25,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\api\api.csproj" />
-		<ProjectReference Include="..\cso-client\cso-client.csproj" />
+    <ProjectReference Include="..\cso-client\cso-client.csproj" />
     <ProjectReference Include="..\db\db.csproj" />
-		<ProjectReference Include="..\transitory-documents-api\transitory-documents-api.csproj" />
+    <ProjectReference Include="..\transitory-documents-api\transitory-documents-api.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**811**----    

JASPER-811

## Description

Do not delete cases until new cases have been inserted. Introduce transactions to make this an atomic operation.

Fixes # (issue)  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue) 


## How Has This Been Tested?

Unit tests, tested locally, confirmed that a failure to write new cases causes a transaction rollback and all previous rows are maintained.

**Test Configuration**:
If applicable

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   