### PR TITLE
JASPER-843: Signing and Digital Workflow - Extract the Directions and Terms from the Word desk order and add to the payload being returned to the CSO system

### DIFF
--- a/api/Documents/Extractors/DeskOrderDetailsExtractor.cs
+++ b/api/Documents/Extractors/DeskOrderDetailsExtractor.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Scv.Core.Helpers;
+using Scv.Models.Order;
+
+namespace Scv.Api.Documents.Extractors;
+
+public class DeskOrderDetailsExtractor : IDeskOrderDetailsExtractor
+{
+    public const string DIRECTIONS_LABEL = "Directions:";
+    public const string ORDER_TERMS_LABEL = "Terms of Order:";
+    public const string SIGNATURE_TAG = "Insert Signature";
+
+    public DeskOrderDetailsDto Extract(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        if (!DocumentHelper.IsWordDocument(stream))
+        {
+            throw new InvalidDataException("Stream is not a valid Word (.docx) document.");
+        }
+
+        using var wordDoc = WordprocessingDocument.Open(stream, false);
+
+        var body = (wordDoc.MainDocumentPart?.Document?.Body)
+            ?? throw new InvalidDataException("Unable to extract desk order details from the document body.");
+
+        // Get the indices of the "Directions:", "Terms of Order:" section and
+        // the signature section to be able to extract the relevant content for each section
+        var (directionsIndex, orderTermsIndex, signatureIndex) = GetSectionIndices(body);
+
+        if (directionsIndex == -1 || orderTermsIndex == -1 || directionsIndex >= orderTermsIndex)
+        {
+            throw new InvalidDataException("Unable to extract directions from the document body.");
+        }
+
+        if (signatureIndex == -1 || orderTermsIndex >= signatureIndex)
+        {
+            throw new InvalidDataException("Unable to extract order terms from the document body.");
+        }
+
+        // Whatever is between "Directions:" and "Terms of Order:" is the Directions content.
+        var directionsContent = ExtractContentBetween(body, directionsIndex, orderTermsIndex);
+
+        if (directionsContent == null
+            || directionsContent.Count == 0
+            || string.IsNullOrWhiteSpace(directionsContent.First()))
+        {
+            throw new InvalidDataException("Directions content is empty or whitespace.");
+        }
+
+        // Whatever is between "Terms of Order:" and the signature field are the Order Terms.
+        var orderTermsContent = ExtractContentBetween(body, orderTermsIndex, signatureIndex);
+
+        if (orderTermsContent == null
+            || orderTermsContent.Count == 0
+            || string.IsNullOrWhiteSpace(orderTermsContent.First()))
+        {
+            throw new InvalidDataException("Order terms content is empty or whitespace.");
+        }
+
+        return new DeskOrderDetailsDto
+        {
+            Directions = string.Join(" ", directionsContent),
+            OrderTerms = [.. orderTermsContent
+                .Select((text, index) => new OrderTermDto
+                {
+                    SequenceNumber = index + 1,
+                    DisplaySortNumber = index + 1,
+                    Text = text
+                })]
+        };
+    }
+
+    private static List<string> ExtractContentBetween(Body body, int startIndex, int endIndex)
+    {
+        var contents = new List<string>();
+
+        for (int i = startIndex + 1; i < endIndex; i++)
+        {
+            var element = body.ChildElements[i];
+
+            switch (element)
+            {
+                // Get the text if Sdt is filled
+                case SdtElement sdt when !IsPlaceholderShowing(sdt):
+                    AddIfNotEmpty(contents, sdt.InnerText);
+                    break;
+
+                // Ignore Sdt that is not filled
+                case SdtElement:
+                    break;
+
+                // Try to capture any other element (paragraph, table, etc.) if it has visible text
+                default:
+                    AddIfNotEmpty(contents, element.InnerText);
+                    break;
+            }
+        }
+
+        return contents;
+    }
+
+    private static void AddIfNotEmpty(List<string> content, string text)
+    {
+        var trimmed = text?.Trim();
+        if (!string.IsNullOrEmpty(trimmed))
+        {
+            content.Add(trimmed);
+        }
+    }
+
+    private static bool IsPlaceholderShowing(SdtElement sdt) =>
+        sdt.SdtProperties?.GetFirstChild<ShowingPlaceholder>() is not null;
+
+    private static (int directionsIndex, int orderTermsIndex, int signatureIndex) GetSectionIndices(Body body)
+    {
+        var directionsIndex = -1;
+        var orderTermsIndex = -1;
+        var signatureIndex = -1;
+
+        for (int i = 0; i < body.ChildElements.Count; i++)
+        {
+            var child = body.ChildElements[i];
+
+            if (directionsIndex < 0 && IsLabelMatch(child.InnerText, DIRECTIONS_LABEL))
+            {
+                directionsIndex = i;
+            }
+            else if (directionsIndex >= 0 && orderTermsIndex < 0 && IsLabelMatch(child.InnerText, ORDER_TERMS_LABEL))
+            {
+                orderTermsIndex = i;
+            }
+            else if (orderTermsIndex >= 0 && HasSignatureTag(child))
+            {
+                signatureIndex = i;
+                break;
+            }
+        }
+
+        return (directionsIndex, orderTermsIndex, signatureIndex);
+    }
+
+    private static bool IsLabelMatch(string text, string label) =>
+        string.Equals(text?.Trim(), label, StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasSignatureTag(OpenXmlElement element)
+    {
+        // Check if the element or any of its descendants is a content control with a tag that contains the signature tag.
+        var sdts = element is SdtElement self
+            ? element.Descendants<SdtElement>().Prepend(self)
+            : element.Descendants<SdtElement>();
+
+        if (sdts.Any(TagMatches))
+        {
+            return true;
+        }
+
+        return element.InnerText.Contains(SIGNATURE_TAG, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TagMatches(SdtElement s) =>
+        s.SdtProperties?
+            .GetFirstChild<Tag>()?
+            .Val?.Value?
+            .Contains(SIGNATURE_TAG, StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/api/Documents/Extractors/DeskOrderDetailsExtractor.cs
+++ b/api/Documents/Extractors/DeskOrderDetailsExtractor.cs
@@ -20,7 +20,7 @@ public class DeskOrderDetailsExtractor : IDeskOrderDetailsExtractor
     {
         ArgumentNullException.ThrowIfNull(stream);
 
-        if (!DocumentHelper.IsWordDocument(stream))
+        if (!DocumentHelper.IsDocXDocument(stream))
         {
             throw new InvalidDataException("Stream is not a valid Word (.docx) document.");
         }

--- a/api/Documents/Extractors/DeskOrderDetailsExtractor.cs
+++ b/api/Documents/Extractors/DeskOrderDetailsExtractor.cs
@@ -49,7 +49,7 @@ public class DeskOrderDetailsExtractor : IDeskOrderDetailsExtractor
 
         if (directionsContent == null
             || directionsContent.Count == 0
-            || string.IsNullOrWhiteSpace(directionsContent.First()))
+            || string.IsNullOrWhiteSpace(directionsContent[0]))
         {
             throw new InvalidDataException("Directions content is empty or whitespace.");
         }
@@ -59,7 +59,7 @@ public class DeskOrderDetailsExtractor : IDeskOrderDetailsExtractor
 
         if (orderTermsContent == null
             || orderTermsContent.Count == 0
-            || string.IsNullOrWhiteSpace(orderTermsContent.First()))
+            || string.IsNullOrWhiteSpace(orderTermsContent[0]))
         {
             throw new InvalidDataException("Order terms content is empty or whitespace.");
         }

--- a/api/Documents/Extractors/IDeskOrderDetailsExtractor.cs
+++ b/api/Documents/Extractors/IDeskOrderDetailsExtractor.cs
@@ -1,0 +1,10 @@
+﻿using System.IO;
+using Scv.Models.Order;
+
+namespace Scv.Api.Documents.Extractors
+{
+    public interface IDeskOrderDetailsExtractor
+    {
+        DeskOrderDetailsDto Extract(Stream stream);
+    }
+}

--- a/api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/api/Infrastructure/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ using MongoDB.Driver;
 using nClam;
 using PostgreSQL.ListenNotify.DependencyInjection;
 using Scv.Api.Documents;
+using Scv.Api.Documents.Extractors;
 using Scv.Api.Documents.Parsers;
 using Scv.Api.Documents.Strategies;
 using Scv.Api.Infrastructure.Authentication;
@@ -94,6 +95,8 @@ namespace Scv.Api.Infrastructure
             services.AddScoped<IDocumentStrategy, TranscriptStrategy>();
             services.AddScoped<IDocumentStrategy, TransitoryDocumentStrategy>();
             services.AddScoped<IDocumentStrategy, OrderDocumentStrategy>();
+
+            services.AddScoped<IDeskOrderDetailsExtractor, DeskOrderDetailsExtractor>();
         }
 
         public static IServiceCollection AddMapster(this IServiceCollection services, Action<TypeAdapterConfig> options = null)

--- a/api/Services/OrderService.cs
+++ b/api/Services/OrderService.cs
@@ -421,6 +421,7 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
         }
 
         var actionDto = Mapper.Map<JudicialAction>(orderDto);
+        actionDto.OrderTerms ??= [];
         actionDto.ReviewedBy = new Reviewer
         {
             AgencyId = agencyId,
@@ -456,30 +457,28 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
 
     private JudicialAction PopulateDeskOrderDetails(OrderDto orderDto, JudicialAction actionDto)
     {
+        // No document will be sent for Desk Orders
+        actionDto.Document = [];
+        if (orderDto.Status != OrderStatus.Approved)
+        {
+            return actionDto;
+        }
+
         var bytes = Convert.FromBase64String(orderDto.SupportingDocumentData);
         using var stream = new MemoryStream(bytes);
 
         var deskOrderDetails = _deskOrderDetailsExtractor.Extract(stream);
 
-        this.Logger.LogInformation(
-            "Extracted desk order details for Order {OrderId}. Directions: {Directions}, Order Terms: {OrderTerms}",
-            orderDto.Id,
-            deskOrderDetails.Directions,
-            string.Join(" ", deskOrderDetails.OrderTerms.Select(term => term.Text)));
+        this.Logger.LogInformation("Desk order Directions and Order Terms extracted successfuly for Order {OrderId}.", orderDto.Id);
 
-        if (orderDto.Status == OrderStatus.Approved)
-        {
-            actionDto.Comment = $"{actionDto.Comment}. {deskOrderDetails.Directions}";
-            actionDto.OrderTerms = [.. deskOrderDetails.OrderTerms.Select(term => new OrderTerm
+        actionDto.Comment = string.Join(". ", new[] { actionDto.Comment, deskOrderDetails.Directions });
+        actionDto.OrderTerms = [.. deskOrderDetails.OrderTerms.Select(term => new OrderTerm
             {
                 SequenceNumber = term.SequenceNumber,
                 Text = term.Text,
                 DisplaySortNumber = term.DisplaySortNumber
             })];
-        }
 
-        // No document will be sent for Desk Orders
-        actionDto.Document = [];
         return actionDto;
     }
 

--- a/api/Services/OrderService.cs
+++ b/api/Services/OrderService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CSOCommon.Clients.JudicialServices;
@@ -13,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Serialization;
+using Scv.Api.Documents.Extractors;
 using Scv.Api.Jobs;
 using Scv.Core.ContractResolver;
 using Scv.Core.Helpers;
@@ -43,6 +45,7 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
     private readonly string _requestPartId;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IJudicialServicesClient _judicialClient;
+    private readonly IDeskOrderDetailsExtractor _deskOrderDetailsExtractor;
 
     public override string CacheName => "GetOrdersAsync";
 
@@ -56,7 +59,8 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
         IJudgeService judgeService,
         IBackgroundJobClient backgroundJobClient,
         IHttpContextAccessor httpContextAccessor,
-        IJudicialServicesClient judicialClient
+        IJudicialServicesClient judicialClient,
+        IDeskOrderDetailsExtractor deskOrderDetailsExtractor
     ) : base(
             cache,
             mapper,
@@ -73,6 +77,7 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
         _requestPartId = configuration.GetNonEmptyValue("Request:PartId");
         _httpContextAccessor = httpContextAccessor;
         _judicialClient = judicialClient;
+        _deskOrderDetailsExtractor = deskOrderDetailsExtractor;
     }
 
     public async Task<OperationResult> ValidateOrderRequestAsync(OrderRequestDto dto)
@@ -416,7 +421,6 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
         }
 
         var actionDto = Mapper.Map<JudicialAction>(orderDto);
-        actionDto.OrderTerms ??= [];
         actionDto.ReviewedBy = new Reviewer
         {
             AgencyId = agencyId,
@@ -441,6 +445,41 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
             actionDto.SignedDate = null;
         }
 
+        if (orderDto.OrderRequest.Referral.CourtListTypeCd == CourtListTypeDescriptor.PROVINCIAL_COURT_DESK_ORDER_SMALL_CLAIMS_TYPE
+            || orderDto.OrderRequest.Referral.CourtListTypeCd == CourtListTypeDescriptor.PROVINCIAL_COURT_DESK_ORDER_FAMILY_LIST_TYPE)
+        {
+            actionDto = PopulateDeskOrderDetails(orderDto, actionDto);
+        }
+
+        return actionDto;
+    }
+
+    private JudicialAction PopulateDeskOrderDetails(OrderDto orderDto, JudicialAction actionDto)
+    {
+        var bytes = Convert.FromBase64String(orderDto.SupportingDocumentData);
+        using var stream = new MemoryStream(bytes);
+
+        var deskOrderDetails = _deskOrderDetailsExtractor.Extract(stream);
+
+        this.Logger.LogInformation(
+            "Extracted desk order details for Order {OrderId}. Directions: {Directions}, Order Terms: {OrderTerms}",
+            orderDto.Id,
+            deskOrderDetails.Directions,
+            string.Join(" ", deskOrderDetails.OrderTerms.Select(term => term.Text)));
+
+        if (orderDto.Status == OrderStatus.Approved)
+        {
+            actionDto.Comment = $"{actionDto.Comment}. {deskOrderDetails.Directions}";
+            actionDto.OrderTerms = [.. deskOrderDetails.OrderTerms.Select(term => new OrderTerm
+            {
+                SequenceNumber = term.SequenceNumber,
+                Text = term.Text,
+                DisplaySortNumber = term.DisplaySortNumber
+            })];
+        }
+
+        // No document will be sent for Desk Orders
+        actionDto.Document = [];
         return actionDto;
     }
 

--- a/api/Services/OrderService.cs
+++ b/api/Services/OrderService.cs
@@ -471,7 +471,7 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
 
         this.Logger.LogInformation("Desk order Directions and Order Terms extracted successfuly for Order {OrderId}.", orderDto.Id);
 
-        actionDto.Comment = string.Join(". ", new[] { actionDto.Comment, deskOrderDetails.Directions });
+        actionDto.Comment = string.Join(". ", actionDto.Comment, deskOrderDetails.Directions);
         actionDto.OrderTerms = [.. deskOrderDetails.OrderTerms.Select(term => new OrderTerm
             {
                 SequenceNumber = term.SequenceNumber,

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="ColeSoft.Extensions.Logging.Splunk" Version="1.0.72" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="dotenv.net" Version="4.0.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />

--- a/core/Helpers/DocumentHelper.cs
+++ b/core/Helpers/DocumentHelper.cs
@@ -8,7 +8,7 @@ public static class DocumentHelper
 
     private static readonly byte[][] PdfOrWordSignatures = [PdfSignature, DocSignature, DocxSignature];
 
-    public static bool IsWordDocument(Stream stream) =>
+    public static bool IsDocXDocument(Stream stream) =>
         HasSignature(stream, DocxSignature);
 
     public static bool IsPdfOrWordDocument(Stream stream) =>

--- a/core/Helpers/DocumentHelper.cs
+++ b/core/Helpers/DocumentHelper.cs
@@ -2,15 +2,17 @@ namespace Scv.Core.Helpers;
 
 public static class DocumentHelper
 {
-    private static readonly byte[][] AllowedSignatures =
-    [
-        // PDF
-        [0x25, 0x50, 0x44, 0x46],
-        // DOC
-        [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1],
-        // DOCX
-        [0x50, 0x4B, 0x03, 0x04]
-    ];
+    private static readonly byte[] PdfSignature = [0x25, 0x50, 0x44, 0x46];
+    private static readonly byte[] DocSignature = [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
+    private static readonly byte[] DocxSignature = [0x50, 0x4B, 0x03, 0x04];
+
+    private static readonly byte[][] PdfOrWordSignatures = [PdfSignature, DocSignature, DocxSignature];
+
+    public static bool IsWordDocument(Stream stream) =>
+        HasSignature(stream, DocxSignature);
+
+    public static bool IsPdfOrWordDocument(Stream stream) =>
+        PdfOrWordSignatures.Any(signature => HasSignature(stream, signature));
 
     public static bool IsPdfOrWordDocumentBase64(string base64Data)
     {
@@ -22,13 +24,38 @@ public static class DocumentHelper
         try
         {
             var bytes = Convert.FromBase64String(base64Data);
-            return AllowedSignatures.Any(signature =>
+            return PdfOrWordSignatures.Any(signature =>
                 bytes.Length >= signature.Length &&
                 bytes.AsSpan(0, signature.Length).SequenceEqual(signature));
         }
         catch (FormatException)
         {
             return false;
+        }
+    }
+
+    private static bool HasSignature(Stream stream, ReadOnlySpan<byte> signature)
+    {
+        if (stream is null || !stream.CanRead || !stream.CanSeek)
+        {
+            return false;
+        }
+
+        if (stream.Length - stream.Position < signature.Length)
+        {
+            return false;
+        }
+
+        var originalPosition = stream.Position;
+        Span<byte> buffer = stackalloc byte[signature.Length];
+        try
+        {
+            stream.ReadExactly(buffer);
+            return buffer.SequenceEqual(signature);
+        }
+        finally
+        {
+            stream.Position = originalPosition;
         }
     }
 }

--- a/models/Order/CourtListTypeDescriptor.cs
+++ b/models/Order/CourtListTypeDescriptor.cs
@@ -1,6 +1,6 @@
 ﻿namespace Scv.Models.Order;
 
-public class CourtListTypeDescriptor
+public static class CourtListTypeDescriptor
 {
     public const string SMALL_CLAIMS_COURT_LIST_TYPE = "PSC";
     public const string FAMILY_COURT_LIST_TYPE = "PFA";

--- a/models/Order/CourtListTypeDescriptor.cs
+++ b/models/Order/CourtListTypeDescriptor.cs
@@ -1,0 +1,22 @@
+﻿namespace Scv.Models.Order;
+
+public class CourtListTypeDescriptor
+{
+    public const string SMALL_CLAIMS_COURT_LIST_TYPE = "PSC";
+    public const string FAMILY_COURT_LIST_TYPE = "PFA";
+    public const string PROVINCIAL_COURT_DESK_ORDER_SMALL_CLAIMS_TYPE = "PSM";
+    public const string PROVINCIAL_COURT_DESK_ORDER_FAMILY_LIST_TYPE = "PFM";
+
+    public const string ORDER_DESCRIPTION = "Order";
+    public const string DESK_ORDER_DESCRIPTION = "Desk Order";
+
+    public static string Describe(string courtListType)
+    {
+        return courtListType switch
+        {
+            SMALL_CLAIMS_COURT_LIST_TYPE or FAMILY_COURT_LIST_TYPE => ORDER_DESCRIPTION,
+            PROVINCIAL_COURT_DESK_ORDER_SMALL_CLAIMS_TYPE or PROVINCIAL_COURT_DESK_ORDER_FAMILY_LIST_TYPE => DESK_ORDER_DESCRIPTION,
+            _ => courtListType,
+        };
+    }
+}

--- a/models/Order/DeskOrderDetailsDto.cs
+++ b/models/Order/DeskOrderDetailsDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Scv.Models.Order
+{
+    public class DeskOrderDetailsDto
+    {
+        public string Directions { get; set; }
+        public OrderTermDto[] OrderTerms { get; set; } = [];
+    }
+}

--- a/models/Order/OrderTermDto.cs
+++ b/models/Order/OrderTermDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Scv.Models.Order
+{
+    public class OrderTermDto
+    {
+        public int SequenceNumber { get; set; }
+        public int DisplaySortNumber { get; set; }
+        public string Text { get; set; }
+    }
+}

--- a/models/Order/OrderViewDto.cs
+++ b/models/Order/OrderViewDto.cs
@@ -15,16 +15,6 @@ public class OrderViewDto : BaseDto
     public string PriorityType { get; set; }
     public string PriorityTypeDesc => PriorityTypeDescriptor.Describe(PriorityType);
     public string CourtListType { get; set; }
-    public string CourtListTypeDescription => GetCourtListTypeDescription(CourtListType);
+    public string CourtListTypeDescription => CourtListTypeDescriptor.Describe(CourtListType);
     public string ReferralNotes { get; set; }
-
-    private static string GetCourtListTypeDescription(string courtListType)
-    {
-        return courtListType switch
-        {
-            "PSC" or "PFA" => "Order", // PCS - Small Claims Court List | PFA - Family Court List
-            "PSM" or "PFM" => "Desk Order", // PSM - Provincial Court Desk Order Small Claims | PFM - Provincial Court Desk Order Family List
-            _ => courtListType,
-        };
-    }
 }

--- a/tests/api/Documents/Extractors/DeskOrderDetailsExtractorTests.cs
+++ b/tests/api/Documents/Extractors/DeskOrderDetailsExtractorTests.cs
@@ -1,0 +1,272 @@
+using System;
+using System.IO;
+using System.Text;
+using Bogus;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Scv.Api.Documents.Extractors;
+using Xunit;
+
+namespace tests.api.Documents.Extractors;
+
+public class DeskOrderDetailsExtractorTests
+{
+    private readonly DeskOrderDetailsExtractor _extractor = new();
+    private readonly Faker _faker = new();
+
+    [Fact]
+    public void Extract_ThrowsArgumentNullException_WhenStreamIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => _extractor.Extract(null));
+    }
+
+    [Fact]
+    public void Extract_ThrowsInvalidDataException_WhenStreamIsNotWordDocument()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("this is plain text, not a docx"));
+
+        var ex = Assert.Throws<InvalidDataException>(() => _extractor.Extract(stream));
+        Assert.Contains("Stream is not a valid Word (.docx) document.", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Extract_ThrowsInvalidDataException_WhenDirectionsLabelIsMissing()
+    {
+        var term = _faker.Lorem.Sentence();
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(ParagraphOf(term));
+            body.AppendChild(SignatureSdt());
+        });
+
+        var ex = Assert.Throws<InvalidDataException>(() => _extractor.Extract(stream));
+        Assert.Contains("Unable to extract directions from the document body.", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Extract_ReturnsDirectionsAndOrderTerms_WhenDocumentIsValid()
+    {
+        var directionsText = _faker.Lorem.Sentence();
+        var term1 = _faker.Lorem.Sentence();
+        var term2 = _faker.Lorem.Sentence();
+
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.DIRECTIONS_LABEL));
+            body.AppendChild(ParagraphOf(directionsText));
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(ParagraphOf(term1));
+            body.AppendChild(ParagraphOf(term2));
+            body.AppendChild(SignatureSdt());
+        });
+
+        var result = _extractor.Extract(stream);
+
+        Assert.Equal(directionsText, result.Directions);
+        Assert.Equal(2, result.OrderTerms.Length);
+
+        Assert.Equal(term1, result.OrderTerms[0].Text);
+        Assert.Equal(1, result.OrderTerms[0].SequenceNumber);
+        Assert.Equal(1, result.OrderTerms[0].DisplaySortNumber);
+
+        Assert.Equal(term2, result.OrderTerms[1].Text);
+        Assert.Equal(2, result.OrderTerms[1].SequenceNumber);
+        Assert.Equal(2, result.OrderTerms[1].DisplaySortNumber);
+    }
+
+    [Fact]
+    public void Extract_TrimsWhitespaceFromOrderTermText()
+    {
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.DIRECTIONS_LABEL));
+            body.AppendChild(ParagraphOf(_faker.Lorem.Sentence()));
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(ParagraphOf("   Padded term text   "));
+            body.AppendChild(SignatureSdt());
+        });
+
+        var result = _extractor.Extract(stream);
+
+        Assert.Single(result.OrderTerms);
+        Assert.Equal("Padded term text", result.OrderTerms[0].Text);
+    }
+
+    [Fact]
+    public void Extract_SkipsEmptyAndWhitespaceParagraphs_BetweenOrderTermsLabelAndSignature()
+    {
+        var realTerm = _faker.Lorem.Sentence();
+        var fakeDirection = _faker.Lorem.Sentence();
+
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.DIRECTIONS_LABEL));
+            body.AppendChild(ParagraphOf(fakeDirection));
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(ParagraphOf(string.Empty));
+            body.AppendChild(ParagraphOf("   "));
+            body.AppendChild(ParagraphOf(realTerm));
+            body.AppendChild(ParagraphOf(string.Empty));
+            body.AppendChild(SignatureSdt());
+        });
+
+        var result = _extractor.Extract(stream);
+
+        Assert.Single(result.OrderTerms);
+        Assert.Equal(realTerm, result.OrderTerms[0].Text);
+    }
+
+    [Fact]
+    public void Extract_IncludesSdtContent_WhenSdtIsFilled()
+    {
+        var sdtContent = _faker.Lorem.Sentence();
+
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.DIRECTIONS_LABEL));
+            body.AppendChild(ParagraphOf(_faker.Lorem.Sentence()));
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(FilledSdtBlock(sdtContent));
+            body.AppendChild(SignatureSdt());
+        });
+
+        var result = _extractor.Extract(stream);
+
+        Assert.Single(result.OrderTerms);
+        Assert.Equal(sdtContent, result.OrderTerms[0].Text);
+    }
+
+    [Fact]
+    public void Extract_IgnoresSdtContent_WhenSdtIsShowingPlaceholder()
+    {
+        var realTerm = _faker.Lorem.Sentence();
+
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.DIRECTIONS_LABEL));
+            body.AppendChild(ParagraphOf(_faker.Lorem.Sentence()));
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(PlaceholderSdtBlock("[placeholder content that should be ignored]"));
+            body.AppendChild(ParagraphOf(realTerm));
+            body.AppendChild(SignatureSdt());
+        });
+
+        var result = _extractor.Extract(stream);
+
+        Assert.Single(result.OrderTerms);
+        Assert.Equal(realTerm, result.OrderTerms[0].Text);
+    }
+
+    [Fact]
+    public void Extract_DetectsSignature_FromSdtTagOnDescendantOfBodyChild()
+    {
+        // Wraps an SdtRun (with the signature tag) inside a paragraph so the SdtElement
+        // is a descendant, not the body child itself. This exercises the Descendants<SdtElement>()
+        // branch of HasSignatureTag.
+        var term = _faker.Lorem.Sentence();
+
+        var paragraphWithDescendantSignature = new Paragraph(
+            new SdtRun(
+                new SdtProperties(new Tag { Val = "Insert Signature here" }),
+                new SdtContentRun(new Run(new Text("name")))));
+
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.DIRECTIONS_LABEL));
+            body.AppendChild(ParagraphOf(_faker.Lorem.Sentence()));
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(ParagraphOf(term));
+            body.AppendChild(paragraphWithDescendantSignature);
+        });
+
+        var result = _extractor.Extract(stream);
+
+        Assert.Single(result.OrderTerms);
+        Assert.Equal(term, result.OrderTerms[0].Text);
+    }
+
+    [Fact]
+    public void Extract_DetectsSignature_FromInnerText_CaseInsensitive()
+    {
+        var term = _faker.Lorem.Sentence();
+
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.DIRECTIONS_LABEL));
+            body.AppendChild(ParagraphOf(_faker.Lorem.Sentence()));
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(ParagraphOf(term));
+            body.AppendChild(ParagraphOf("insert SIGNATURE"));
+        });
+
+        var result = _extractor.Extract(stream);
+
+        Assert.Single(result.OrderTerms);
+        Assert.Equal(term, result.OrderTerms[0].Text);
+    }
+
+    [Fact]
+    public void Extract_ThrowsInvalidDataException_WhenOrderTermsLabelMissing()
+    {
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf("Some unrelated content"));
+            body.AppendChild(SignatureSdt());
+        });
+
+        var ex = Assert.Throws<InvalidDataException>(() => _extractor.Extract(stream));
+        Assert.Contains("Unable to extract directions from the document body.", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Extract_ThrowsInvalidDataException_WhenSignatureMissing()
+    {
+        using var stream = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.DIRECTIONS_LABEL));
+            body.AppendChild(ParagraphOf(_faker.Lorem.Sentence()));
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(ParagraphOf(_faker.Lorem.Sentence()));
+            // No signature element follows the order terms label.
+        });
+
+        var ex = Assert.Throws<InvalidDataException>(() => _extractor.Extract(stream));
+        Assert.Contains("Unable to extract order terms from the document body.", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static MemoryStream BuildDocxStream(Action<Body> configureBody)
+    {
+        var stream = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+        {
+            var mainPart = doc.AddMainDocumentPart();
+            mainPart.Document = new Document();
+            var body = mainPart.Document.AppendChild(new Body());
+            configureBody(body);
+        }
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static Paragraph ParagraphOf(string text) =>
+        new(new Run(new Text(text) { Space = SpaceProcessingModeValues.Preserve }));
+
+    private static SdtBlock FilledSdtBlock(string text) =>
+        new(
+            new SdtProperties(),
+            new SdtContentBlock(
+                new Paragraph(new Run(new Text(text) { Space = SpaceProcessingModeValues.Preserve }))));
+
+    private static SdtBlock PlaceholderSdtBlock(string text) =>
+        new(
+            new SdtProperties(new ShowingPlaceholder()),
+            new SdtContentBlock(
+                new Paragraph(new Run(new Text(text) { Space = SpaceProcessingModeValues.Preserve }))));
+
+    private static SdtBlock SignatureSdt(string tagValue = "Insert Signature") =>
+        new(
+            new SdtProperties(new Tag { Val = tagValue }),
+            new SdtContentBlock(new Paragraph(new Run(new Text("[signature]")))));
+}

--- a/tests/api/Services/OrderServiceTests.cs
+++ b/tests/api/Services/OrderServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Security.Claims;
@@ -18,6 +19,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using PCSSCommon.Models;
+using Scv.Api.Documents.Extractors;
 using Scv.Api.Infrastructure.Mappings;
 using Scv.Api.Services;
 using Scv.Db.Models;
@@ -38,6 +40,7 @@ public class OrderServiceTests : ServiceTestBase
     private readonly Mock<Hangfire.IBackgroundJobClient> _mockBackgroundJobClient;
     private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private readonly Mock<IJudicialServicesClient> _mockJudicialClient;
+    private readonly Mock<IDeskOrderDetailsExtractor> _mockDeskOrderDetailsExtractor;
     private readonly IMapper _mapper;
     private readonly IAppCache _cache;
     private readonly OrderService _orderService;
@@ -56,6 +59,7 @@ public class OrderServiceTests : ServiceTestBase
 
         var config = new TypeAdapterConfig();
         config.Apply(new AccessControlManagementMapping());
+        config.Apply(new OrderMapping());
         _mapper = new Mapper(config);
 
         _mockLogger = new Mock<ILogger<OrderService>>();
@@ -66,6 +70,7 @@ public class OrderServiceTests : ServiceTestBase
         _mockBackgroundJobClient = new Mock<Hangfire.IBackgroundJobClient>();
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockJudicialClient = new Mock<IJudicialServicesClient>();
+        _mockDeskOrderDetailsExtractor = new Mock<IDeskOrderDetailsExtractor>();
 
         _requestAgencyIdentifierId = _faker.Random.Double().ToString();
         _requestPartId = _faker.Random.AlphaNumeric(10);
@@ -85,7 +90,8 @@ public class OrderServiceTests : ServiceTestBase
             _mockJudgeService.Object,
             _mockBackgroundJobClient.Object,
             _mockHttpContextAccessor.Object,
-            _mockJudicialClient.Object);
+            _mockJudicialClient.Object,
+            _mockDeskOrderDetailsExtractor.Object);
     }
 
     private void SetupConfiguration()
