### PR TITLE
JASPER-845: Fix dark/light theme toggle after Vuetify 4 upgrade

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -31,7 +31,7 @@
   const themeStore = useThemeStore();
   const darsStore = useDarsStore();
   const commonStore = useCommonStore();
-  const theme = ref(themeStore.state);
+  const theme = themeStore.state;
   const profile = ref(false);
 </script>
 

--- a/web/src/components/shared/ProfileOffCanvas.vue
+++ b/web/src/components/shared/ProfileOffCanvas.vue
@@ -67,7 +67,7 @@
   const model = defineModel<boolean>();
   const themeStore = useThemeStore();
   const commonStore = useCommonStore();
-  const appliedThemes = ref(['']);
+  const appliedThemes = ref(themeStore.state.value === 'dark' ? ['dark'] : []);
   const openedGroups = ref(['quick-links']); // Expand Quick links by default
   const showTimebankModal = ref(false);
 
@@ -104,5 +104,10 @@
   .v-list-item-title {
     white-space: normal;
     word-break: break-word;
+  }
+  .v-navigation-drawer__content {
+    flex: 1 1 0 !important;
+    height: auto !important;
+    min-height: 0 !important;
   }
 </style>


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-845

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-845

## Description
- Pass the theme store's ref directly to <v-theme-provider> so toggli…ng stays reactive.
- Override .v-navigation-drawer__content flex sizing so the dark-mode toggle renders inside the drawer instead of being pushed below the viewport.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Local testing
- [ ] Test B  

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules   

## Screen Grab
https://github.com/user-attachments/assets/58ce4944-587a-44c2-a700-81e29343c13b
