### PR TITLE
Add support for mongo certs, and mongo cert generation image

### DIFF
--- a/.github/workflows/publish-openshift-images.yml
+++ b/.github/workflows/publish-openshift-images.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - "docker/openshift/**"
-      - "openshift/**"
+      - 'docker/openshift/**'
+      - 'openshift/**'
 
 env:
   GITHUB_IMAGE_REPO: ghcr.io/bcgov/jasper
@@ -26,6 +26,7 @@ jobs:
       matrix:
         dockerfile-image:
           - Dockerfile=./docker/openshift/Dockerfile.sync-secrets,image=sync-secrets
+          - Dockerfile=./docker/openshift/Dockerfile.generate-mongo-tls,image=generate-mongo-tls
           - Dockerfile=./docker/openshift/Dockerfile.update-aws-creds,image=update-aws-creds
 
     steps:

--- a/api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/api/Infrastructure/ServiceCollectionExtensions.cs
@@ -26,6 +26,8 @@ using Microsoft.Graph;
 using MongoDB.Driver;
 using nClam;
 using PostgreSQL.ListenNotify.DependencyInjection;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
 using Scv.Api.Documents;
 using Scv.Api.Documents.Parsers;
 using Scv.Api.Documents.Strategies;
@@ -110,6 +112,7 @@ namespace Scv.Api.Infrastructure
         {
             var connectionString = configuration.GetValue<string>("MONGODB_CONNECTION_STRING");
             var dbName = configuration.GetValue<string>("MONGODB_NAME");
+            var mongoTlsPem = configuration.GetValue<string>("MONGODB_TLS_PEM");
 
             if (string.IsNullOrWhiteSpace(connectionString) || string.IsNullOrWhiteSpace(dbName))
             {
@@ -120,6 +123,61 @@ namespace Scv.Api.Infrastructure
             {
                 var logger = m.GetRequiredService<ILogger<MongoClient>>();
                 var settings = MongoClientSettings.FromConnectionString(connectionString);
+
+                if (!string.IsNullOrWhiteSpace(mongoTlsPem))
+                {
+                    var pemValue = mongoTlsPem;
+
+                    try
+                    {
+                        using var jsonDoc = JsonDocument.Parse(mongoTlsPem);
+                        if (jsonDoc.RootElement.ValueKind == JsonValueKind.Object)
+                        {
+                            if (jsonDoc.RootElement.TryGetProperty("pem", out var pemProperty))
+                            {
+                                pemValue = pemProperty.GetString();
+                            }
+                            else if (jsonDoc.RootElement.TryGetProperty("ca", out var caProperty))
+                            {
+                                pemValue = caProperty.GetString();
+                            }
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Secret is not JSON. Treat it as raw PEM text.
+                    }
+
+                    var normalizedPem = pemValue?.Replace("\\n", "\n").Trim();
+                    if (string.IsNullOrWhiteSpace(normalizedPem))
+                    {
+                        throw new ConfigurationException("MONGODB_TLS_PEM is set but does not contain a valid PEM value.");
+                    }
+
+                    var customRootCa = X509Certificate2.CreateFromPem(normalizedPem);
+
+                    settings.SslSettings = new SslSettings
+                    {
+                        ServerCertificateValidationCallback = (_, certificate, _, _) =>
+                        {
+                            if (certificate is null)
+                            {
+                                return false;
+                            }
+
+                            using var chain = new X509Chain();
+                            chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                            chain.ChainPolicy.CustomTrustStore.Add(customRootCa);
+
+                            using var serverCertificate = new X509Certificate2(certificate);
+                            return chain.Build(serverCertificate);
+                        }
+                    };
+
+                    logger.LogInformation("MongoDB TLS custom root certificate configured from MONGODB_TLS_PEM.");
+                }
+
                 var client = new MongoClient(settings);
 
                 logger.LogInformation("MongoDB client configured successfully.");

--- a/docker/openshift/Dockerfile.generate-mongo-tls
+++ b/docker/openshift/Dockerfile.generate-mongo-tls
@@ -1,0 +1,20 @@
+FROM alpine:3.20
+
+ARG APP_ROOT=/usr/local/bin
+ARG SRC=./docker/openshift
+
+RUN apk add --no-cache \
+    aws-cli \
+    ca-certificates \
+    jq \
+    kubectl \
+    mongodb-tools \
+    openssl
+
+WORKDIR ${APP_ROOT}
+
+COPY ${SRC}/generate-mongo-tls.sh ${APP_ROOT}/generate-mongo-tls.sh
+
+RUN chmod +x ${APP_ROOT}/generate-mongo-tls.sh
+
+CMD ["./generate-mongo-tls.sh"]

--- a/docker/openshift/generate-mongo-tls.sh
+++ b/docker/openshift/generate-mongo-tls.sh
@@ -1,0 +1,250 @@
+#!/bin/sh
+set -eu
+
+umask 077
+
+log() {
+  echo "[generate-mongo-tls] $*"
+}
+
+fail() {
+  echo "[generate-mongo-tls] ERROR: $*" >&2
+  exit 1
+}
+
+required() {
+  name="$1"
+  eval "value=\${$name:-}"
+  if [ -z "$value" ]; then
+    fail "Missing required environment variable: $name"
+  fi
+}
+
+required CERT_SUBJECT_ALT_NAME
+required OPENSHIFT_SECRET_NAME
+required OPENSHIFT_SECRET_NAMESPACE
+required AWS_SECRET_ID
+required MONGO_STATEFULSET_SELECTOR
+required CA_CERT_PATH
+required CA_KEY_PATH
+
+CERT_DAYS="${CERT_DAYS:-14}"
+KEY_SIZE="${KEY_SIZE:-4096}"
+CERT_COMMON_NAME="${CERT_COMMON_NAME:-cloudpirates-mongodb}"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-300s}"
+
+# CERT_SUBJECT_ALT_NAME must be a valid openssl subjectAltName value string.
+# e.g. "IP:10.99.10.9,DNS:my-host.svc.cluster.local,DNS:localhost"
+
+GENERATED_CERT_KEY="${GENERATED_CERT_KEY:-tls.crt}"
+GENERATED_PRIVATE_KEY_KEY="${GENERATED_PRIVATE_KEY_KEY:-tls.key}"
+GENERATED_PEM_KEY="${GENERATED_PEM_KEY:-tls.pem}"
+CA_BUNDLE_KEY="${CA_BUNDLE_KEY:-ca.crt}"
+
+AWS_FORCE_PUT="${AWS_FORCE_PUT:-false}"
+
+WORKDIR="$(mktemp -d)"
+
+SERVER_KEY="$WORKDIR/tls.key"
+SERVER_CSR="$WORKDIR/tls.csr"
+SERVER_CRT="$WORKDIR/tls.crt"
+SERVER_PEM="$WORKDIR/tls.pem"
+SERVER_EXT="$WORKDIR/server-ext.cnf"
+
+AWS_GET_JSON="$WORKDIR/aws-secret-current.json"
+AWS_BACKUP="$WORKDIR/aws-secret-backup.pem"
+K8S_BACKUP="$WORKDIR/k8s-secret-backup.json"
+
+AWS_MUTATED="false"
+K8S_MUTATED="false"
+K8S_SECRET_EXISTED="false"
+
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+
+get_statefulsets() {
+  kubectl -n "$OPENSHIFT_SECRET_NAMESPACE" get statefulset \
+    -l "$MONGO_STATEFULSET_SELECTOR" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+}
+
+restart_mongo_statefulsets() {
+  STATEFULSETS="$(get_statefulsets)"
+
+  if [ -z "$STATEFULSETS" ]; then
+    fail "No StatefulSets found for selector: $MONGO_STATEFULSET_SELECTOR"
+  fi
+
+  for STATEFULSET in $STATEFULSETS; do
+    log "Restarting StatefulSet: ${OPENSHIFT_SECRET_NAMESPACE}/${STATEFULSET}"
+    kubectl -n "$OPENSHIFT_SECRET_NAMESPACE" rollout restart statefulset "$STATEFULSET"
+  done
+
+  for STATEFULSET in $STATEFULSETS; do
+    log "Waiting for StatefulSet rollout: ${OPENSHIFT_SECRET_NAMESPACE}/${STATEFULSET}"
+    kubectl -n "$OPENSHIFT_SECRET_NAMESPACE" rollout status statefulset "$STATEFULSET" \
+      --timeout="$ROLLOUT_TIMEOUT"
+  done
+}
+
+restore_k8s_secret() {
+  if [ "$K8S_MUTATED" != "true" ]; then
+    return 0
+  fi
+
+  if [ "$K8S_SECRET_EXISTED" = "true" ] && [ -f "$K8S_BACKUP" ]; then
+    log "Rolling back OpenShift secret: ${OPENSHIFT_SECRET_NAMESPACE}/${OPENSHIFT_SECRET_NAME}"
+    kubectl -n "$OPENSHIFT_SECRET_NAMESPACE" apply -f "$K8S_BACKUP" >/dev/null || true
+  else
+    log "Deleting newly-created OpenShift secret: ${OPENSHIFT_SECRET_NAMESPACE}/${OPENSHIFT_SECRET_NAME}"
+    kubectl -n "$OPENSHIFT_SECRET_NAMESPACE" delete secret "$OPENSHIFT_SECRET_NAME" \
+      --ignore-not-found=true >/dev/null || true
+  fi
+}
+
+restore_aws_secret() {
+  if [ "$AWS_MUTATED" != "true" ]; then
+    return 0
+  fi
+
+  if [ -f "$AWS_BACKUP" ]; then
+    log "Rolling back AWS secret: $AWS_SECRET_ID"
+    aws secretsmanager put-secret-value \
+      --secret-id "$AWS_SECRET_ID" \
+      --secret-string "file://$AWS_BACKUP" >/dev/null || true
+  fi
+}
+
+on_exit() {
+  status="$1"
+
+  if [ "$status" -eq 0 ]; then
+    cleanup
+    exit 0
+  fi
+
+  set +e
+
+  log "Certificate rotation failed. Attempting rollback."
+
+  restore_k8s_secret
+
+  if [ "$K8S_MUTATED" = "true" ]; then
+    log "Restarting MongoDB after OpenShift secret rollback."
+    restart_mongo_statefulsets || true
+  fi
+
+  restore_aws_secret
+
+  cleanup
+
+  log "Rollback attempt completed. Original failure status: $status"
+  exit "$status"
+}
+
+trap 'status=$?; on_exit "$status"' EXIT
+
+command -v openssl >/dev/null 2>&1 || fail "openssl is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v aws >/dev/null 2>&1 || fail "aws CLI is required"
+command -v kubectl >/dev/null 2>&1 || fail "kubectl is required"
+
+[ -f "$CA_CERT_PATH" ] || fail "CA cert file not found: $CA_CERT_PATH"
+[ -f "$CA_KEY_PATH" ] || fail "CA key file not found: $CA_KEY_PATH"
+
+log "Validating AWS secret exists: $AWS_SECRET_ID"
+aws secretsmanager describe-secret --secret-id "$AWS_SECRET_ID" >/dev/null
+
+log "Backing up current AWS secret value."
+aws secretsmanager get-secret-value \
+  --secret-id "$AWS_SECRET_ID" \
+  --output json > "$AWS_GET_JSON"
+
+jq -e 'has("SecretString") and (.SecretString != null)' "$AWS_GET_JSON" >/dev/null \
+  || fail "AWS secret must contain SecretString, not SecretBinary."
+
+jq -r '.SecretString' "$AWS_GET_JSON" > "$AWS_BACKUP"
+
+log "Checking existing OpenShift secret: ${OPENSHIFT_SECRET_NAMESPACE}/${OPENSHIFT_SECRET_NAME}"
+if kubectl -n "$OPENSHIFT_SECRET_NAMESPACE" get secret "$OPENSHIFT_SECRET_NAME" >/dev/null 2>&1; then
+  K8S_SECRET_EXISTED="true"
+
+  kubectl -n "$OPENSHIFT_SECRET_NAMESPACE" get secret "$OPENSHIFT_SECRET_NAME" -o json \
+    | jq '
+        del(
+          .metadata.uid,
+          .metadata.resourceVersion,
+          .metadata.creationTimestamp,
+          .metadata.managedFields,
+          .metadata.ownerReferences,
+          .metadata.annotations."kubectl.kubernetes.io/last-applied-configuration"
+        )
+      ' > "$K8S_BACKUP"
+fi
+
+log "Generating MongoDB server private key."
+openssl genrsa -out "$SERVER_KEY" "$KEY_SIZE"
+
+log "Generating MongoDB server certificate signing request."
+openssl req \
+  -new \
+  -key "$SERVER_KEY" \
+  -out "$SERVER_CSR" \
+  -subj "/CN=${CERT_COMMON_NAME}"
+
+cat > "$SERVER_EXT" <<EOF
+subjectAltName = ${CERT_SUBJECT_ALT_NAME}
+basicConstraints = critical,CA:FALSE
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+EOF
+
+log "Signing MongoDB server certificate with mounted private CA."
+SERIAL_HEX="$(openssl rand -hex 16)"
+
+openssl x509 \
+  -req \
+  -in "$SERVER_CSR" \
+  -CA "$CA_CERT_PATH" \
+  -CAkey "$CA_KEY_PATH" \
+  -set_serial "0x${SERIAL_HEX}" \
+  -out "$SERVER_CRT" \
+  -days "$CERT_DAYS" \
+  -sha256 \
+  -extfile "$SERVER_EXT"
+
+cat "$SERVER_KEY" "$SERVER_CRT" > "$SERVER_PEM"
+
+log "Validating generated certificate."
+openssl verify -CAfile "$CA_CERT_PATH" "$SERVER_CRT" >/dev/null
+
+log "Ensuring AWS secret contains current CA PEM."
+if [ "$AWS_FORCE_PUT" = "true" ] || ! cmp -s "$AWS_BACKUP" "$CA_CERT_PATH"; then
+  aws secretsmanager put-secret-value \
+    --secret-id "$AWS_SECRET_ID" \
+    --secret-string "file://$CA_CERT_PATH" >/dev/null
+  AWS_MUTATED="true"
+  log "AWS secret updated: $AWS_SECRET_ID"
+else
+  log "AWS secret already matches CA PEM; skipping AWS put-secret-value."
+fi
+
+log "Applying OpenShift TLS secret: ${OPENSHIFT_SECRET_NAMESPACE}/${OPENSHIFT_SECRET_NAME}"
+kubectl create secret generic "$OPENSHIFT_SECRET_NAME" \
+  -n "$OPENSHIFT_SECRET_NAMESPACE" \
+  --from-file="${CA_BUNDLE_KEY}=${CA_CERT_PATH}" \
+  --from-file="${GENERATED_CERT_KEY}=${SERVER_CRT}" \
+  --from-file="${GENERATED_PRIVATE_KEY_KEY}=${SERVER_KEY}" \
+  --from-file="${GENERATED_PEM_KEY}=${SERVER_PEM}" \
+  --dry-run=client \
+  -o yaml \
+  | kubectl apply -f - >/dev/null
+
+K8S_MUTATED="true"
+
+restart_mongo_statefulsets
+
+log "MongoDB TLS rotation completed successfully."

--- a/infrastructure/cloud/environments/lz-dev/lz-dev.tfvars
+++ b/infrastructure/cloud/environments/lz-dev/lz-dev.tfvars
@@ -49,3 +49,6 @@ clamav_config = {
   memory_reservation = 512
   stream_max_length  = "100M"
 }
+
+use_existing_mongo_tls_secret = true
+existing_mongo_tls_secret_name = "external/jasper-mongo-tls-lz-dev"

--- a/infrastructure/cloud/environments/lz-dev/main.tf
+++ b/infrastructure/cloud/environments/lz-dev/main.tf
@@ -47,6 +47,8 @@ module "secrets_manager" {
   region                = var.region
   kms_key_arn           = module.initial.kms_key_arn
   rotate_key_lambda_arn = module.lambda.lambda_functions["rotate-key"].arn
+  use_existing_mongo_tls_secret = var.use_existing_mongo_tls_secret
+  existing_mongo_tls_secret_name = var.existing_mongo_tls_secret_name
 }
 
 # Create RDS Database

--- a/infrastructure/cloud/environments/lz-dev/variables.tf
+++ b/infrastructure/cloud/environments/lz-dev/variables.tf
@@ -181,3 +181,15 @@ variable "lza_log_archive_account_id" {
   description = "LZA Log Archive Account ID for centralized ALB logging"
   type        = string
 }
+
+variable "use_existing_mongo_tls_secret" {
+  description = "Use an existing Mongo TLS secret instead of creating one"
+  type        = bool
+  default     = false
+}
+
+variable "existing_mongo_tls_secret_name" {
+  description = "Optional existing Mongo TLS secret name"
+  type        = string
+  default     = ""
+}

--- a/infrastructure/cloud/modules/SecretsManager/main.tf
+++ b/infrastructure/cloud/modules/SecretsManager/main.tf
@@ -479,3 +479,30 @@ resource "aws_secretsmanager_secret_version" "smb_secret_value" {
     ignore_changes = [secret_string]
   }
 }
+
+locals {
+  mongo_tls_secret_name = var.existing_mongo_tls_secret_name != "" ? var.existing_mongo_tls_secret_name : "external/${var.app_name}-mongo-tls-${var.environment}"
+}
+
+data "aws_secretsmanager_secret" "existing_mongo_tls_secret" {
+  count = var.use_existing_mongo_tls_secret ? 1 : 0
+  name  = local.mongo_tls_secret_name
+}
+
+resource "aws_secretsmanager_secret" "mongo_tls_secret" {
+  count      = var.use_existing_mongo_tls_secret ? 0 : 1
+  name       = "external/${var.app_name}-mongo-tls-${var.environment}"
+  kms_key_id = var.kms_key_arn
+}
+
+resource "aws_secretsmanager_secret_version" "mongo_tls_secret_value" {
+  count     = var.use_existing_mongo_tls_secret ? 0 : 1
+  secret_id = aws_secretsmanager_secret.mongo_tls_secret[0].id
+  secret_string = jsonencode({
+    ca  = "",
+    pem = ""
+  })
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/infrastructure/cloud/modules/SecretsManager/output.tf
+++ b/infrastructure/cloud/modules/SecretsManager/output.tf
@@ -1,3 +1,7 @@
+locals {
+  mongo_tls_secret_arn = var.use_existing_mongo_tls_secret ? data.aws_secretsmanager_secret.existing_mongo_tls_secret[0].arn : aws_secretsmanager_secret.mongo_tls_secret[0].arn
+}
+
 output "secrets_arn_list" {
   value = [
     aws_secretsmanager_secret.api_authorizer_secret.arn,
@@ -24,7 +28,8 @@ output "secrets_arn_list" {
     aws_secretsmanager_secret.splunk_secret.arn,
     aws_secretsmanager_secret.user_services_client_secret.arn,
     aws_secretsmanager_secret.keycloak_td_secret.arn,
-    aws_secretsmanager_secret.smb_secret.arn
+    aws_secretsmanager_secret.smb_secret.arn,
+    local.mongo_tls_secret_arn
   ]
 }
 
@@ -87,6 +92,7 @@ output "api_secrets" {
     ["LookupServicesClient__Url", "${aws_secretsmanager_secret.lookup_services_client_secret.arn}:baseUrl::"],
     ["MONGODB_CONNECTION_STRING", "${aws_secretsmanager_secret.database_secret.arn}:mongoDbConnectionString::"],
     ["MONGODB_NAME", "${aws_secretsmanager_secret.database_secret.arn}:mongoDbName::"],
+    ["MONGODB_TLS_PEM", local.mongo_tls_secret_arn],
     ["NUTRIENT_BE_LICENSE_KEY", "${aws_secretsmanager_secret.nutrient_secret.arn}:nutrientBeLicenseKey::"],
     ["NUTRIENT_FE_LICENSE_KEY", "${aws_secretsmanager_secret.nutrient_secret.arn}:nutrientFeLicenseKey::"],
     ["ORDER_MAX_REASSIGNMENT_NOTIFICATIONS", "${aws_secretsmanager_secret.order_secret.arn}:maxReassignmentNotifications::"],

--- a/infrastructure/cloud/modules/SecretsManager/variables.tf
+++ b/infrastructure/cloud/modules/SecretsManager/variables.tf
@@ -22,3 +22,15 @@ variable "rotate_key_lambda_arn" {
   description = "The Rotate Key Lambda ARN"
   type        = string
 }
+
+variable "use_existing_mongo_tls_secret" {
+  description = "If true, do not create the mongo TLS secret and instead use an existing one"
+  type        = bool
+  default     = false
+}
+
+variable "existing_mongo_tls_secret_name" {
+  description = "Optional existing Mongo TLS secret name to use when use_existing_mongo_tls_secret is true"
+  type        = string
+  default     = ""
+}

--- a/openshift/mongo-s3-restore.job.yaml
+++ b/openshift/mongo-s3-restore.job.yaml
@@ -1,0 +1,275 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: mongo-s3-restore
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mongo-s3-restore
+      namespace: ${NAMESPACE}
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 86400
+      activeDeadlineSeconds: 7200
+      template:
+        metadata:
+          labels:
+            app: mongo-s3-restore
+            DataClass: Medium
+            owner: ${OWNER_LABEL}
+            project: ${PROJECT_LABEL}
+          annotations:
+            vault.hashicorp.com/agent-inject: 'true'
+            vault.hashicorp.com/agent-run-as-init: 'true'
+            vault.hashicorp.com/agent-pre-populate-only: 'true'
+            vault.hashicorp.com/agent-inject-token: 'false'
+            vault.hashicorp.com/namespace: ${VAULT_NAMESPACE}
+            vault.hashicorp.com/auth-path: ${VAULT_AUTH_PATH}
+            vault.hashicorp.com/role: ${VAULT_ROLE}
+            vault.hashicorp.com/agent-configmap: ${VAULT_AGENT_CONFIGMAP}
+            vault.hashicorp.com/agent-inject-secret-jasper-secret: ${VAULT_SECRET_PATH}
+        spec:
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          automountServiceAccountToken: true
+          restartPolicy: Never
+          containers:
+            - name: restore
+              image: ${RESTORE_IMAGE}
+              imagePullPolicy: Always
+              env:
+                # AWS credentials from existing OpenShift Secret.
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${AWS_SECRET_NAME}
+                      key: AWS_ACCESS_KEY_ID
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${AWS_SECRET_NAME}
+                      key: AWS_SECRET_ACCESS_KEY
+                - name: AWS_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${AWS_SECRET_NAME}
+                      key: AWS_REGION
+                - name: AWS_DEFAULT_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${AWS_SECRET_NAME}
+                      key: AWS_REGION
+
+                # S3 backup location.
+                - name: S3_BUCKET
+                  value: ${S3_BUCKET}
+
+                # Example:
+                # mongo-migration/emerald/aws-docdb-jasper-20260617T211500Z.archive.gz
+                - name: S3_DUMP_KEY
+                  value: ${S3_DUMP_KEY}
+
+                # Optional. If empty, checksum validation is skipped.
+                # Example:
+                # mongo-migration/emerald/aws-docdb-jasper-20260617T211500Z.archive.gz.sha256
+                - name: S3_CHECKSUM_KEY
+                  value: ${S3_CHECKSUM_KEY}
+
+                # Target MongoDB service.
+                - name: MONGO_HOST
+                  value: ${MONGO_HOST}
+                - name: MONGO_PORT
+                  value: ${MONGO_PORT}
+                - name: MONGO_AUTH_DB
+                  value: ${MONGO_AUTH_DB}
+
+                # Matches the StatefulSet.
+                - name: MONGO_INITDB_ROOT_USERNAME
+                  value: ${MONGO_INITDB_ROOT_USERNAME}
+
+                # Target MongoDB TLS settings.
+                - name: MONGO_TLS_CA_FILE
+                  value: /etc/mongo/tls/ca.crt
+
+                # Set to "true" if rerunning and you want existing collections dropped first.
+                - name: DROP_EXISTING
+                  value: ${DROP_EXISTING}
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  set -eu
+                  set +x
+
+                  log() {
+                    echo "[mongo-s3-restore] $*"
+                  }
+
+                  fail() {
+                    echo "[mongo-s3-restore] ERROR: $*" >&2
+                    exit 1
+                  }
+
+                  DUMP_PATH="/tmp/mongo-dump.archive.gz"
+                  CHECKSUM_PATH="/tmp/mongo-dump.archive.gz.sha256"
+
+                  log "Checking required tools."
+                  command -v aws >/dev/null 2>&1 || fail "aws CLI is required in the image."
+                  command -v mongorestore >/dev/null 2>&1 || fail "mongorestore is required in the image."
+                  command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required in the image."
+
+                  log "Loading MongoDB credentials from Vault-injected file."
+                  if [ -f "/vault/secrets/jasper-secret" ]; then
+                    . "/vault/secrets/jasper-secret"
+                  else
+                    VAULT_SECRET_FILE="$(ls /vault/secrets/jasper-secret* 2>/dev/null | head -n 1 || true)"
+                    if [ -n "$VAULT_SECRET_FILE" ]; then
+                      . "$VAULT_SECRET_FILE"
+                    else
+                      fail "No Vault-injected jasper secret file found under /vault/secrets."
+                    fi
+                  fi
+
+                  MONGO_USERNAME="${MONGO_INITDB_ROOT_USERNAME:-root}"
+                  MONGO_PASSWORD="${MONGO_INITDB_ROOT_PASSWORD:-}"
+
+                  [ -n "${MONGO_PASSWORD}" ] || fail "MONGO_INITDB_ROOT_PASSWORD was not found after sourcing Vault secret."
+                  [ -n "${S3_BUCKET:-}" ] || fail "S3_BUCKET is required."
+                  [ -n "${S3_DUMP_KEY:-}" ] || fail "S3_DUMP_KEY is required."
+                  [ -f "${MONGO_TLS_CA_FILE}" ] || fail "Mongo TLS CA file not found: ${MONGO_TLS_CA_FILE}"
+
+                  log "Downloading dump from S3: s3://${S3_BUCKET}/${S3_DUMP_KEY}"
+                  aws s3 cp \
+                    "s3://${S3_BUCKET}/${S3_DUMP_KEY}" \
+                    "${DUMP_PATH}" \
+                    --only-show-errors
+
+                  test -s "${DUMP_PATH}" || fail "Downloaded dump is missing or empty."
+
+                  if [ -n "${S3_CHECKSUM_KEY:-}" ]; then
+                    log "Downloading checksum from S3: s3://${S3_BUCKET}/${S3_CHECKSUM_KEY}"
+                    aws s3 cp \
+                      "s3://${S3_BUCKET}/${S3_CHECKSUM_KEY}" \
+                      "${CHECKSUM_PATH}" \
+                      --only-show-errors
+
+                    test -s "${CHECKSUM_PATH}" || fail "Downloaded checksum is missing or empty."
+
+                    log "Verifying checksum."
+                    EXPECTED_SHA="$(awk '{print $1}' "${CHECKSUM_PATH}")"
+                    ACTUAL_SHA="$(sha256sum "${DUMP_PATH}" | awk '{print $1}')"
+
+                    if [ "${EXPECTED_SHA}" != "${ACTUAL_SHA}" ]; then
+                      fail "Checksum mismatch. Expected ${EXPECTED_SHA}, got ${ACTUAL_SHA}."
+                    fi
+
+                    log "Checksum verified."
+                  else
+                    log "No S3_CHECKSUM_KEY provided; skipping checksum validation."
+                  fi
+
+                  DROP_ARG=""
+                  if [ "${DROP_EXISTING}" = "true" ]; then
+                    DROP_ARG="--drop"
+                  fi
+
+                  log "Restoring archive to MongoDB at ${MONGO_HOST}:${MONGO_PORT}."
+                  mongorestore \
+                    --host "${MONGO_HOST}:${MONGO_PORT}" \
+                    --ssl \
+                    --sslCAFile "${MONGO_TLS_CA_FILE}" \
+                    --sslAllowInvalidHostnames \
+                    --username "${MONGO_USERNAME}" \
+                    --password "${MONGO_PASSWORD}" \
+                    --authenticationDatabase "${MONGO_AUTH_DB}" \
+                    --archive="${DUMP_PATH}" \
+                    --gzip \
+                    ${DROP_ARG}
+
+                  log "MongoDB restore completed successfully."
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: '1'
+                  memory: 1Gi
+              securityContext:
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+              volumeMounts:
+                - name: mongodb-temp-tls
+                  mountPath: /etc/mongo/tls
+                  readOnly: true
+          volumes:
+            - name: mongodb-temp-tls
+              secret:
+                secretName: ${MONGODB_TLS_SECRET_NAME}
+                items:
+                  - key: ${MONGODB_TLS_CA_KEY}
+                    path: ca.crt
+                defaultMode: 420
+
+parameters:
+  - name: NAMESPACE
+    required: true
+
+  - name: OWNER_LABEL
+    value: platform-team
+
+  - name: PROJECT_LABEL
+    value: application-project
+
+  - name: SERVICE_ACCOUNT_NAME
+    value: e4161f-vault
+
+  - name: RESTORE_IMAGE
+    value: ghcr.io/bcgov/jasper/generate-mongo-tls:latest
+
+  - name: AWS_SECRET_NAME
+    required: true
+
+  - name: S3_BUCKET
+    required: true
+
+  - name: S3_DUMP_KEY
+    required: true
+
+  - name: S3_CHECKSUM_KEY
+    value: ''
+
+  - name: MONGO_HOST
+    required: true
+
+  - name: MONGO_PORT
+    value: '27017'
+
+  - name: MONGO_AUTH_DB
+    value: admin
+
+  - name: MONGO_INITDB_ROOT_USERNAME
+    value: root
+
+  - name: DROP_EXISTING
+    value: 'false'
+
+  - name: MONGODB_TLS_SECRET_NAME
+    value: mongodb-temp-secrets
+
+  - name: MONGODB_TLS_CA_KEY
+    value: crt
+
+  - name: VAULT_NAMESPACE
+    value: platform-services
+
+  - name: VAULT_AUTH_PATH
+    value: auth/k8s-emerald
+
+  - name: VAULT_ROLE
+    value: e4161f-nonprod
+
+  - name: VAULT_AGENT_CONFIGMAP
+    value: mongodb-vault
+
+  - name: VAULT_SECRET_PATH
+    required: true

--- a/openshift/mongo-tls-certificate-cronjob.cj.yaml
+++ b/openshift/mongo-tls-certificate-cronjob.cj.yaml
@@ -1,0 +1,364 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: mongo-tls-certificate-cronjob-template
+  annotations:
+    description: 'Creates a CronJob that generates MongoDB TLS certificates, updates an OpenShift TLS secret, syncs the certificate payload to AWS Secrets Manager, and restarts the MongoDB StatefulSet.'
+objects:
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: ${CRONJOB_NAME}
+      labels:
+        app: generate-mongo-tls
+        app.kubernetes.io/name: ${APP_NAME}
+        app.kubernetes.io/instance: ${APP_INSTANCE}
+        app.kubernetes.io/managed-by: openshift-template
+        DataClass: ${DATA_CLASS}
+        role: ${ROLE_LABEL}
+        template: mongo-tls-certificate-cronjob-template
+    spec:
+      schedule: '${SCHEDULE}'
+      concurrencyPolicy: Forbid
+      suspend: ${{SUSPEND}}
+      successfulJobsHistoryLimit: ${{SUCCESSFUL_JOBS_HISTORY_LIMIT}}
+      failedJobsHistoryLimit: ${{FAILED_JOBS_HISTORY_LIMIT}}
+      jobTemplate:
+        spec:
+          activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+          backoffLimit: ${{BACKOFF_LIMIT}}
+          ttlSecondsAfterFinished: ${{TTL_SECONDS_AFTER_FINISHED}}
+          template:
+            metadata:
+              labels:
+                app: generate-mongo-tls
+                app.kubernetes.io/name: ${APP_NAME}
+                app.kubernetes.io/instance: ${APP_INSTANCE}
+                DataClass: ${DATA_CLASS}
+                role: ${ROLE_LABEL}
+                template: mongo-tls-certificate-cronjob-template
+            spec:
+              restartPolicy: Never
+              serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+              automountServiceAccountToken: true
+              terminationGracePeriodSeconds: 30
+              dnsPolicy: ClusterFirst
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: generate-mongo-tls
+                  image: ${IMAGE}
+                  imagePullPolicy: ${IMAGE_PULL_POLICY}
+                  resources:
+                    requests:
+                      cpu: ${CPU_REQUEST}
+                      memory: ${MEMORY_REQUEST}
+                    limits:
+                      cpu: ${CPU_LIMIT}
+                      memory: ${MEMORY_LIMIT}
+                  env:
+                    - name: CERT_SUBJECT_ALT_NAME
+                      value: ${CERT_SUBJECT_ALT_NAME}
+
+                    - name: CERT_DAYS
+                      value: '${CERT_DAYS}'
+
+                    - name: OPENSHIFT_SECRET_NAME
+                      value: ${OPENSHIFT_SECRET_NAME}
+
+                    - name: OPENSHIFT_SECRET_NAMESPACE
+                      value: ${OPENSHIFT_SECRET_NAMESPACE}
+
+                    - name: AWS_SECRET_ID
+                      value: ${AWS_SECRET_ID}
+
+                    - name: MONGO_STATEFULSET_SELECTOR
+                      value: ${MONGO_STATEFULSET_SELECTOR}
+
+                    - name: ROLLOUT_TIMEOUT
+                      value: ${ROLLOUT_TIMEOUT}
+
+                    - name: CA_CERT_PATH
+                      value: /ca/ca.crt
+
+                    - name: CA_KEY_PATH
+                      value: /ca/ca.key
+
+                    - name: GENERATED_CERT_KEY
+                      value: ${GENERATED_CERT_KEY}
+
+                    - name: GENERATED_PRIVATE_KEY_KEY
+                      value: ${GENERATED_PRIVATE_KEY_KEY}
+
+                    - name: GENERATED_PEM_KEY
+                      value: ${GENERATED_PEM_KEY}
+
+                    - name: CA_BUNDLE_KEY
+                      value: ${CA_BUNDLE_KEY}
+
+                    - name: AWS_ACCESS_KEY_ID
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${AWS_CREDENTIALS_SECRET_NAME}
+                          key: ${AWS_ACCESS_KEY_ID_KEY}
+
+                    - name: AWS_SECRET_ACCESS_KEY
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${AWS_CREDENTIALS_SECRET_NAME}
+                          key: ${AWS_SECRET_ACCESS_KEY_KEY}
+
+                    - name: AWS_REGION
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${AWS_CREDENTIALS_SECRET_NAME}
+                          key: ${AWS_REGION_KEY}
+
+                    - name: HTTP_PROXY
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${PROXY_CONFIG_SECRET_NAME}
+                          key: ${HTTP_PROXY_KEY}
+
+                    - name: HTTPS_PROXY
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${PROXY_CONFIG_SECRET_NAME}
+                          key: ${HTTPS_PROXY_KEY}
+
+                    - name: NO_PROXY
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${PROXY_CONFIG_SECRET_NAME}
+                          key: ${NO_PROXY_KEY}
+
+                    - name: http_proxy
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${PROXY_CONFIG_SECRET_NAME}
+                          key: ${HTTP_PROXY_KEY}
+
+                    - name: https_proxy
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${PROXY_CONFIG_SECRET_NAME}
+                          key: ${HTTPS_PROXY_KEY}
+
+                    - name: no_proxy
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${PROXY_CONFIG_SECRET_NAME}
+                          key: ${NO_PROXY_KEY}
+
+                  securityContext:
+                    capabilities:
+                      drop:
+                        - ALL
+                    allowPrivilegeEscalation: false
+
+                  volumeMounts:
+                    - name: mongo-tls-ca
+                      readOnly: true
+                      mountPath: /ca
+
+                    - name: work
+                      mountPath: /tmp
+
+                  terminationMessagePath: /dev/termination-log
+                  terminationMessagePolicy: File
+
+              volumes:
+                - name: mongo-tls-ca
+                  secret:
+                    secretName: ${CA_SECRET_NAME}
+                    items:
+                      - key: ${CA_CERT_SECRET_KEY}
+                        path: ca.crt
+                      - key: ${CA_KEY_SECRET_KEY}
+                        path: ca.key
+                    defaultMode: 420
+
+                - name: work
+                  emptyDir:
+                    medium: Memory
+                    sizeLimit: ${WORK_VOLUME_SIZE_LIMIT}
+
+parameters:
+  - name: CRONJOB_NAME
+    displayName: CronJob name
+    required: true
+    value: sync-mongo-certificate
+
+  - name: APP_NAME
+    displayName: Application name label
+    required: true
+    value: sync-mongo-certificate
+
+  - name: APP_INSTANCE
+    displayName: Application instance label
+    required: true
+
+  - name: DATA_CLASS
+    displayName: DataClass label
+    required: true
+    value: Medium
+
+  - name: ROLE_LABEL
+    displayName: Role label
+    required: true
+    value: update-aws-creds
+
+  - name: SCHEDULE
+    displayName: Cron schedule
+    required: true
+    value: '0 0 * * 0'
+
+  - name: SUSPEND
+    displayName: Suspend CronJob
+    required: true
+    value: 'false'
+
+  - name: SUCCESSFUL_JOBS_HISTORY_LIMIT
+    required: true
+    value: '3'
+
+  - name: FAILED_JOBS_HISTORY_LIMIT
+    required: true
+    value: '3'
+
+  - name: ACTIVE_DEADLINE_SECONDS
+    required: true
+    value: '600'
+
+  - name: BACKOFF_LIMIT
+    required: true
+    value: '1'
+
+  - name: TTL_SECONDS_AFTER_FINISHED
+    required: true
+    value: '259200'
+
+  - name: SERVICE_ACCOUNT_NAME
+    displayName: ServiceAccount used by the CronJob
+    required: true
+
+  - name: IMAGE
+    displayName: Certificate generation image
+    required: true
+    value: ghcr.io/devinleighsmith/jasper/generate-mongo-tls:latest
+
+  - name: IMAGE_PULL_POLICY
+    required: true
+    value: Always
+
+  - name: CPU_REQUEST
+    required: true
+    value: 50m
+
+  - name: MEMORY_REQUEST
+    required: true
+    value: 64Mi
+
+  - name: CPU_LIMIT
+    required: true
+    value: 250m
+
+  - name: MEMORY_LIMIT
+    required: true
+    value: 256Mi
+
+  - name: CERT_SUBJECT_ALT_NAME
+    displayName: Certificate SANs
+    description: 'Comma-separated SAN list, for example: IP:10.0.0.1,DNS:mongodb-0.mongodb-headless.namespace.svc.cluster.local'
+    required: true
+
+  - name: CERT_DAYS
+    required: true
+    value: '14'
+
+  - name: OPENSHIFT_SECRET_NAME
+    displayName: OpenShift TLS secret name to update
+    required: true
+    value: mongo-tls
+
+  - name: OPENSHIFT_SECRET_NAMESPACE
+    displayName: Namespace containing the OpenShift TLS secret to update
+    required: true
+
+  - name: AWS_SECRET_ID
+    displayName: AWS Secrets Manager secret id
+    required: true
+
+  - name: MONGO_STATEFULSET_SELECTOR
+    displayName: MongoDB StatefulSet selector
+    description: 'Label selector used by the job to find the MongoDB StatefulSet to restart.'
+    required: true
+
+  - name: ROLLOUT_TIMEOUT
+    required: true
+    value: 300s
+
+  - name: GENERATED_CERT_KEY
+    required: true
+    value: tls.crt
+
+  - name: GENERATED_PRIVATE_KEY_KEY
+    required: true
+    value: tls.key
+
+  - name: GENERATED_PEM_KEY
+    required: true
+    value: tls.pem
+
+  - name: CA_BUNDLE_KEY
+    required: true
+    value: ca.crt
+
+  - name: AWS_CREDENTIALS_SECRET_NAME
+    displayName: Secret containing AWS credentials
+    required: true
+
+  - name: AWS_ACCESS_KEY_ID_KEY
+    required: true
+    value: AWS_ACCESS_KEY_ID
+
+  - name: AWS_SECRET_ACCESS_KEY_KEY
+    required: true
+    value: AWS_SECRET_ACCESS_KEY
+
+  - name: AWS_REGION_KEY
+    required: true
+    value: AWS_REGION
+
+  - name: PROXY_CONFIG_SECRET_NAME
+    displayName: Secret containing proxy config
+    required: true
+    value: proxy-config
+
+  - name: HTTP_PROXY_KEY
+    required: true
+    value: HTTP_PROXY
+
+  - name: HTTPS_PROXY_KEY
+    required: true
+    value: HTTPS_PROXY
+
+  - name: NO_PROXY_KEY
+    required: true
+    value: NO_PROXY
+
+  - name: CA_SECRET_NAME
+    displayName: Secret containing the CA certificate and key
+    required: true
+
+  - name: CA_CERT_SECRET_KEY
+    required: true
+    value: ca.crt
+
+  - name: CA_KEY_SECRET_KEY
+    required: true
+    value: ca.key
+
+  - name: WORK_VOLUME_SIZE_LIMIT
+    required: true
+    value: 64Mi


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**841/842**----    

## Issue ticket number and link  
[JASPER-842](https://jira.justice.gov.bc.ca/browse/JASPER-842)
[JASPER-841](https://jira.justice.gov.bc.ca/browse/JASPER-841)
## Description

provides tf changes necessary to store/pull self-signed emerald certs
creates new image with associated script to generate ssh certs
updates api to pull certs from secrets, and use during mongo connection

See:
https://wiki.justice.gov.bc.ca/wiki/spaces/JASPER/pages/508690464/Database+Migration+LZA+to+Emerald
and:
https://github.com/bcgov-c/tenant-gitops-e4161f/pull/11

for context

Fixes # (issue)  

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Tested this by deploying these changes into dev, migrating the db, and connecting the aws api to the emerald db.



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


## Documentation References  

https://wiki.justice.gov.bc.ca/wiki/spaces/JASPER/pages/508690464/Database+Migration+LZA+to+Emerald