### PR TITLE
JASPER-848: Signing and Digital Workflow: Separate Desk Orders (applications) from Orders (for signing) and show 2 menu options

### DIFF
--- a/api/Jobs/SendOrderNotificationJob.cs
+++ b/api/Jobs/SendOrderNotificationJob.cs
@@ -35,13 +35,6 @@ public class SendOrderNotificationJob(
             _logger.LogInformation("Processing order notification job for file {FileId}",
                 order.OrderRequest.PhysicalFileId);
 
-            if (order.OrderRequest?.Referral?.IsPriority != true)
-            {
-                _logger.LogInformation("Order for file {FileId} is not marked as priority - skipping notification",
-                    order.OrderRequest.PhysicalFileId);
-                return;
-            }
-
             await NotifyJudgeOfNewOrderAsync(order);
 
             _logger.LogInformation("Order notification job completed for file {FileId}",
@@ -87,6 +80,13 @@ public class SendOrderNotificationJob(
         }
 
         await _orderReceivedAck.SendAsync(order, databaseUser.Id);
+
+        if (order.OrderRequest?.Referral?.IsPriority != true)
+        {
+            _logger.LogInformation("Order for file {FileId} is not marked as priority - skipping email notification",
+                order.OrderRequest.PhysicalFileId);
+            return;
+        }
 
         var judgeEmail = databaseUser.Email;
         if (string.IsNullOrWhiteSpace(judgeEmail))

--- a/tests/api/Jobs/SendOrderNotificationJobTests.cs
+++ b/tests/api/Jobs/SendOrderNotificationJobTests.cs
@@ -109,19 +109,34 @@ public class SendOrderNotificationJobTests
         orderRequestDto.PhysicalFileId = physicalFileId;
         var orderDto = CreateOrderDto(judgeId, orderRequestDto);
 
+        var judge = CreateActiveJudge(judgeId);
+        _mockJudgeService.Setup(s => s.GetJudge(judgeId))
+            .ReturnsAsync(judge);
+
+        var databaseUser = new UserDto
+        {
+            Id = _faker.Random.AlphaNumeric(24),
+            FirstName = _faker.Person.FirstName,
+            LastName = _faker.Person.LastName,
+            Email = _faker.Person.Email,
+            JudgeId = judgeId
+        };
+
+        _mockUserService.Setup(s => s.GetByJudgeIdAsync(judgeId))
+            .ReturnsAsync(databaseUser);
         await _job.Execute(orderDto);
 
         _mockLogger.Verify(
             x => x.Log(
                 LogLevel.Information,
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((o, t) => o.ToString().Contains($"Order for file {physicalFileId} is not marked as priority - skipping notification")),
+                It.Is<It.IsAnyType>((o, t) => o.ToString().Contains($"Order for file {physicalFileId} is not marked as priority - skipping email notification")),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception, string>>()),
             Times.Once);
 
-        _mockJudgeService.Verify(s => s.GetJudge(It.IsAny<int>()), Times.Never);
-        _mockUserService.Verify(s => s.GetByJudgeIdAsync(It.IsAny<int>()), Times.Never);
+        _mockJudgeService.Verify(s => s.GetJudge(It.IsAny<int>()), Times.Once);
+        _mockUserService.Verify(s => s.GetByJudgeIdAsync(It.IsAny<int>()), Times.Once);
         _mockEmailTemplateService.Verify(s => s.SendEmailTemplateAsync(
             It.IsAny<string>(),
             It.IsAny<string>(),

--- a/web/src/components/orders/Orders.vue
+++ b/web/src/components/orders/Orders.vue
@@ -65,7 +65,7 @@
   </div>
 </template>
 <script lang="ts" setup>
-  import { isDeskOrder } from '@/composables/useOrderCounts';
+  import { isDeskOrder, isPendingOrder } from '@/composables/useOrderCounts';
   import { OrderService } from '@/services';
   import {
     useCommonStore,
@@ -73,7 +73,7 @@
     useOrdersStore,
   } from '@/stores';
   import { Order } from '@/types';
-  import { KeyValueInfo, OrderReviewStatus } from '@/types/common';
+  import { KeyValueInfo } from '@/types/common';
   import { viewOrderDetails } from '@/utils/orderDetails';
   import { getCourtClassLabel, isCourtClassLabelCriminal } from '@/utils/utils';
   import { DateTime } from 'luxon';
@@ -111,11 +111,7 @@
   });
 
   const pendingOrders = computed(() =>
-    filteredOrders.value.filter(
-      (order) =>
-        order.status === OrderReviewStatus.Pending ||
-        order.status === OrderReviewStatus.AwaitingDocumentation
-    )
+    filteredOrders.value.filter((order) => isPendingOrder(order))
   );
 
   const completedOrders = computed(() => {
@@ -124,7 +120,7 @@
       .startOf('day');
     return filteredOrders.value.filter(
       (order) =>
-        order.status === OrderReviewStatus.Approved &&
+        !isPendingOrder(order) &&
         DateTime.fromJSDate(new Date(order.receivedDate)) >= cutoff
     );
   });

--- a/web/src/components/orders/Orders.vue
+++ b/web/src/components/orders/Orders.vue
@@ -15,21 +15,18 @@
       <v-expansion-panel>
         <v-expansion-panel-title class="px-3">
           <h5 class="m-0">
-            For signing
-            {{
-              forSigningOrders.length > 0 ? `(${forSigningOrders.length})` : ''
-            }}
+            {{ isDeskOrdersView ? 'Applications' : 'For signing' }}
+            {{ pendingOrders.length > 0 ? `(${pendingOrders.length})` : '' }}
           </h5>
         </v-expansion-panel-title>
         <v-expansion-panel-text>
           <OrdersDataTable
-            :data="forSigningOrders"
+            :data="pendingOrders"
             :viewCaseDetails="viewCaseDetails"
             :viewOrderDetails="viewOrderDetails"
             :columns="[
               'packageId',
               'priorityTypeDesc',
-              'courtListType',
               'receivedDate',
               'division',
               'fileNumber',
@@ -52,7 +49,6 @@
             :columns="[
               'packageId',
               'priorityTypeDesc',
-              'courtListType',
               'receivedDate',
               'processedDate',
               'division',
@@ -69,6 +65,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+  import { isDeskOrder } from '@/composables/useOrderCounts';
   import { OrderService } from '@/services';
   import {
     useCommonStore,
@@ -81,11 +78,22 @@
   import { getCourtClassLabel, isCourtClassLabelCriminal } from '@/utils/utils';
   import { DateTime } from 'luxon';
   import { computed, inject, onMounted } from 'vue';
+  import { useRoute } from 'vue-router';
 
   const ordersStore = useOrdersStore();
   const courtFileSearchStore = useCourtFileSearchStore();
   const commonStore = useCommonStore();
   const orderService = inject<OrderService>('orderService');
+  const route = useRoute();
+
+  // When the route is /desk-orders show desk orders only; otherwise show non-desk orders.
+  const isDeskOrdersView = computed(() => route.name === 'DeskOrders');
+
+  const filteredOrders = computed(() =>
+    (ordersStore?.orders ?? []).filter((order) =>
+      isDeskOrdersView.value ? isDeskOrder(order) : !isDeskOrder(order)
+    )
+  );
 
   // Only show completed orders that were received within the last 30 days.
   const COMPLETED_ORDERS_CUTOFF_DAYS = 30;
@@ -102,25 +110,22 @@
     ordersStore.initialize(orderService, judgeId);
   });
 
-  const forSigningOrders = computed(
-    () =>
-      ordersStore?.orders?.filter(
-        (order) =>
-          order.status === OrderReviewStatus.Pending ||
-          order.status === OrderReviewStatus.AwaitingDocumentation
-      ) ?? []
+  const pendingOrders = computed(() =>
+    filteredOrders.value.filter(
+      (order) =>
+        order.status === OrderReviewStatus.Pending ||
+        order.status === OrderReviewStatus.AwaitingDocumentation
+    )
   );
 
   const completedOrders = computed(() => {
     const cutoff = DateTime.now()
       .minus({ days: COMPLETED_ORDERS_CUTOFF_DAYS })
       .startOf('day');
-    return (
-      ordersStore?.orders?.filter(
-        (order) =>
-          order.status === OrderReviewStatus.Approved &&
-          DateTime.fromJSDate(new Date(order.receivedDate)) >= cutoff
-      ) ?? []
+    return filteredOrders.value.filter(
+      (order) =>
+        order.status === OrderReviewStatus.Approved &&
+        DateTime.fromJSDate(new Date(order.receivedDate)) >= cutoff
     );
   });
 

--- a/web/src/components/orders/OrdersDataTable.vue
+++ b/web/src/components/orders/OrdersDataTable.vue
@@ -30,9 +30,6 @@
     <template #[`item.priorityTypeDesc`]="{ item }">
       <span>{{ item.priorityTypeDesc }}</span>
     </template>
-    <template #[`item.courtListType`]="{ item }">
-      <span>{{ item.courtListTypeDescription }}</span>
-    </template>
   </v-data-table-virtual>
 </template>
 <script setup lang="ts">
@@ -46,7 +43,6 @@
   type ColumnKey =
     | 'packageId'
     | 'priorityTypeDesc'
-    | 'courtListType'
     | 'receivedDate'
     | 'processedDate'
     | 'division'
@@ -98,10 +94,6 @@
       title: 'PRIORITY',
       key: 'priorityTypeDesc',
     },
-    courtListType: {
-      title: 'TYPE',
-      key: 'courtListTypeDescription',
-    },
     receivedDate: {
       title: 'DATE RECEIVED',
       key: 'receivedDate',
@@ -140,7 +132,6 @@
     const columnKeys = props.columns || [
       'packageId',
       'priorityTypeDesc',
-      'courtListType',
       'receivedDate',
       'division',
       'fileNumber',

--- a/web/src/components/orders/OrdersTab.vue
+++ b/web/src/components/orders/OrdersTab.vue
@@ -1,0 +1,120 @@
+<template>
+  <v-tab :value="value" :to="`/${value}`">
+    <v-badge
+      v-if="priorityCount > 0 && regularCount > 0"
+      data-testid="order-combo-badge"
+      :class="{
+        'badge-pulse': pulseActive,
+        'order-combo-badge': true,
+      }"
+      offset-x="10"
+      offset-y="-12"
+    >
+      <template #badge>
+        <span
+          class="capsule-half priority"
+          :title="`${priorityCount} priority ${label} pending`"
+        >
+          {{ priorityCount }}
+        </span>
+        <span
+          class="capsule-half regular"
+          :title="`${regularCount} regular ${label} pending`"
+        >
+          {{ regularCount }}
+        </span>
+      </template>
+      {{ title }}
+    </v-badge>
+    <v-badge
+      v-else-if="priorityCount > 0"
+      data-testid="priority-badge"
+      :content="priorityCount"
+      :class="{ 'badge-pulse': pulseActive, 'priority-badge': true }"
+      color="var(--bg-red-500)"
+      :title="`${priorityCount} priority ${label} pending`"
+      offset-x="-10"
+      offset-y="-10"
+    >
+      {{ title }}
+    </v-badge>
+    <v-badge
+      v-else-if="regularCount > 0"
+      data-testid="regular-badge"
+      :content="regularCount"
+      :class="{ 'badge-pulse': pulseActive, 'regular-badge': true }"
+      color="var(--bg-green-500)"
+      :title="`${regularCount} regular ${label} pending`"
+      offset-x="-10"
+      offset-y="-10"
+    >
+      {{ title }}
+    </v-badge>
+    <template v-else>{{ title }}</template>
+  </v-tab>
+</template>
+
+<script setup lang="ts">
+  defineProps<{
+    value: string;
+    title: string;
+    label: string;
+    priorityCount: number;
+    regularCount: number;
+    pulseActive: boolean;
+  }>();
+</script>
+
+<style scoped>
+  .badge-pulse :deep(.v-badge__badge) {
+    animation: badge-pop 0.35s ease-out;
+  }
+
+  .priority-badge :deep(.v-badge__badge),
+  .regular-badge :deep(.v-badge__badge) {
+    min-width: auto;
+    height: 16px;
+    overflow: hidden;
+    color: var(--bg-white-500);
+  }
+
+  .order-combo-badge :deep(.v-badge__badge) {
+    padding: 0;
+    min-width: auto;
+    height: 16px;
+    overflow: hidden;
+    background: transparent;
+  }
+
+  .order-combo-badge :deep(.v-badge__badge) .capsule-half {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 100%;
+    padding: 0 6px;
+    font-size: 0.75rem;
+    line-height: 1;
+    color: var(--bg-white-500);
+  }
+
+  .order-combo-badge :deep(.v-badge__badge) .capsule-half.priority {
+    background-color: var(--bg-red-500);
+  }
+
+  .order-combo-badge :deep(.v-badge__badge) .capsule-half.regular {
+    background-color: var(--bg-green-500);
+  }
+
+  @keyframes badge-pop {
+    0% {
+      transform: scale(1);
+    }
+    45% {
+      transform: scale(1.2);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+</style>

--- a/web/src/components/shared/AppBar.vue
+++ b/web/src/components/shared/AppBar.vue
@@ -25,6 +25,7 @@
         >DARS</v-btn
       >
       <OrdersTab
+        data-testid="orders-tab"
         v-if="showOrders"
         value="orders"
         title="For Signing"
@@ -34,6 +35,7 @@
         :pulse-active="badgePulseActive"
       />
       <OrdersTab
+        data-testid="desk-orders-tab"
         v-if="showOrders"
         value="desk-orders"
         title="Applications"

--- a/web/src/components/shared/AppBar.vue
+++ b/web/src/components/shared/AppBar.vue
@@ -24,59 +24,24 @@
         :rounded="false"
         >DARS</v-btn
       >
-      <v-tab value="orders" to="/orders" v-if="showOrders">
-        <v-badge
-          v-if="priorityPendingOrdersCount > 0 && regularPendingOrdersCount > 0"
-          data-testid="order-combo-badge"
-          :class="{
-            'badge-pulse': badgePulseActive,
-            'order-combo-badge': true,
-          }"
-          offset-x="0"
-          offset-y="-10"
-        >
-          <template #badge>
-            <span
-              class="capsule-half priority"
-              :title="`${priorityPendingOrdersCount} priority orders pending`"
-            >
-              {{ priorityPendingOrdersCount }}
-            </span>
-            <span
-              class="capsule-half regular"
-              :title="`${regularPendingOrdersCount} regular orders pending`"
-            >
-              {{ regularPendingOrdersCount }}
-            </span>
-          </template>
-          For Signing
-        </v-badge>
-        <v-badge
-          v-else-if="priorityPendingOrdersCount > 0"
-          data-testid="priority-badge"
-          :content="priorityPendingOrdersCount"
-          :class="{ 'badge-pulse': badgePulseActive }"
-          color="var(--bg-red-500)"
-          :title="`${priorityPendingOrdersCount} priority orders pending`"
-          offset-x="-10"
-          offset-y="-10"
-        >
-          For Signing
-        </v-badge>
-        <v-badge
-          v-else-if="regularPendingOrdersCount > 0"
-          data-testid="regular-badge"
-          :content="regularPendingOrdersCount"
-          :class="{ 'badge-pulse': badgePulseActive }"
-          color="var(--bg-green-500)"
-          :title="`${regularPendingOrdersCount} regular orders pending`"
-          offset-x="-10"
-          offset-y="-10"
-        >
-          For Signing
-        </v-badge>
-        <template v-else>For Signing</template>
-      </v-tab>
+      <OrdersTab
+        v-if="showOrders"
+        value="orders"
+        title="For Signing"
+        label="orders"
+        :priority-count="priorityPendingOrdersCount"
+        :regular-count="regularPendingOrdersCount"
+        :pulse-active="badgePulseActive"
+      />
+      <OrdersTab
+        v-if="showOrders"
+        value="desk-orders"
+        title="Applications"
+        label="desk orders"
+        :priority-count="priorityPendingDeskOrdersCount"
+        :regular-count="regularPendingDeskOrdersCount"
+        :pulse-active="badgePulseActive"
+      />
       <v-spacer></v-spacer>
       <div class="d-flex align-center">
         <JudgeSelector
@@ -113,6 +78,8 @@
 
 <script setup lang="ts">
   import logo from '@/assets/jasper-logo.svg?url';
+  import { useOrderBadgePulse } from '@/composables/useOrderBadgePulse.js';
+  import { isDeskOrder, useOrderCounts } from '@/composables/useOrderCounts';
   import { JudgeService, OrderService } from '@/services';
   import { NotificationsService } from '@/signalr/notifications';
   import { useCommonStore } from '@/stores';
@@ -120,15 +87,12 @@
   import { useNotificationsStore } from '@/stores/NotificationsStore';
   import { useOrdersStore } from '@/stores/OrdersStore';
   import { PersonSearchItem } from '@/types';
-  import {
-    OrderPriorityEnum,
-    OrderReviewStatus,
-    RolesEnum,
-  } from '@/types/common';
+  import { RolesEnum } from '@/types/common';
   import { mdiAccountCircle } from '@mdi/js';
-  import { computed, inject, nextTick, onMounted, ref, watch } from 'vue';
+  import { computed, inject, onMounted, ref, watch } from 'vue';
   import { useRoute } from 'vue-router';
   import JudgeSelector from './JudgeSelector.vue';
+  import OrdersTab from '../orders/OrdersTab.vue';
 
   const emit = defineEmits<(e: 'open-profile') => void>();
 
@@ -147,7 +111,6 @@
   const judges = ref<PersonSearchItem[]>([]);
   // Only users with Admin role can see Orders tab for now.
   const requiredOrderRoles = [RolesEnum.Admin] as const;
-  const priorityOrderTypes = new Set<string>(Object.values(OrderPriorityEnum));
 
   if (!judgeService || !orderService || !notificationsService) {
     throw new Error('Service is not available!');
@@ -232,52 +195,23 @@
       judges.value.length > 0
   );
 
-  const priorityPendingOrdersCount = computed(
-    () =>
-      ordersStore.orders.filter(
-        (o) =>
-          o.status === OrderReviewStatus.Pending &&
-          priorityOrderTypes.has(o.priorityType)
-      ).length
+  // Pending order counts, split by desk vs. non-desk and priority vs. regular.
+  const orderCounts = useOrderCounts(
+    () => ordersStore.orders,
+    (o) => !isDeskOrder(o)
   );
+  const deskOrderCounts = useOrderCounts(() => ordersStore.orders, isDeskOrder);
 
-  const regularPendingOrdersCount = computed(
-    () =>
-      ordersStore.orders.filter(
-        (o) =>
-          o.status === OrderReviewStatus.Pending &&
-          !priorityOrderTypes.has(o.priorityType)
-      ).length
+  // Names retained for backward compatibility with existing tests/templates.
+  const priorityPendingOrdersCount = orderCounts.priority;
+  const regularPendingOrdersCount = orderCounts.regular;
+  const priorityPendingDeskOrdersCount = deskOrderCounts.priority;
+  const regularPendingDeskOrdersCount = deskOrderCounts.regular;
+
+  const { active: badgePulseActive } = useOrderBadgePulse(
+    [orderCounts, deskOrderCounts],
+    [() => ordersStore.lastFetched]
   );
-
-  const badgePulseActive = ref(false);
-
-  const triggerBadgePulse = async () => {
-    if (
-      priorityPendingOrdersCount.value === 0 ||
-      regularPendingOrdersCount.value === 0
-    ) {
-      return;
-    }
-
-    badgePulseActive.value = false;
-    await nextTick();
-    badgePulseActive.value = true;
-    globalThis.setTimeout(() => {
-      badgePulseActive.value = false;
-    }, 1200);
-  };
-
-  watch(
-    () => ordersStore.lastFetched,
-    () => {
-      void triggerBadgePulse();
-    }
-  );
-
-  watch([priorityPendingOrdersCount, regularPendingOrdersCount], () => {
-    void triggerBadgePulse();
-  });
 </script>
 
 <style scoped>
@@ -308,49 +242,5 @@
   .release-notes-emphasis {
     text-decoration: underline;
     text-underline-offset: 2px;
-  }
-
-  .badge-pulse :deep(.v-badge__badge) {
-    animation: badge-pop 0.35s ease-out;
-  }
-
-  .order-combo-badge :deep(.v-badge__badge) {
-    padding: 0;
-    min-width: auto;
-    height: 18px;
-    overflow: hidden;
-    background: transparent;
-  }
-
-  .order-combo-badge :deep(.v-badge__badge) .capsule-half {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 20px;
-    height: 100%;
-    padding: 0 6px;
-    font-size: 0.75rem;
-    line-height: 1;
-    color: var(--bg-white-500);
-  }
-
-  .order-combo-badge :deep(.v-badge__badge) .capsule-half.priority {
-    background-color: var(--bg-red-500);
-  }
-
-  .order-combo-badge :deep(.v-badge__badge) .capsule-half.regular {
-    background-color: var(--bg-green-500);
-  }
-
-  @keyframes badge-pop {
-    0% {
-      transform: scale(1);
-    }
-    45% {
-      transform: scale(1.2);
-    }
-    100% {
-      transform: scale(1);
-    }
   }
 </style>

--- a/web/src/composables/useOrderBadgePulse.ts
+++ b/web/src/composables/useOrderBadgePulse.ts
@@ -1,0 +1,49 @@
+import { nextTick, ref, watch, type ComputedRef, type WatchSource } from 'vue';
+
+const PULSE_DURATION_MS = 1200;
+
+export interface CountPair {
+  priority: ComputedRef<number>;
+  regular: ComputedRef<number>;
+}
+
+/**
+ * Triggers animation on an order badge when any of the priority or regular counts change.
+ *
+ * @param countPairs - Pairs of priority/regular count refs to watch.
+ * @param extraTriggers - Additional reactive sources that should also re-evaluate the pulse.
+ * @returns An object with `active`, a ref that is `true` while the pulse animation should play.
+ */
+export function useOrderBadgePulse(
+  countPairs: ReadonlyArray<CountPair>,
+  extraTriggers: ReadonlyArray<WatchSource> = []
+) {
+  const active = ref(false);
+
+  const trigger = async () => {
+    const shouldPulse = countPairs.some(
+      ({ priority, regular }) => priority.value > 0 || regular.value > 0
+    );
+    if (!shouldPulse) {
+      return;
+    }
+
+    active.value = false;
+    await nextTick();
+    active.value = true;
+    globalThis.setTimeout(() => {
+      active.value = false;
+    }, PULSE_DURATION_MS);
+  };
+
+  const sources: WatchSource[] = [
+    ...countPairs.flatMap(({ priority, regular }) => [priority, regular]),
+    ...extraTriggers,
+  ];
+
+  watch(sources, () => {
+    void trigger();
+  });
+
+  return { active };
+}

--- a/web/src/composables/useOrderCounts.ts
+++ b/web/src/composables/useOrderCounts.ts
@@ -1,10 +1,12 @@
 import type { Order } from '@/types';
-import { OrderPriorityEnum, OrderReviewStatus } from '@/types/common';
+import {
+  OrderCourtLisTypeEnum,
+  OrderPriorityEnum,
+  OrderReviewStatus,
+} from '@/types/common';
 import { computed, type ComputedRef } from 'vue';
 
 const PRIORITY_ORDER_TYPES = new Set<string>(Object.values(OrderPriorityEnum));
-
-export const DESK_ORDER_DESCRIPTION = 'Desk Order';
 
 export const isPendingOrder = (order: Order): boolean =>
   order.status === OrderReviewStatus.Pending;
@@ -13,7 +15,8 @@ export const isPriorityOrder = (order: Order): boolean =>
   PRIORITY_ORDER_TYPES.has(order.priorityType);
 
 export const isDeskOrder = (order: Order): boolean =>
-  order.courtListTypeDescription === DESK_ORDER_DESCRIPTION;
+  order.courtListType === OrderCourtLisTypeEnum.PSM ||
+  order.courtListType === OrderCourtLisTypeEnum.PFM;
 
 export interface PendingOrderCounts {
   priority: ComputedRef<number>;

--- a/web/src/composables/useOrderCounts.ts
+++ b/web/src/composables/useOrderCounts.ts
@@ -1,0 +1,42 @@
+import type { Order } from '@/types';
+import { OrderPriorityEnum, OrderReviewStatus } from '@/types/common';
+import { computed, type ComputedRef } from 'vue';
+
+const PRIORITY_ORDER_TYPES = new Set<string>(Object.values(OrderPriorityEnum));
+
+export const DESK_ORDER_DESCRIPTION = 'Desk Order';
+
+export const isPendingOrder = (order: Order): boolean =>
+  order.status === OrderReviewStatus.Pending;
+
+export const isPriorityOrder = (order: Order): boolean =>
+  PRIORITY_ORDER_TYPES.has(order.priorityType);
+
+export const isDeskOrder = (order: Order): boolean =>
+  order.courtListTypeDescription === DESK_ORDER_DESCRIPTION;
+
+export interface PendingOrderCounts {
+  priority: ComputedRef<number>;
+  regular: ComputedRef<number>;
+}
+
+/**
+ * Reactive counts of pending priority/regular orders matching an optional predicate.
+ *
+ * @param ordersAccessor Accessor returning the orders list to count over.
+ * @param matches        Optional filter applied in addition to the pending-status check.
+ */
+export function useOrderCounts(
+  ordersAccessor: () => readonly Order[],
+  matches: (order: Order) => boolean = () => true
+): PendingOrderCounts {
+  const pending = computed(() =>
+    ordersAccessor().filter((o) => isPendingOrder(o) && matches(o))
+  );
+
+  const priority = computed(() => pending.value.filter(isPriorityOrder).length);
+
+  const regular = computed(() => pending.value.length - priority.value);
+
+  return { priority, regular };
+}

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -87,6 +87,11 @@ const routes: RouteRecordRaw[] = [
     name: 'Orders',
     component: () => import('@/components/orders/Orders.vue'),
   },
+  {
+    path: '/desk-orders',
+    name: 'DeskOrders',
+    component: () => import('@/components/orders/Orders.vue'),
+  },
 ];
 
 const router = createRouter({

--- a/web/tests/components/orders/Orders.test.ts
+++ b/web/tests/components/orders/Orders.test.ts
@@ -1,5 +1,10 @@
 import type { Order } from '@/types';
-import { OrderReviewStatus, RolesEnum, UserInfo } from '@/types/common';
+import {
+  OrderCourtLisTypeEnum,
+  OrderReviewStatus,
+  RolesEnum,
+  UserInfo,
+} from '@/types/common';
 import { faker } from '@faker-js/faker';
 import { mount } from '@vue/test-utils';
 import Orders from 'CMP/orders/Orders.vue';
@@ -215,11 +220,11 @@ describe('Orders.vue', () => {
 
     it('displays count next to "Applications" title when there are pending desk orders', () => {
       mockRoute.name = 'DeskOrders';
-      // A desk order is identified by courtListTypeDescription === 'Desk Order'
+      // A desk order is identified by courtListType === 'PFM' | 'PSM'
       // (see isDeskOrder in useOrderCounts).
       const deskOrder: Order = {
         ...generateOrder(OrderReviewStatus.Pending, 'Criminal'),
-        courtListTypeDescription: 'Desk Order',
+        courtListType: OrderCourtLisTypeEnum.PFM,
       };
       mockOrdersStore.orders = [deskOrder];
 

--- a/web/tests/components/orders/Orders.test.ts
+++ b/web/tests/components/orders/Orders.test.ts
@@ -30,6 +30,12 @@ vi.mock('@/stores', () => ({
   }),
 }));
 
+// Mock vue-router's useRoute (Orders.vue derives isDeskOrdersView from route.name)
+const mockRoute = { name: 'Orders' };
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+}));
+
 // Mock the utils
 vi.mock('@/utils/utils', () => ({
   getCourtClassLabel: vi.fn((courtClass: string) => courtClass),
@@ -92,6 +98,9 @@ describe('Orders.vue', () => {
   beforeEach(async () => {
     pinia = createPinia();
     setActivePinia(pinia);
+
+    // Reset route to default before each test
+    mockRoute.name = 'Orders';
 
     mockOrdersStore = {
       isLoading: false,
@@ -159,13 +168,76 @@ describe('Orders.vue', () => {
     expect(title).not.toContain('(');
   });
 
+  describe('expansion panel titles', () => {
+    it('renders both pending and completed expansion panel titles', () => {
+      const wrapper = createWrapper();
+
+      const titles = wrapper.findAll('h5');
+      expect(titles).toHaveLength(2);
+      expect(titles[0].text()).toContain('For signing');
+      expect(titles[1].text()).toBe('Completed');
+    });
+
+    it('renders "Completed" title on the second expansion panel', () => {
+      const wrapper = createWrapper();
+
+      const titles = wrapper.findAll('h5');
+      expect(titles[1].text()).toBe('Completed');
+    });
+
+    it('"Completed" title does not include a count', () => {
+      const wrapper = createWrapper();
+
+      const completedTitle = wrapper.findAll('h5')[1].text();
+      expect(completedTitle).toBe('Completed');
+      expect(completedTitle).not.toContain('(');
+    });
+
+    it('renders "Applications" title when on DeskOrders route', () => {
+      mockRoute.name = 'DeskOrders';
+
+      const wrapper = createWrapper();
+
+      const title = wrapper.findAll('h5')[0].text();
+      expect(title).toContain('Applications');
+      expect(title).not.toContain('For signing');
+    });
+
+    it('does not render "For signing" title when on DeskOrders route', () => {
+      mockRoute.name = 'DeskOrders';
+      mockOrdersStore.orders = [];
+
+      const wrapper = createWrapper();
+
+      const title = wrapper.findAll('h5')[0].text();
+      expect(title).toBe('Applications');
+    });
+
+    it('displays count next to "Applications" title when there are pending desk orders', () => {
+      mockRoute.name = 'DeskOrders';
+      // A desk order is identified by courtListTypeDescription === 'Desk Order'
+      // (see isDeskOrder in useOrderCounts).
+      const deskOrder: Order = {
+        ...generateOrder(OrderReviewStatus.Pending, 'Criminal'),
+        courtListTypeDescription: 'Desk Order',
+      };
+      mockOrdersStore.orders = [deskOrder];
+
+      const wrapper = createWrapper();
+
+      const title = wrapper.findAll('h5')[0].text();
+      expect(title).toContain('Applications');
+      expect(title).toContain('(1)');
+    });
+  });
+
   it('filters pending orders correctly', () => {
     const wrapper = createWrapper();
 
     const vm = wrapper.vm as any;
-    expect(vm.forSigningOrders).toHaveLength(1);
-    expect(vm.forSigningOrders[0].id).toBe(mockPendingOrder.id);
-    expect(vm.forSigningOrders[0].status).toBe(OrderReviewStatus.Pending);
+    expect(vm.pendingOrders).toHaveLength(1);
+    expect(vm.pendingOrders[0].id).toBe(mockPendingOrder.id);
+    expect(vm.pendingOrders[0].status).toBe(OrderReviewStatus.Pending);
   });
 
   it('filters completed orders correctly', () => {
@@ -217,7 +289,7 @@ describe('Orders.vue', () => {
     const wrapper = createWrapper();
 
     const vm = wrapper.vm as any;
-    expect(vm.forSigningOrders).toHaveLength(0);
+    expect(vm.pendingOrders).toHaveLength(0);
     expect(vm.completedOrders).toHaveLength(0);
   });
 
@@ -227,7 +299,7 @@ describe('Orders.vue', () => {
     const wrapper = createWrapper();
 
     const vm = wrapper.vm as any;
-    expect(vm.forSigningOrders).toHaveLength(0);
+    expect(vm.pendingOrders).toHaveLength(0);
     expect(vm.completedOrders).toHaveLength(0);
   });
 

--- a/web/tests/components/orders/OrdersDataTable.test.ts
+++ b/web/tests/components/orders/OrdersDataTable.test.ts
@@ -112,7 +112,6 @@ describe('OrdersDataTable.vue', () => {
     expect(headerTitles).toEqual([
       'PACKAGE #',
       'PRIORITY',
-      'TYPE',
       'DATE RECEIVED',
       'DIVISION',
       'FILE #',
@@ -335,45 +334,6 @@ describe('OrdersDataTable.vue', () => {
     });
 
     expect(wrapper.text()).toContain('Test Priority Description');
-  });
-
-  it('renders courtListType as plain text (already mapped to display label)', () => {
-    const wrapper = mount(OrdersDataTable, {
-      props: {
-        data: [mockData[0]],
-        viewOrderDetails: mockViewOrderDetails,
-        viewCaseDetails: mockViewCaseDetails,
-      },
-      global: {
-        stubs: {
-          VDataTableVirtual: VDataTableVirtualStub,
-        },
-      },
-    });
-
-    expect(wrapper.text()).toContain('Order');
-  });
-
-  it('renders an empty priority cell when priorityTypeDesc is missing', () => {
-    const orderWithoutDescription: Order = {
-      ...mockData[1],
-      priorityTypeDesc: undefined,
-    };
-    const wrapper = mount(OrdersDataTable, {
-      props: {
-        data: [orderWithoutDescription],
-        viewOrderDetails: mockViewOrderDetails,
-        viewCaseDetails: mockViewCaseDetails,
-      },
-      global: {
-        stubs: {
-          VDataTableVirtual: VDataTableVirtualStub,
-        },
-      },
-    });
-
-    expect(wrapper.text()).not.toContain('IS');
-    expect(wrapper.text()).toContain('Application');
   });
 
   describe('isAgedOrder', () => {

--- a/web/tests/components/orders/OrdersTab.test.ts
+++ b/web/tests/components/orders/OrdersTab.test.ts
@@ -1,0 +1,258 @@
+import { mount } from '@vue/test-utils';
+import OrdersTab from 'CMP/orders/OrdersTab.vue';
+import { describe, expect, it } from 'vitest';
+import { createRouter, createWebHistory } from 'vue-router';
+
+const createTestRouter = () =>
+  createRouter({
+    history: createWebHistory(),
+    routes: [
+      { path: '/', component: { template: '<div>Home</div>' } },
+      { path: '/orders', component: { template: '<div>Orders</div>' } },
+      {
+        path: '/desk-orders',
+        component: { template: '<div>Desk Orders</div>' },
+      },
+    ],
+  });
+
+const defaultProps = {
+  value: 'orders',
+  title: 'For Signing',
+  label: 'orders',
+  priorityCount: 0,
+  regularCount: 0,
+  pulseActive: false,
+};
+
+const mountTab = (props: Partial<typeof defaultProps> = {}) =>
+  mount(OrdersTab, {
+    props: { ...defaultProps, ...props },
+    global: {
+      plugins: [createTestRouter()],
+    },
+  });
+
+describe('OrdersTab.vue', () => {
+  describe('rendering', () => {
+    it('renders the component', () => {
+      const wrapper = mountTab();
+      expect(wrapper.exists()).toBe(true);
+    });
+
+    it('renders the title text', () => {
+      const wrapper = mountTab({ title: 'For Signing' });
+      expect(wrapper.text()).toContain('For Signing');
+    });
+
+    it('renders the Applications title when provided', () => {
+      const wrapper = mountTab({
+        value: 'desk-orders',
+        title: 'Applications',
+        label: 'desk orders',
+      });
+      expect(wrapper.text()).toContain('Applications');
+    });
+  });
+
+  describe('badges - empty state', () => {
+    it('does not render any badge when both counts are zero', () => {
+      const wrapper = mountTab({ priorityCount: 0, regularCount: 0 });
+      expect(wrapper.find('[data-testid="priority-badge"]').exists()).toBe(
+        false
+      );
+      expect(wrapper.find('[data-testid="regular-badge"]').exists()).toBe(
+        false
+      );
+      expect(wrapper.find('[data-testid="order-combo-badge"]').exists()).toBe(
+        false
+      );
+    });
+
+    it('renders only the title when both counts are zero', () => {
+      const wrapper = mountTab({
+        title: 'For Signing',
+        priorityCount: 0,
+        regularCount: 0,
+      });
+      expect(wrapper.text().trim()).toBe('For Signing');
+    });
+  });
+
+  describe('badges - priority only', () => {
+    it('renders the priority badge when priorityCount > 0 and regularCount === 0', () => {
+      const wrapper = mountTab({ priorityCount: 3, regularCount: 0 });
+      const badge = wrapper.find('[data-testid="priority-badge"]');
+      expect(badge.exists()).toBe(true);
+    });
+
+    it('sets the badge content to the priority count', () => {
+      const wrapper = mountTab({ priorityCount: 5, regularCount: 0 });
+      const badge = wrapper.find('[data-testid="priority-badge"]');
+      expect(badge.attributes('content')).toBe('5');
+    });
+
+    it('sets a descriptive title attribute on the priority badge', () => {
+      const wrapper = mountTab({
+        priorityCount: 2,
+        regularCount: 0,
+        label: 'orders',
+      });
+      const badge = wrapper.find('[data-testid="priority-badge"]');
+      expect(badge.attributes('title')).toBe('2 priority orders pending');
+    });
+
+    it('uses the provided label in the priority badge title', () => {
+      const wrapper = mountTab({
+        priorityCount: 1,
+        regularCount: 0,
+        label: 'desk orders',
+      });
+      const badge = wrapper.find('[data-testid="priority-badge"]');
+      expect(badge.attributes('title')).toBe('1 priority desk orders pending');
+    });
+
+    it('does not render regular or combo badges when only priority is set', () => {
+      const wrapper = mountTab({ priorityCount: 3, regularCount: 0 });
+      expect(wrapper.find('[data-testid="regular-badge"]').exists()).toBe(
+        false
+      );
+      expect(wrapper.find('[data-testid="order-combo-badge"]').exists()).toBe(
+        false
+      );
+    });
+  });
+
+  describe('badges - regular only', () => {
+    it('renders the regular badge when regularCount > 0 and priorityCount === 0', () => {
+      const wrapper = mountTab({ priorityCount: 0, regularCount: 4 });
+      const badge = wrapper.find('[data-testid="regular-badge"]');
+      expect(badge.exists()).toBe(true);
+    });
+
+    it('sets the badge content to the regular count', () => {
+      const wrapper = mountTab({ priorityCount: 0, regularCount: 7 });
+      const badge = wrapper.find('[data-testid="regular-badge"]');
+      expect(badge.attributes('content')).toBe('7');
+    });
+
+    it('sets a descriptive title attribute on the regular badge', () => {
+      const wrapper = mountTab({
+        priorityCount: 0,
+        regularCount: 4,
+        label: 'orders',
+      });
+      const badge = wrapper.find('[data-testid="regular-badge"]');
+      expect(badge.attributes('title')).toBe('4 regular orders pending');
+    });
+
+    it('uses the provided label in the regular badge title', () => {
+      const wrapper = mountTab({
+        priorityCount: 0,
+        regularCount: 2,
+        label: 'desk orders',
+      });
+      const badge = wrapper.find('[data-testid="regular-badge"]');
+      expect(badge.attributes('title')).toBe('2 regular desk orders pending');
+    });
+
+    it('does not render priority or combo badges when only regular is set', () => {
+      const wrapper = mountTab({ priorityCount: 0, regularCount: 4 });
+      expect(wrapper.find('[data-testid="priority-badge"]').exists()).toBe(
+        false
+      );
+      expect(wrapper.find('[data-testid="order-combo-badge"]').exists()).toBe(
+        false
+      );
+    });
+  });
+
+  describe('badges - combo (priority + regular)', () => {
+    it('renders the combo badge when both counts > 0', () => {
+      const wrapper = mountTab({ priorityCount: 2, regularCount: 3 });
+      const badge = wrapper.find('[data-testid="order-combo-badge"]');
+      expect(badge.exists()).toBe(true);
+    });
+
+    it('does not render single priority or regular badges when combo is shown', () => {
+      const wrapper = mountTab({ priorityCount: 2, regularCount: 3 });
+      expect(wrapper.find('[data-testid="priority-badge"]').exists()).toBe(
+        false
+      );
+      expect(wrapper.find('[data-testid="regular-badge"]').exists()).toBe(
+        false
+      );
+    });
+
+    it('still renders the title text alongside the combo badge', () => {
+      const wrapper = mountTab({
+        title: 'For Signing',
+        priorityCount: 2,
+        regularCount: 3,
+      });
+      expect(wrapper.text()).toContain('For Signing');
+    });
+  });
+
+  describe('pulse animation', () => {
+    it('applies the badge-pulse class when pulseActive is true (priority only)', () => {
+      const wrapper = mountTab({
+        priorityCount: 1,
+        regularCount: 0,
+        pulseActive: true,
+      });
+      const badge = wrapper.find('[data-testid="priority-badge"]');
+      expect(badge.classes()).toContain('badge-pulse');
+    });
+
+    it('does not apply badge-pulse class when pulseActive is false (priority only)', () => {
+      const wrapper = mountTab({
+        priorityCount: 1,
+        regularCount: 0,
+        pulseActive: false,
+      });
+      const badge = wrapper.find('[data-testid="priority-badge"]');
+      expect(badge.classes()).not.toContain('badge-pulse');
+    });
+
+    it('applies the badge-pulse class when pulseActive is true (regular only)', () => {
+      const wrapper = mountTab({
+        priorityCount: 0,
+        regularCount: 1,
+        pulseActive: true,
+      });
+      const badge = wrapper.find('[data-testid="regular-badge"]');
+      expect(badge.classes()).toContain('badge-pulse');
+    });
+
+    it('does not apply badge-pulse class when pulseActive is false (regular only)', () => {
+      const wrapper = mountTab({
+        priorityCount: 0,
+        regularCount: 1,
+        pulseActive: false,
+      });
+      const badge = wrapper.find('[data-testid="regular-badge"]');
+      expect(badge.classes()).not.toContain('badge-pulse');
+    });
+
+    it('applies the badge-pulse class when pulseActive is true (combo)', () => {
+      const wrapper = mountTab({
+        priorityCount: 1,
+        regularCount: 1,
+        pulseActive: true,
+      });
+      const badge = wrapper.find('[data-testid="order-combo-badge"]');
+      expect(badge.classes()).toContain('badge-pulse');
+    });
+
+    it('does not apply badge-pulse class when pulseActive is false (combo)', () => {
+      const wrapper = mountTab({
+        priorityCount: 1,
+        regularCount: 1,
+        pulseActive: false,
+      });
+      const badge = wrapper.find('[data-testid="order-combo-badge"]');
+      expect(badge.classes()).not.toContain('badge-pulse');
+    });
+  });
+});

--- a/web/tests/components/shared/AppBar.test.ts
+++ b/web/tests/components/shared/AppBar.test.ts
@@ -3,6 +3,7 @@ import { ApplicationConfigurationKey } from '@/stores/CommonStore';
 import { PersonSearchItem } from '@/types';
 import {
   ApplicationInfo,
+  OrderCourtLisTypeEnum,
   OrderPriorityEnum,
   OrderReviewStatus,
   RolesEnum,
@@ -67,7 +68,7 @@ const generateUserInfo = (overrides: Partial<UserInfo> = {}): UserInfo => ({
 const generateOrder = (
   status: OrderReviewStatus,
   priorityType: string = 'NONPRIORITY',
-  courtListTypeDescription: string = 'Daily List'
+  courtListType: string = ''
 ) => ({
   id: faker.string.uuid(),
   status,
@@ -78,8 +79,7 @@ const generateOrder = (
   receivedDate: faker.date.past().toISOString().split('T')[0],
   processedDate: faker.date.past().toISOString().split('T')[0],
   courtClass: faker.helpers.arrayElement(['CC', 'CV']),
-  courtListType: faker.helpers.arrayElement(['Daily', 'Weekly']),
-  courtListTypeDescription,
+  courtListType,
   courtFileNumber: faker.string.alphanumeric({ length: 10 }).toUpperCase(),
   styleOfCause: `${faker.person.lastName()} v ${faker.person.lastName()}`,
   physicalFileId: faker.number.int().toString(),
@@ -87,8 +87,9 @@ const generateOrder = (
 
 const generateDeskOrder = (
   status: OrderReviewStatus,
-  priorityType: string = 'NONPRIORITY'
-) => generateOrder(status, priorityType, 'Desk Order');
+  priorityType: string = 'NONPRIORITY',
+  courtListType: string = OrderCourtLisTypeEnum.PSM
+) => generateOrder(status, priorityType, courtListType);
 
 const generateAppInfo = (overrides: Partial<ApplicationInfo> = {}) => ({
   version: '1.0.0',
@@ -447,6 +448,8 @@ describe('AppBar.vue', () => {
 
       const wrapper = createWrapper();
       await flushPromises();
+
+      console.log(wrapper.html());
 
       expect((wrapper.vm as any).priorityPendingOrdersCount).toBe(1);
       expect((wrapper.vm as any).regularPendingOrdersCount).toBe(1);

--- a/web/tests/components/shared/AppBar.test.ts
+++ b/web/tests/components/shared/AppBar.test.ts
@@ -66,7 +66,8 @@ const generateUserInfo = (overrides: Partial<UserInfo> = {}): UserInfo => ({
 
 const generateOrder = (
   status: OrderReviewStatus,
-  priorityType: string = 'NONPRIORITY'
+  priorityType: string = 'NONPRIORITY',
+  courtListTypeDescription: string = 'Daily List'
 ) => ({
   id: faker.string.uuid(),
   status,
@@ -78,10 +79,16 @@ const generateOrder = (
   processedDate: faker.date.past().toISOString().split('T')[0],
   courtClass: faker.helpers.arrayElement(['CC', 'CV']),
   courtListType: faker.helpers.arrayElement(['Daily', 'Weekly']),
+  courtListTypeDescription,
   courtFileNumber: faker.string.alphanumeric({ length: 10 }).toUpperCase(),
   styleOfCause: `${faker.person.lastName()} v ${faker.person.lastName()}`,
   physicalFileId: faker.number.int().toString(),
 });
+
+const generateDeskOrder = (
+  status: OrderReviewStatus,
+  priorityType: string = 'NONPRIORITY'
+) => generateOrder(status, priorityType, 'Desk Order');
 
 const generateAppInfo = (overrides: Partial<ApplicationInfo> = {}) => ({
   version: '1.0.0',
@@ -294,6 +301,7 @@ describe('AppBar.vue', () => {
 
       expect((wrapper.vm as any).showOrders).toBe(false);
       expect(wrapper.text()).not.toContain('For Signing');
+      expect(wrapper.text()).not.toContain('Applications');
     });
 
     it('should show Orders tab for admin users', async () => {
@@ -304,6 +312,8 @@ describe('AppBar.vue', () => {
       await wrapper.vm.$nextTick();
 
       expect((wrapper.vm as any).showOrders).toBe(true);
+      expect(wrapper.text()).toContain('For Signing');
+      expect(wrapper.text()).toContain('Applications');
     });
 
     it('should display priority pending orders badge when there are priority pending orders', async () => {
@@ -402,6 +412,142 @@ describe('AppBar.vue', () => {
 
       const comboBadge = wrapper.find('[data-testid="order-combo-badge"]');
       expect(comboBadge.exists()).toBe(true);
+    });
+  });
+
+  describe('Applications tab (desk orders)', () => {
+    it('should split desk orders into desk-order counts and not into For Signing counts', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
+
+      const mockOrders = [
+        // For Signing: 1 priority, 1 regular
+        generateOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.ProtectionOrders
+        ),
+        generateOrder(OrderReviewStatus.Pending),
+        // Applications (desk): 2 priority, 1 regular
+        generateDeskOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.ProtectionOrders
+        ),
+        generateDeskOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.CourtDirected
+        ),
+        generateDeskOrder(OrderReviewStatus.Pending),
+        // Should be ignored (not pending)
+        generateDeskOrder(OrderReviewStatus.Approved),
+      ];
+
+      mockOrderService.getOrders.mockResolvedValue(mockOrders);
+      const orderStore = useOrdersStore();
+      orderStore.orders = mockOrders;
+
+      const wrapper = createWrapper();
+      await flushPromises();
+
+      expect((wrapper.vm as any).priorityPendingOrdersCount).toBe(1);
+      expect((wrapper.vm as any).regularPendingOrdersCount).toBe(1);
+      expect((wrapper.vm as any).priorityPendingDeskOrdersCount).toBe(2);
+      expect((wrapper.vm as any).regularPendingDeskOrdersCount).toBe(1);
+    });
+
+    it('should display priority badge on Applications tab when there are priority pending desk orders', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
+
+      const mockOrders = [
+        generateDeskOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.ProtectionOrders
+        ),
+        generateDeskOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.CourtDirected
+        ),
+        generateDeskOrder(OrderReviewStatus.Approved),
+      ];
+
+      mockOrderService.getOrders.mockResolvedValue(mockOrders);
+      const orderStore = useOrdersStore();
+      orderStore.orders = mockOrders;
+
+      const wrapper = createWrapper();
+      await flushPromises();
+
+      const badge = wrapper.find('[data-testid="priority-badge"]');
+
+      expect(badge.exists()).toBe(true);
+      expect(badge.attributes('content')).toBe('2');
+      expect((wrapper.vm as any).priorityPendingDeskOrdersCount).toBe(2);
+      expect((wrapper.vm as any).priorityPendingOrdersCount).toBe(0);
+    });
+
+    it('should display regular badge on Applications tab when there are non-priority pending desk orders', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
+
+      const mockOrders = [
+        generateDeskOrder(OrderReviewStatus.Pending),
+        generateDeskOrder(OrderReviewStatus.Pending),
+        generateDeskOrder(OrderReviewStatus.Approved),
+      ];
+
+      mockOrderService.getOrders.mockResolvedValue(mockOrders);
+      const orderStore = useOrdersStore();
+      orderStore.orders = mockOrders;
+
+      const wrapper = createWrapper();
+      await flushPromises();
+
+      const badge = wrapper.find('[data-testid="regular-badge"]');
+
+      expect(badge.exists()).toBe(true);
+      expect(badge.attributes('content')).toBe('2');
+      expect((wrapper.vm as any).regularPendingDeskOrdersCount).toBe(2);
+      expect((wrapper.vm as any).regularPendingOrdersCount).toBe(0);
+    });
+
+    it('should show order-combo-badge when there are both priority and regular pending desk orders', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
+
+      const mockOrders = [
+        generateDeskOrder(
+          OrderReviewStatus.Pending,
+          OrderPriorityEnum.ProtectionOrders
+        ),
+        generateDeskOrder(OrderReviewStatus.Pending),
+      ];
+
+      mockOrderService.getOrders.mockResolvedValue(mockOrders);
+      const orderStore = useOrdersStore();
+      orderStore.orders = mockOrders;
+
+      const wrapper = createWrapper();
+      await flushPromises();
+
+      const comboBadge = wrapper.find('[data-testid="order-combo-badge"]');
+      expect(comboBadge.exists()).toBe(true);
+    });
+
+    it('should not display any desk-order badge when there are no pending desk orders', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
+
+      const mockOrders = [generateDeskOrder(OrderReviewStatus.Approved)];
+
+      mockOrderService.getOrders.mockResolvedValue(mockOrders);
+      const orderStore = useOrdersStore();
+      orderStore.orders = mockOrders;
+
+      const wrapper = createWrapper();
+      await flushPromises();
+
+      expect((wrapper.vm as any).priorityPendingDeskOrdersCount).toBe(0);
+      expect((wrapper.vm as any).regularPendingDeskOrdersCount).toBe(0);
     });
   });
 

--- a/web/tests/composables/useOrderBadgePulse.test.ts
+++ b/web/tests/composables/useOrderBadgePulse.test.ts
@@ -1,0 +1,225 @@
+import { useOrderBadgePulse } from '@/composables/useOrderBadgePulse';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, defineComponent, h, nextTick, ref } from 'vue';
+
+const PULSE_DURATION_MS = 1200;
+
+/**
+ * Mounts the composable inside a real component so that Vue lifecycle
+ * hooks and watchers are properly registered.
+ */
+function withSetup<T>(composable: () => T) {
+  let result: T;
+  const TestComponent = defineComponent({
+    setup() {
+      result = composable();
+      return () => h('div');
+    },
+  });
+  const wrapper = mount(TestComponent);
+  return { result: result!, wrapper };
+}
+
+function makeCountPair(priorityInit = 0, regularInit = 0) {
+  const priority = ref(priorityInit);
+  const regular = ref(regularInit);
+  return {
+    priority,
+    regular,
+    pair: {
+      priority: computed(() => priority.value),
+      regular: computed(() => regular.value),
+    },
+  };
+}
+
+describe('useOrderBadgePulse', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('initialises with active = false', () => {
+    const { pair } = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    expect(result.active.value).toBe(false);
+  });
+
+  it('does not pulse when counts have not changed', async () => {
+    const { pair } = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    await nextTick();
+    vi.advanceTimersByTime(PULSE_DURATION_MS);
+
+    expect(result.active.value).toBe(false);
+  });
+
+  it('activates pulse when priority count changes to a positive number', async () => {
+    const { priority, pair } = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    priority.value = 1;
+    // Wait for the watcher to fire and trigger() to advance past its internal nextTick.
+    await nextTick();
+    await nextTick();
+
+    expect(result.active.value).toBe(true);
+  });
+
+  it('activates pulse when regular count changes to a positive number', async () => {
+    const { regular, pair } = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    regular.value = 3;
+    await nextTick();
+    await nextTick();
+
+    expect(result.active.value).toBe(true);
+  });
+
+  it('deactivates pulse after PULSE_DURATION_MS', async () => {
+    const { priority, pair } = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    priority.value = 2;
+    await nextTick();
+    await nextTick();
+    expect(result.active.value).toBe(true);
+
+    vi.advanceTimersByTime(PULSE_DURATION_MS);
+    expect(result.active.value).toBe(false);
+  });
+
+  it('does not deactivate before PULSE_DURATION_MS elapses', async () => {
+    const { priority, pair } = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    priority.value = 1;
+    await nextTick();
+    await nextTick();
+    expect(result.active.value).toBe(true);
+
+    vi.advanceTimersByTime(PULSE_DURATION_MS - 1);
+    expect(result.active.value).toBe(true);
+  });
+
+  it('does not pulse when counts change but all counts remain zero', async () => {
+    const { priority, regular, pair } = makeCountPair(0, 0);
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    // Mutate refs but resulting computed values stay at 0.
+    priority.value = 0;
+    regular.value = 0;
+    await nextTick();
+    await nextTick();
+
+    expect(result.active.value).toBe(false);
+  });
+
+  it('does not re-activate after counts drop back to zero', async () => {
+    const { priority, pair } = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    priority.value = 1;
+    await nextTick();
+    await nextTick();
+    expect(result.active.value).toBe(true);
+
+    vi.advanceTimersByTime(PULSE_DURATION_MS);
+    expect(result.active.value).toBe(false);
+
+    priority.value = 0;
+    await nextTick();
+    await nextTick();
+
+    expect(result.active.value).toBe(false);
+  });
+
+  it('pulses again when counts change again after the previous pulse finishes', async () => {
+    const { priority, pair } = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    priority.value = 1;
+    await nextTick();
+    await nextTick();
+    expect(result.active.value).toBe(true);
+
+    vi.advanceTimersByTime(PULSE_DURATION_MS);
+    expect(result.active.value).toBe(false);
+
+    priority.value = 2;
+    await nextTick();
+    await nextTick();
+
+    expect(result.active.value).toBe(true);
+  });
+
+  it('restarts the pulse when counts change before the previous pulse finishes', async () => {
+    const { priority, pair } = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([pair]));
+
+    priority.value = 1;
+    await nextTick();
+    await nextTick();
+    expect(result.active.value).toBe(true);
+
+    // Half-way through the pulse, change the count again.
+    vi.advanceTimersByTime(PULSE_DURATION_MS / 2);
+    priority.value = 2;
+    await nextTick();
+    await nextTick();
+    expect(result.active.value).toBe(true);
+
+    // Original timeout fires - but a new one should still keep us active.
+    vi.advanceTimersByTime(PULSE_DURATION_MS / 2);
+    expect(result.active.value).toBe(false);
+  });
+
+  it('supports multiple count pairs and pulses when any pair changes', async () => {
+    const a = makeCountPair();
+    const b = makeCountPair();
+    const { result } = withSetup(() => useOrderBadgePulse([a.pair, b.pair]));
+
+    b.regular.value = 5;
+    await nextTick();
+    await nextTick();
+
+    expect(result.active.value).toBe(true);
+  });
+
+  it('pulses when an extra trigger fires and at least one count is non-zero', async () => {
+    const { priority, pair } = makeCountPair(1, 0);
+    const trigger = ref(0);
+    const { result } = withSetup(() => useOrderBadgePulse([pair], [trigger]));
+
+    // Sanity: priority is already 1 but no change has occurred yet.
+    expect(result.active.value).toBe(false);
+
+    trigger.value = 1;
+    await nextTick();
+    await nextTick();
+
+    expect(result.active.value).toBe(true);
+
+    // Suppress unused warning - priority is the controlling ref via the pair.
+    void priority;
+  });
+
+  it('does not pulse when an extra trigger fires while all counts are zero', async () => {
+    const { pair } = makeCountPair(0, 0);
+    const trigger = ref(0);
+    const { result } = withSetup(() => useOrderBadgePulse([pair], [trigger]));
+
+    trigger.value = 1;
+    await nextTick();
+    await nextTick();
+
+    expect(result.active.value).toBe(false);
+  });
+});

--- a/web/tests/composables/useOrderCounts.test.ts
+++ b/web/tests/composables/useOrderCounts.test.ts
@@ -1,0 +1,234 @@
+import {
+  DESK_ORDER_DESCRIPTION,
+  isDeskOrder,
+  isPendingOrder,
+  isPriorityOrder,
+  useOrderCounts,
+} from '@/composables/useOrderCounts';
+import type { Order } from '@/types';
+import { OrderPriorityEnum, OrderReviewStatus } from '@/types/common';
+import { describe, expect, it } from 'vitest';
+import { ref } from 'vue';
+
+const makeOrder = (overrides: Partial<Order> = {}): Order =>
+  ({
+    status: OrderReviewStatus.Pending,
+    priorityType: 'NONPRIORITY',
+    courtListTypeDescription: 'Daily List',
+    ...overrides,
+  }) as Order;
+
+describe('useOrderCounts', () => {
+  describe('helpers', () => {
+    describe('isPendingOrder', () => {
+      it('returns true when status is Pending', () => {
+        expect(
+          isPendingOrder(makeOrder({ status: OrderReviewStatus.Pending }))
+        ).toBe(true);
+      });
+
+      it('returns false for non-pending statuses', () => {
+        expect(
+          isPendingOrder(makeOrder({ status: OrderReviewStatus.Approved }))
+        ).toBe(false);
+        expect(
+          isPendingOrder(
+            makeOrder({ status: OrderReviewStatus.AwaitingDocumentation })
+          )
+        ).toBe(false);
+      });
+    });
+
+    describe('isPriorityOrder', () => {
+      it.each([
+        OrderPriorityEnum.ProtectionOrders,
+        OrderPriorityEnum.CourtDirected,
+        OrderPriorityEnum.Other,
+      ])('returns true for priority type %s', (priorityType) => {
+        expect(isPriorityOrder(makeOrder({ priorityType }))).toBe(true);
+      });
+
+      it('returns false for non-priority types', () => {
+        expect(
+          isPriorityOrder(makeOrder({ priorityType: 'NONPRIORITY' }))
+        ).toBe(false);
+        expect(isPriorityOrder(makeOrder({ priorityType: '' }))).toBe(false);
+        expect(isPriorityOrder(makeOrder({ priorityType: 'UNKNOWN' }))).toBe(
+          false
+        );
+      });
+    });
+
+    describe('isDeskOrder', () => {
+      it('returns true when courtListTypeDescription matches DESK_ORDER_DESCRIPTION', () => {
+        expect(
+          isDeskOrder(
+            makeOrder({ courtListTypeDescription: DESK_ORDER_DESCRIPTION })
+          )
+        ).toBe(true);
+      });
+
+      it('returns false for any other courtListTypeDescription', () => {
+        expect(
+          isDeskOrder(makeOrder({ courtListTypeDescription: 'Daily List' }))
+        ).toBe(false);
+        expect(isDeskOrder(makeOrder({ courtListTypeDescription: '' }))).toBe(
+          false
+        );
+      });
+    });
+  });
+
+  describe('useOrderCounts', () => {
+    it('returns zero counts for an empty list', () => {
+      const { priority, regular } = useOrderCounts(() => []);
+
+      expect(priority.value).toBe(0);
+      expect(regular.value).toBe(0);
+    });
+
+    it('ignores non-pending orders', () => {
+      const orders: Order[] = [
+        makeOrder({
+          status: OrderReviewStatus.Approved,
+          priorityType: OrderPriorityEnum.ProtectionOrders,
+        }),
+        makeOrder({
+          status: OrderReviewStatus.AwaitingDocumentation,
+          priorityType: 'NONPRIORITY',
+        }),
+      ];
+
+      const { priority, regular } = useOrderCounts(() => orders);
+
+      expect(priority.value).toBe(0);
+      expect(regular.value).toBe(0);
+    });
+
+    it('counts pending priority orders into priority', () => {
+      const orders: Order[] = [
+        makeOrder({ priorityType: OrderPriorityEnum.ProtectionOrders }),
+        makeOrder({ priorityType: OrderPriorityEnum.CourtDirected }),
+        makeOrder({ priorityType: OrderPriorityEnum.Other }),
+      ];
+
+      const { priority, regular } = useOrderCounts(() => orders);
+
+      expect(priority.value).toBe(3);
+      expect(regular.value).toBe(0);
+    });
+
+    it('counts pending non-priority orders into regular', () => {
+      const orders: Order[] = [
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+      ];
+
+      const { priority, regular } = useOrderCounts(() => orders);
+
+      expect(priority.value).toBe(0);
+      expect(regular.value).toBe(2);
+    });
+
+    it('splits a mixed list into priority and regular counts', () => {
+      const orders: Order[] = [
+        makeOrder({ priorityType: OrderPriorityEnum.ProtectionOrders }),
+        makeOrder({ priorityType: OrderPriorityEnum.CourtDirected }),
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+        // Non-pending should be excluded.
+        makeOrder({
+          status: OrderReviewStatus.Approved,
+          priorityType: OrderPriorityEnum.ProtectionOrders,
+        }),
+      ];
+
+      const { priority, regular } = useOrderCounts(() => orders);
+
+      expect(priority.value).toBe(2);
+      expect(regular.value).toBe(3);
+    });
+
+    it('applies the matches predicate in addition to pending status', () => {
+      const orders: Order[] = [
+        makeOrder({
+          priorityType: OrderPriorityEnum.ProtectionOrders,
+          courtListTypeDescription: DESK_ORDER_DESCRIPTION,
+        }),
+        makeOrder({
+          priorityType: 'NONPRIORITY',
+          courtListTypeDescription: DESK_ORDER_DESCRIPTION,
+        }),
+        makeOrder({
+          priorityType: OrderPriorityEnum.CourtDirected,
+          courtListTypeDescription: 'Daily List',
+        }),
+        makeOrder({
+          priorityType: 'NONPRIORITY',
+          courtListTypeDescription: 'Daily List',
+        }),
+      ];
+
+      const desk = useOrderCounts(() => orders, isDeskOrder);
+      const nonDesk = useOrderCounts(
+        () => orders,
+        (o) => !isDeskOrder(o)
+      );
+
+      expect(desk.priority.value).toBe(1);
+      expect(desk.regular.value).toBe(1);
+      expect(nonDesk.priority.value).toBe(1);
+      expect(nonDesk.regular.value).toBe(1);
+    });
+
+    it('treats a predicate that excludes everything as zero counts', () => {
+      const orders: Order[] = [
+        makeOrder({ priorityType: OrderPriorityEnum.ProtectionOrders }),
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+      ];
+
+      const { priority, regular } = useOrderCounts(
+        () => orders,
+        () => false
+      );
+
+      expect(priority.value).toBe(0);
+      expect(regular.value).toBe(0);
+    });
+
+    it('is reactive: counts update when the underlying orders ref changes', () => {
+      const orders = ref<Order[]>([]);
+      const { priority, regular } = useOrderCounts(() => orders.value);
+
+      expect(priority.value).toBe(0);
+      expect(regular.value).toBe(0);
+
+      orders.value = [
+        makeOrder({ priorityType: OrderPriorityEnum.ProtectionOrders }),
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+      ];
+
+      expect(priority.value).toBe(1);
+      expect(regular.value).toBe(2);
+
+      // Mark the priority order as approved -- it should drop out of both counts.
+      orders.value = [
+        makeOrder({
+          status: OrderReviewStatus.Approved,
+          priorityType: OrderPriorityEnum.ProtectionOrders,
+        }),
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+        makeOrder({ priorityType: 'NONPRIORITY' }),
+      ];
+
+      expect(priority.value).toBe(0);
+      expect(regular.value).toBe(2);
+    });
+
+    it('exposes DESK_ORDER_DESCRIPTION as the expected literal', () => {
+      expect(DESK_ORDER_DESCRIPTION).toBe('Desk Order');
+    });
+  });
+});

--- a/web/tests/composables/useOrderCounts.test.ts
+++ b/web/tests/composables/useOrderCounts.test.ts
@@ -1,12 +1,15 @@
 import {
-  DESK_ORDER_DESCRIPTION,
   isDeskOrder,
   isPendingOrder,
   isPriorityOrder,
   useOrderCounts,
 } from '@/composables/useOrderCounts';
 import type { Order } from '@/types';
-import { OrderPriorityEnum, OrderReviewStatus } from '@/types/common';
+import {
+  OrderCourtLisTypeEnum,
+  OrderPriorityEnum,
+  OrderReviewStatus,
+} from '@/types/common';
 import { describe, expect, it } from 'vitest';
 import { ref } from 'vue';
 
@@ -60,21 +63,22 @@ describe('useOrderCounts', () => {
     });
 
     describe('isDeskOrder', () => {
-      it('returns true when courtListTypeDescription matches DESK_ORDER_DESCRIPTION', () => {
+      it('returns true when courtListType is PFM or PSM', () => {
         expect(
-          isDeskOrder(
-            makeOrder({ courtListTypeDescription: DESK_ORDER_DESCRIPTION })
-          )
+          isDeskOrder(makeOrder({ courtListType: OrderCourtLisTypeEnum.PFM }))
+        ).toBe(true);
+        expect(
+          isDeskOrder(makeOrder({ courtListType: OrderCourtLisTypeEnum.PSM }))
         ).toBe(true);
       });
 
-      it('returns false for any other courtListTypeDescription', () => {
+      it('returns false for any other courtListType', () => {
         expect(
-          isDeskOrder(makeOrder({ courtListTypeDescription: 'Daily List' }))
+          isDeskOrder(makeOrder({ courtListType: OrderCourtLisTypeEnum.PCS }))
         ).toBe(false);
-        expect(isDeskOrder(makeOrder({ courtListTypeDescription: '' }))).toBe(
-          false
-        );
+        expect(
+          isDeskOrder(makeOrder({ courtListType: OrderCourtLisTypeEnum.PFA }))
+        ).toBe(false);
       });
     });
   });
@@ -154,19 +158,19 @@ describe('useOrderCounts', () => {
       const orders: Order[] = [
         makeOrder({
           priorityType: OrderPriorityEnum.ProtectionOrders,
-          courtListTypeDescription: DESK_ORDER_DESCRIPTION,
+          courtListType: OrderCourtLisTypeEnum.PSM,
         }),
         makeOrder({
           priorityType: 'NONPRIORITY',
-          courtListTypeDescription: DESK_ORDER_DESCRIPTION,
+          courtListType: OrderCourtLisTypeEnum.PSM,
         }),
         makeOrder({
           priorityType: OrderPriorityEnum.CourtDirected,
-          courtListTypeDescription: 'Daily List',
+          courtListType: OrderCourtLisTypeEnum.PCS,
         }),
         makeOrder({
           priorityType: 'NONPRIORITY',
-          courtListTypeDescription: 'Daily List',
+          courtListType: OrderCourtLisTypeEnum.PFA,
         }),
       ];
 
@@ -225,10 +229,6 @@ describe('useOrderCounts', () => {
 
       expect(priority.value).toBe(0);
       expect(regular.value).toBe(2);
-    });
-
-    it('exposes DESK_ORDER_DESCRIPTION as the expected literal', () => {
-      expect(DESK_ORDER_DESCRIPTION).toBe('Desk Order');
     });
   });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-848

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-848

## Description
This feature separates "desk orders" from orders so judges can easily distinguish them. It includes some refactoring from existing components to minimize duplicate code and promote component re-use.

This changes also fixes bug so judge is notified (via Snackbar) that an order has been submitted regardless of priority

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Local

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screen Shots:
<img width="722" height="104" alt="image" src="https://github.com/user-attachments/assets/fbd04659-8c99-4e3b-b452-e51ae792ac7f" />
