### PR TITLE
jasper-844 allow reference documents to be removed from judicial bind…

### DIFF
--- a/api/Services/Files/CivilFilesService.cs
+++ b/api/Services/Files/CivilFilesService.cs
@@ -382,7 +382,7 @@ namespace Scv.Api.Services.Files
 
             var binderDocuments = await PopulateDetailDocuments([.. csrDocs.Concat(otherDocs)], detail, fileContentCivilFile, false, false);
 
-            return binderDocuments;
+            return [.. binderDocuments.Where(bd => documentIds.Contains(bd.CivilDocumentId))]; // Must re-apply document id filter to avoid reference documents being re-added by PopulateDetailDocuments.
         }
 
         #endregion Methods

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -24,7 +24,7 @@
         item-title="title"
         item-value="value"
       >
-        <template v-slot:item="{ props: itemProps, internalItem: item }">
+        <template v-slot:item="{ props: itemProps, item }">
           <v-list-item
             v-bind="itemProps"
             :title="`${item.title} (${categoryCount(item.raw.value)})`"

--- a/web/src/components/case-details/civil/CivilDocumentsView.vue
+++ b/web/src/components/case-details/civil/CivilDocumentsView.vue
@@ -126,7 +126,7 @@
     mdiNotebookOutline,
     mdiNotebookRemoveOutline,
   } from '@mdi/js';
-  import { computed, inject, onMounted, ref } from 'vue';
+  import { computed, inject, onMounted, ref, watch } from 'vue';
   import AllDocuments from './documents/AllDocuments.vue';
   import JudicialBinder from './documents/JudicialBinder.vue';
 
@@ -272,6 +272,20 @@
       .map((id) => documentsMaps.get(id))
       .filter((item): item is civilDocumentType => item !== undefined);
   });
+
+  watch(
+    binderDocuments,
+    (documents) => {
+      const binderDocumentIds = new Set(
+        documents.map((document) => document.civilDocumentId)
+      );
+
+      selectedBinderItems.value = selectedBinderItems.value.filter((item) =>
+        binderDocumentIds.has(item.civilDocumentId)
+      );
+    },
+    { immediate: true }
+  );
 
   const categoryCount = (category: string): number => {
     if (category.toLowerCase() === SCHEDULED_CATEGORY.toLowerCase()) {

--- a/web/src/components/case-details/criminal/CriminalDocumentsView.vue
+++ b/web/src/components/case-details/criminal/CriminalDocumentsView.vue
@@ -21,7 +21,7 @@
           hide-details
           :items="documentCategories"
         >
-          <template v-slot:[`item`]="{ props: itemProps, internalItem: item }">
+          <template v-slot:[`item`]="{ props: itemProps, item }">
             <v-list-item
               v-bind="itemProps"
               :title="item.raw + ' (' + categoryCount(item.raw) + ')'"

--- a/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
+++ b/web/tests/components/case-details/civil/CivilDocumentsView.test.ts
@@ -163,6 +163,37 @@ describe('CivilDocumentsView.vue', () => {
     expect(wrapper.vm.selectedBinderItems).toEqual([]);
   });
 
+  it('removeDocumentFromBinder should remove deleted documents from selected binder items', async () => {
+    wrapper.vm.currentBinder = {
+      id: 'binder-1',
+      labels: {},
+      documents: [
+        {
+          documentId: '1',
+          order: 0,
+          documentType: DocumentRequestType.CourtSummary,
+          fileName: 'Civil Document 1',
+        },
+        {
+          documentId: '2',
+          order: 1,
+          documentType: DocumentRequestType.File,
+          fileName: 'Civil Document 2',
+        },
+      ],
+    };
+    wrapper.vm.selectedBinderItems = [mockDocuments[0]];
+    (mockBinderService.updateBinder as Mock).mockResolvedValue({
+      succeeded: true,
+      payload: wrapper.vm.currentBinder,
+    });
+
+    await wrapper.vm.removeDocumentFromBinder('1');
+    await nextTick();
+
+    expect(wrapper.vm.selectedBinderItems).toEqual([]);
+  });
+
   it('inserts "Scheduled" option when a document has a next appearance date', async () => {
     expect(wrapper.vm.documentCategories[0]).toEqual({
       title: 'Scheduled',


### PR DESCRIPTION
…ers.

Fix issue with dropdown introduced by vuetify 4.


# Pull Request for JIRA Ticket: ----**jasper-844**----    

## Issue ticket number and link  
Include the JIRA ticket 844 and link here  

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested that reference docs can be removed from judicial binders.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   