@@ -1002,6 +1008,129 @@ public class OrderServiceTests : ServiceTestBase
 
         Assert.True(result.Succeeded);
         _mockJudicialClient.Verify(c => c.SaveJudicialActionAsync(It.IsAny<Guid>(), It.IsAny<double>(), It.IsAny<JudicialAction>()), Times.Once);
+        _mockOrderRepo.Verify(r => r.UpdateAsync(It.Is<Order>(o => o.SubmitAttempts == 3)), Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitApprovedDeskOrder_ReturnsSuccess_WhenCsoSubmitSucceeds()
+    {
+        var fakeComment = _faker.Lorem.Sentence();
+        var fakeDirections = _faker.Lorem.Sentence();
+        var fakeOrderTerm = _faker.Lorem.Sentence();
+
+        var order = CreateOrder();
+        order.SubmitAttempts = 2;
+        order.OrderRequest.Referral.CourtListTypeCd = CourtListTypeDescriptor.PROVINCIAL_COURT_DESK_ORDER_FAMILY_LIST_TYPE;
+        order.SupportingDocumentData = _faker.Random.Bytes(32);
+        order.Status = OrderStatus.Approved;
+        order.Comments = fakeComment;
+        SetupHttpContextWithGuid();
+
+        _mockOrderRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<string>()))
+            .ReturnsAsync(order);
+
+        _mockOrderRepo
+            .Setup(r => r.UpdateAsync(It.IsAny<Order>()))
+            .Returns(Task.CompletedTask);
+
+        _mockJudicialClient
+            .Setup(c => c.SaveJudicialActionAsync(It.IsAny<Guid>(), It.IsAny<double>(), It.IsAny<JudicialAction>()))
+            .Returns(() => Task.CompletedTask);
+
+        _mockJudgeService
+            .Setup(d => d.GetJudges(null, null))
+            .ReturnsAsync(
+            [
+                new PersonSearchItem
+                {
+                    PersonId = order.JudgeId,
+                    ParticipantId = order.OrderRequest.Referral.SentToPartId.GetValueOrDefault()
+                }
+            ]);
+
+        _mockDeskOrderDetailsExtractor.Setup(d => d.Extract(It.IsAny<Stream>()))
+            .Returns(new DeskOrderDetailsDto
+            {
+                Directions = fakeDirections,
+                OrderTerms = [new() { Text = fakeOrderTerm }],
+            });
+
+        var result = await _orderService.SubmitOrder(order.Id);
+
+        Assert.True(result.Succeeded);
+        _mockJudicialClient
+            .Verify(c =>
+                c.SaveJudicialActionAsync(It.IsAny<Guid>(),
+                It.IsAny<double>(),
+                It.Is<JudicialAction>(ja =>
+                    ja.Comment == $"{fakeComment}. {fakeDirections}"
+                    && ja.OrderTerms.Count == 1
+                    && ja.OrderTerms.First().Text == fakeOrderTerm
+                    && ja.Document.Length == 0
+                )),
+                Times.Once);
+        _mockOrderRepo.Verify(r => r.UpdateAsync(It.Is<Order>(o => o.SubmitAttempts == 3)), Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitNotApprovedDeskOrder_ReturnsSuccess_WhenCsoSubmitSucceeds()
+    {
+        var fakeComment = _faker.Lorem.Sentence();
+        var fakeDirections = _faker.Lorem.Sentence();
+        var fakeOrderTerm = _faker.Lorem.Sentence();
+
+        var order = CreateOrder();
+        order.SubmitAttempts = 2;
+        order.OrderRequest.Referral.CourtListTypeCd = CourtListTypeDescriptor.PROVINCIAL_COURT_DESK_ORDER_FAMILY_LIST_TYPE;
+        order.SupportingDocumentData = _faker.Random.Bytes(32);
+        order.Status = OrderStatus.Unapproved;
+        order.Comments = fakeComment;
+        SetupHttpContextWithGuid();
+
+        _mockOrderRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<string>()))
+            .ReturnsAsync(order);
+
+        _mockOrderRepo
+            .Setup(r => r.UpdateAsync(It.IsAny<Order>()))
+            .Returns(Task.CompletedTask);
+
+        _mockJudicialClient
+            .Setup(c => c.SaveJudicialActionAsync(It.IsAny<Guid>(), It.IsAny<double>(), It.IsAny<JudicialAction>()))
+            .Returns(() => Task.CompletedTask);
+
+        _mockJudgeService
+            .Setup(d => d.GetJudges(null, null))
+            .ReturnsAsync(
+            [
+                new PersonSearchItem
+                {
+                    PersonId = order.JudgeId,
+                    ParticipantId = order.OrderRequest.Referral.SentToPartId.GetValueOrDefault()
+                }
+            ]);
+
+        _mockDeskOrderDetailsExtractor.Setup(d => d.Extract(It.IsAny<Stream>()))
+            .Returns(new DeskOrderDetailsDto
+            {
+                Directions = fakeDirections,
+                OrderTerms = [new() { Text = fakeOrderTerm }],
+            });
+
+        var result = await _orderService.SubmitOrder(order.Id);
+
+        Assert.True(result.Succeeded);
+        _mockJudicialClient
+            .Verify(c =>
+                c.SaveJudicialActionAsync(It.IsAny<Guid>(),
+                It.IsAny<double>(),
+                It.Is<JudicialAction>(ja =>
+                    ja.Comment == fakeComment
+                    && ja.OrderTerms.Count == 0
+                    && ja.Document.Length == 0
+                )),
+                Times.Once);
         _mockOrderRepo.Verify(r => r.UpdateAsync(It.Is<Order>(o => o.SubmitAttempts == 3)), Times.Once);
     }
 

