### PR TITLE
Initialize LicenseManager in DocumentMergerTest static constructor

### DIFF
--- a/tests/api/Documents/DocumentMergerTests.cs
+++ b/tests/api/Documents/DocumentMergerTests.cs
@@ -24,6 +24,11 @@ namespace tests.api.Documents;
 
 public class DocumentMergerTest : ServiceTestBase
 {
+    static DocumentMergerTest()
+    {
+        new LicenseManager().RegisterKEY(string.Empty);
+    }
+
     [Fact]
     public async Task MergeDocuments_RetrievesDocumentsInBatches()
     {


### PR DESCRIPTION
Encountering a build failure due to failing unit test. Initializing the `LicenseManager` appears to fix the issue and unit test `DocumentMergerTest.MergeDocuments_PreservesBookmarks_ForTransitoryDocuments` is now passing.

`
Failed tests.api.Documents.DocumentMergerTest.MergeDocuments_PreservesBookmarks_ForTransitoryDocuments [26 ms]
  Error Message:
   System.DllNotFoundException : Unable to load shared library 'GdPicture.NET.14.image.gdimgplug{PLATFORM}' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable: 
/home/runner/work/jasper/jasper/tests/bin/Debug/net10.0/runtimes/linux-x64/native/GdPicture.NET.14.image.gdimgplug{PLATFORM}.so: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/10.0.9/GdPicture.NET.14.image.gdimgplug{PLATFORM}.so: cannot open shared object file: No such file or directory
/home/runner/work/jasper/jasper/tests/bin/Debug/net10.0/GdPicture.NET.14.image.gdimgplug{PLATFORM}.so: cannot open shared object file: No such file or directory
/home/runner/work/jasper/jasper/tests/bin/Debug/net10.0/runtimes/linux-x64/native/libGdPicture.NET.14.image.gdimgplug{PLATFORM}.so: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/10.0.9/libGdPicture.NET.14.image.gdimgplug{PLATFORM}.so: cannot open shared object file: No such file or directory
/home/runner/work/jasper/jasper/tests/bin/Debug/net10.0/libGdPicture.NET.14.image.gdimgplug{PLATFORM}.so: cannot open shared object file: No such file or directory
/home/runner/work/jasper/jasper/tests/bin/Debug/net10.0/runtimes/linux-x64/native/GdPicture.NET.14.image.gdimgplug{PLATFORM}: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/10.0.9/GdPicture.NET.14.image.gdimgplug{PLATFORM}: cannot open shared object file: No such file or directory
/home/runner/work/jasper/jasper/tests/bin/Debug/net10.0/GdPicture.NET.14.image.gdimgplug{PLATFORM}: cannot open shared object file: No such file or directory
/home/runner/work/jasper/jasper/tests/bin/Debug/net10.0/runtimes/linux-x64/native/libGdPicture.NET.14.image.gdimgplug{PLATFORM}: cannot open shared object file: No such file or directory
/usr/share/dotnet/shared/Microsoft.NETCore.App/10.0.9/libGdPicture.NET.14.image.gdimgplug{PLATFORM}: cannot open shared object file: No such file or directory
/home/runner/work/jasper/jasper/tests/bin/Debug/net10.0/libGdPicture.NET.14.image.gdimgplug{PLATFORM}: cannot open shared object file: No such file or directory
`