### PR TITLE
Update users RoleIds when there aren't existing role ids

### DIFF
--- a/api/Services/UserService.cs
+++ b/api/Services/UserService.cs
@@ -126,12 +126,15 @@ public class UserService(
         var groups = (await _groupRepo.FindAsync(g => user.GroupIds.Contains(g.Id)));
         user.Groups = [.. groups.Select(g => g.Name)];
 
-        // Get all role ids from user's groups
-        var groupRoleIds = groups.SelectMany(g => g.RoleIds).ToList();
-        if (groupRoleIds.Count != 0)
+        // Get user's role ids from groups if user does not have any direct roles assigned. Works for now until current Groups are
+        // narrowed down to be functional. Long term solution should be combining roles from both user and groups.
+        if (user.RoleIds.Count == 0)
         {
-            // Combine role ids from user's groups and user. Existing role ids, may have been assigned by the sync service when the user logged-in.
-            user.RoleIds = [.. user.RoleIds.Union(groupRoleIds, StringComparer.OrdinalIgnoreCase)];
+            var groupRoleIds = groups.SelectMany(g => g.RoleIds).ToList();
+            if (groupRoleIds.Count != 0)
+            {
+                user.RoleIds = groupRoleIds;
+            }
         }
 
         // Find user's roles


### PR DESCRIPTION
When fetching the current user info via `api/auth/info`, our logic merges the user's group roles with their existing roles. Because a PCSS "Judge" role maps to the "Judiciary" group which in turn contains the roles "RAJ", "CJ", and "Judge". The user effectively ends up with all three roles from JASPER's perspective.

This was [discussed](https://github.com/bcgov/jasper/pull/1060#discussion_r3250524067) in PR #1060: relying on group roles requires narrowing the role set down to be usable and it's not yet clear when that work will happen. The change below addresses this by adding a check. If an existing role ID is already present, we preserve it rather than overriding; otherwise, we fall back to the group's roles.