--- a/web/src/components/documents/DocumentUpload.vue
+++ b/web/src/components/documents/DocumentUpload.vue
@@ -29,7 +29,7 @@
           density="comfortable"
           clearable
           :multiple="false"
-          filter-by-type=".pdf,.doc,.docx"
+          :filter-by-type="props.supportedTypes"
           scrim="primary"
           :disabled="props.disabled"
           @update:model-value="onDocumentSelected"
@@ -61,9 +61,11 @@
       disabled: boolean;
       text: string | null;
       collapsible?: boolean;
+      supportedTypes?: string;
     }>(),
     {
       collapsible: true,
+      supportedTypes: '.pdf,.doc,.docx',
     }
   );
   const selectedFile = defineModel<File | null>('selectedFile', {

--- a/web/src/components/documents/ReviewModal.vue
+++ b/web/src/components/documents/ReviewModal.vue
@@ -90,6 +90,7 @@
             v-model:show="show"
             v-model:selectedFile="selectedUpload"
             text="Attach Desk Order"
+            :supportedTypes="isFamilyDeskOrder ? '.docx' : ''"
             :collapsible="false"
           />
         </v-card-text>


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-843

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-843

## Description
This feature allows JASPER to extract data for submitted Desk Orders. Directions and Terms of Order are extracted to the attached template when an order is submitted to CSO.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Local

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   