### PR TITLE
Sanitize unicode/special characters to their ASCII equivalents to app…

### DIFF
--- a/api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/api/Infrastructure/ServiceCollectionExtensions.cs
@@ -97,6 +97,7 @@ namespace Scv.Api.Infrastructure
             services.AddScoped<IDocumentStrategy, OrderDocumentStrategy>();
 
             services.AddScoped<IDeskOrderDetailsExtractor, DeskOrderDetailsExtractor>();
+            services.AddScoped<ICsoTextSanitizer, CsoTextSanitizer>();
         }
 
         public static IServiceCollection AddMapster(this IServiceCollection services, Action<TypeAdapterConfig> options = null)

--- a/api/Services/CsoTextSanitizer.cs
+++ b/api/Services/CsoTextSanitizer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text;
+using System.Text.RegularExpressions;
+using AnyAscii;
+
+namespace Scv.Api.Services;
+
+public sealed partial class CsoTextSanitizer : ICsoTextSanitizer
+{
+    public string Sanitize(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        var sanitized = text
+            .Normalize(NormalizationForm.FormKC)
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Transliterate();
+
+        sanitized = HorizontalWhitespaceRegex().Replace(sanitized, " ");
+        sanitized = BlankLineWhitespaceRegex().Replace(sanitized, "\n");
+
+        return sanitized.Trim();
+    }
+
+    [GeneratedRegex("[ \\t]+")]
+    private static partial Regex HorizontalWhitespaceRegex();
+
+    [GeneratedRegex(" *\\n *")]
+    private static partial Regex BlankLineWhitespaceRegex();
+}

--- a/api/Services/CsoTextSanitizer.cs
+++ b/api/Services/CsoTextSanitizer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using AnyAscii;

--- a/api/Services/ICsoTextSanitizer.cs
+++ b/api/Services/ICsoTextSanitizer.cs
@@ -1,0 +1,6 @@
+namespace Scv.Api.Services;
+
+public interface ICsoTextSanitizer
+{
+    string Sanitize(string text);
+}

--- a/api/Services/OrderService.cs
+++ b/api/Services/OrderService.cs
@@ -46,6 +46,7 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IJudicialServicesClient _judicialClient;
     private readonly IDeskOrderDetailsExtractor _deskOrderDetailsExtractor;
+    private readonly ICsoTextSanitizer _csoTextSanitizer;
 
     public override string CacheName => "GetOrdersAsync";
 
@@ -60,7 +61,8 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
         IBackgroundJobClient backgroundJobClient,
         IHttpContextAccessor httpContextAccessor,
         IJudicialServicesClient judicialClient,
-        IDeskOrderDetailsExtractor deskOrderDetailsExtractor
+        IDeskOrderDetailsExtractor deskOrderDetailsExtractor,
+        ICsoTextSanitizer csoTextSanitizer
     ) : base(
             cache,
             mapper,
@@ -78,6 +80,7 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
         _httpContextAccessor = httpContextAccessor;
         _judicialClient = judicialClient;
         _deskOrderDetailsExtractor = deskOrderDetailsExtractor;
+        _csoTextSanitizer = csoTextSanitizer;
     }
 
     public async Task<OperationResult> ValidateOrderRequestAsync(OrderRequestDto dto)
@@ -469,13 +472,14 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
 
         var deskOrderDetails = _deskOrderDetailsExtractor.Extract(stream);
 
-        this.Logger.LogInformation("Desk order Directions and Order Terms extracted successfuly for Order {OrderId}.", orderDto.Id);
+        this.Logger.LogInformation("Desk order Directions and Order Terms extracted successfully for Order {OrderId}.", orderDto.Id);
 
-        actionDto.Comment = string.Join(". ", actionDto.Comment, deskOrderDetails.Directions);
+        var sanitizedDirections = _csoTextSanitizer.Sanitize(deskOrderDetails.Directions);
+        actionDto.Comment = _csoTextSanitizer.Sanitize(string.Join(". ", actionDto.Comment, sanitizedDirections));
         actionDto.OrderTerms = [.. deskOrderDetails.OrderTerms.Select(term => new OrderTerm
             {
                 SequenceNumber = term.SequenceNumber,
-                Text = term.Text,
+                Text = _csoTextSanitizer.Sanitize(term.Text),
                 DisplaySortNumber = term.DisplaySortNumber
             })];
 

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.Lambda" Version="4.0.100.2" />
+    <PackageReference Include="AnyAscii" Version="0.3.3" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="ColeSoft.Extensions.Logging.Splunk" Version="1.0.72" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />

--- a/tests/api/Services/CsoTextSanitizerTests.cs
+++ b/tests/api/Services/CsoTextSanitizerTests.cs
@@ -1,0 +1,46 @@
+using Scv.Api.Services;
+using Xunit;
+
+namespace tests.api.Services;
+
+public class CsoTextSanitizerTests
+{
+    private readonly CsoTextSanitizer _sanitizer = new();
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    public void Sanitize_ReturnsEmptyString_WhenInputIsNullEmptyOrWhitespace(string input, string expected)
+    {
+        Assert.Equal(expected, _sanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void Sanitize_LeavesRegularAsciiTextUnchanged()
+    {
+        const string text = "The order must be filed by 4:00 PM.";
+
+        var result = _sanitizer.Sanitize(text);
+
+        Assert.Equal(text, result);
+    }
+
+    [Theory]
+    [InlineData("Court’s order", "Court's order")]
+    [InlineData("The “quoted” term", "The \"quoted\" term")]
+    [InlineData("non\u00A0breaking\u00A0spaces", "non breaking spaces")]
+    [InlineData("due Monday – Friday", "due Monday - Friday")]
+    [InlineData("file now — no delay", "file now - no delay")]
+    [InlineData("balance − payment", "balance - payment")]
+    [InlineData("continue…", "continue...")]
+    [InlineData("• first term", "* first term")]
+    [InlineData("café résumé naïve façade", "cafe resume naive facade")]
+    public void Sanitize_TransliteratesWordAndUnicodeCharacters(string input, string expected)
+    {
+        var result = _sanitizer.Sanitize(input);
+
+        Assert.Equal(expected, result);
+        Assert.All(result, c => Assert.True(c <= 127, $"Character '{c}' is not ASCII."));
+    }
+}

--- a/tests/api/Services/CsoTextSanitizerTests.cs
+++ b/tests/api/Services/CsoTextSanitizerTests.cs
@@ -36,6 +36,7 @@ public class CsoTextSanitizerTests
     [InlineData("continue…", "continue...")]
     [InlineData("• first term", "* first term")]
     [InlineData("café résumé naïve façade", "cafe resume naive facade")]
+    [InlineData("ᑕᓂᓯ / tânisi — SENĆOŦEN — k̓ʷak̓ʷ — Dähdzįį — ᖃᓄᐃᑉᐱᑦ", "tanisi / tanisi - SENCOTEN - kwakw - Dahdzii - qanoippit")]
     public void Sanitize_TransliteratesWordAndUnicodeCharacters(string input, string expected)
     {
         var result = _sanitizer.Sanitize(input);

--- a/tests/api/Services/OrderServiceTests.cs
+++ b/tests/api/Services/OrderServiceTests.cs
@@ -8,6 +8,9 @@ using System.Threading.Tasks;
 using Bogus;
 using CSOCommon.Clients.JudicialServices;
 using CSOCommon.Models;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
 using JCCommon.Clients.FileServices;
 using LazyCache;
 using LazyCache.Providers;
@@ -41,6 +44,7 @@ public class OrderServiceTests : ServiceTestBase
     private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private readonly Mock<IJudicialServicesClient> _mockJudicialClient;
     private readonly Mock<IDeskOrderDetailsExtractor> _mockDeskOrderDetailsExtractor;
+    private readonly Mock<ICsoTextSanitizer> _mockCsoTextSanitizer;
     private readonly IMapper _mapper;
     private readonly IAppCache _cache;
     private readonly OrderService _orderService;
@@ -71,6 +75,10 @@ public class OrderServiceTests : ServiceTestBase
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockJudicialClient = new Mock<IJudicialServicesClient>();
         _mockDeskOrderDetailsExtractor = new Mock<IDeskOrderDetailsExtractor>();
+        _mockCsoTextSanitizer = new Mock<ICsoTextSanitizer>();
+        _mockCsoTextSanitizer
+            .Setup(s => s.Sanitize(It.IsAny<string>()))
+            .Returns((string text) => text);
 
         _requestAgencyIdentifierId = _faker.Random.Double().ToString();
         _requestPartId = _faker.Random.AlphaNumeric(10);
@@ -91,7 +99,8 @@ public class OrderServiceTests : ServiceTestBase
             _mockBackgroundJobClient.Object,
             _mockHttpContextAccessor.Object,
             _mockJudicialClient.Object,
-            _mockDeskOrderDetailsExtractor.Object);
+            _mockDeskOrderDetailsExtractor.Object,
+            _mockCsoTextSanitizer.Object);
     }
 
     private void SetupConfiguration()
@@ -1008,6 +1017,7 @@ public class OrderServiceTests : ServiceTestBase
 
         Assert.True(result.Succeeded);
         _mockJudicialClient.Verify(c => c.SaveJudicialActionAsync(It.IsAny<Guid>(), It.IsAny<double>(), It.IsAny<JudicialAction>()), Times.Once);
+        _mockCsoTextSanitizer.Verify(s => s.Sanitize(It.IsAny<string>()), Times.Never);
         _mockOrderRepo.Verify(r => r.UpdateAsync(It.Is<Order>(o => o.SubmitAttempts == 3)), Times.Once);
     }
 
@@ -1015,8 +1025,11 @@ public class OrderServiceTests : ServiceTestBase
     public async Task SubmitApprovedDeskOrder_ReturnsSuccess_WhenCsoSubmitSucceeds()
     {
         var fakeComment = _faker.Lorem.Sentence();
-        var fakeDirections = _faker.Lorem.Sentence();
-        var fakeOrderTerm = _faker.Lorem.Sentence();
+        var fakeDirections = "Registry “must” review cafés — today…";
+        var fakeOrderTerm = "Pay $50 – then file résumé • exhibit";
+        var sanitizedDirections = "Registry \"must\" review cafes - today...";
+        var sanitizedOrderTerm = "Pay $50 - then file resume * exhibit";
+        var sanitizedComment = $"{fakeComment}. {sanitizedDirections}";
 
         var order = CreateOrder();
         order.SubmitAttempts = 2;
@@ -1055,6 +1068,9 @@ public class OrderServiceTests : ServiceTestBase
                 Directions = fakeDirections,
                 OrderTerms = [new() { Text = fakeOrderTerm }],
             });
+        _mockCsoTextSanitizer.Setup(s => s.Sanitize(fakeDirections)).Returns(sanitizedDirections);
+        _mockCsoTextSanitizer.Setup(s => s.Sanitize(fakeOrderTerm)).Returns(sanitizedOrderTerm);
+        _mockCsoTextSanitizer.Setup(s => s.Sanitize($"{fakeComment}. {sanitizedDirections}")).Returns(sanitizedComment);
 
         var result = await _orderService.SubmitOrder(order.Id);
 
@@ -1064,13 +1080,95 @@ public class OrderServiceTests : ServiceTestBase
                 c.SaveJudicialActionAsync(It.IsAny<Guid>(),
                 It.IsAny<double>(),
                 It.Is<JudicialAction>(ja =>
-                    ja.Comment == $"{fakeComment}. {fakeDirections}"
+                    ja.Comment == sanitizedComment
                     && ja.OrderTerms.Count == 1
-                    && ja.OrderTerms.First().Text == fakeOrderTerm
+                    && ja.OrderTerms.First().Text == sanitizedOrderTerm
                     && ja.Document.Length == 0
                 )),
                 Times.Once);
+        _mockCsoTextSanitizer.Verify(s => s.Sanitize(fakeDirections), Times.Once);
+        _mockCsoTextSanitizer.Verify(s => s.Sanitize(fakeOrderTerm), Times.Once);
+        _mockCsoTextSanitizer.Verify(s => s.Sanitize($"{fakeComment}. {sanitizedDirections}"), Times.Once);
         _mockOrderRepo.Verify(r => r.UpdateAsync(It.Is<Order>(o => o.SubmitAttempts == 3)), Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitApprovedDeskOrder_SanitizesWordSpecificCharacters_WhenSendingToCso()
+    {
+        const string comment = "Desk order note";
+        const string extractedDirections = "Registry “must” review cafés — today…";
+        const string extractedOrderTerm = "Pay $50 – then file résumé • exhibit";
+
+        var order = CreateOrder();
+        order.SubmitAttempts = 2;
+        order.OrderRequest.Referral.CourtListTypeCd = CourtListTypeDescriptor.PROVINCIAL_COURT_DESK_ORDER_SMALL_CLAIMS_TYPE;
+        using var deskOrderDocument = BuildDocxStream(body =>
+        {
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.DIRECTIONS_LABEL));
+            body.AppendChild(ParagraphOf(extractedDirections));
+            body.AppendChild(ParagraphOf(DeskOrderDetailsExtractor.ORDER_TERMS_LABEL));
+            body.AppendChild(ParagraphOf(extractedOrderTerm));
+            body.AppendChild(SignatureSdt());
+        });
+
+        order.SupportingDocumentData = deskOrderDocument.ToArray();
+        order.Status = OrderStatus.Approved;
+        order.Comments = comment;
+        SetupHttpContextWithGuid();
+
+        var orderService = new OrderService(
+            _cache,
+            _mapper,
+            _mockLogger.Object,
+            _mockOrderRepo.Object,
+            _mockFileServicesClient.Object,
+            _mockConfiguration.Object,
+            _mockJudgeService.Object,
+            _mockBackgroundJobClient.Object,
+            _mockHttpContextAccessor.Object,
+            _mockJudicialClient.Object,
+            new DeskOrderDetailsExtractor(),
+            new CsoTextSanitizer());
+
+        _mockOrderRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<string>()))
+            .ReturnsAsync(order);
+
+        _mockOrderRepo
+            .Setup(r => r.UpdateAsync(It.IsAny<Order>()))
+            .Returns(Task.CompletedTask);
+
+        _mockJudicialClient
+            .Setup(c => c.SaveJudicialActionAsync(It.IsAny<Guid>(), It.IsAny<double>(), It.IsAny<JudicialAction>()))
+            .Returns(() => Task.CompletedTask);
+
+        _mockJudgeService
+            .Setup(d => d.GetJudges(null, null))
+            .ReturnsAsync(
+            [
+                new PersonSearchItem
+                {
+                    PersonId = order.JudgeId,
+                    ParticipantId = order.OrderRequest.Referral.SentToPartId.GetValueOrDefault()
+                }
+            ]);
+
+        var result = await orderService.SubmitOrder(order.Id);
+
+        Assert.True(result.Succeeded);
+        _mockJudicialClient
+            .Verify(c =>
+                c.SaveJudicialActionAsync(It.IsAny<Guid>(),
+                It.IsAny<double>(),
+                It.Is<JudicialAction>(ja =>
+                    ja.Comment == "Desk order note. Registry \"must\" review cafes - today..."
+                    && ja.OrderTerms.Count == 1
+                    && ja.OrderTerms.First().Text == "Pay $50 - then file resume * exhibit"
+                    && ja.OrderTerms.First().SequenceNumber == 1
+                    && ja.OrderTerms.First().DisplaySortNumber == 1
+                    && ja.Document.Length == 0
+                )),
+                Times.Once);
     }
 
     [Fact]
@@ -1131,6 +1229,9 @@ public class OrderServiceTests : ServiceTestBase
                     && ja.Document.Length == 0
                 )),
                 Times.Once);
+        _mockDeskOrderDetailsExtractor.Verify(d => d.Extract(It.IsAny<Stream>()), Times.Never);
+        _mockCsoTextSanitizer.Verify(s => s.Sanitize(fakeDirections), Times.Never);
+        _mockCsoTextSanitizer.Verify(s => s.Sanitize(fakeOrderTerm), Times.Never);
         _mockOrderRepo.Verify(r => r.UpdateAsync(It.Is<Order>(o => o.SubmitAttempts == 3)), Times.Once);
     }
 
@@ -1263,6 +1364,29 @@ public class OrderServiceTests : ServiceTestBase
             .Setup(x => x.HttpContext)
             .Returns(httpContext);
     }
+
+    private static MemoryStream BuildDocxStream(Action<Body> configureBody)
+    {
+        var stream = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+        {
+            var mainPart = doc.AddMainDocumentPart();
+            mainPart.Document = new Document();
+            var body = mainPart.Document.AppendChild(new Body());
+            configureBody(body);
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static Paragraph ParagraphOf(string text) =>
+        new(new Run(new Text(text) { Space = SpaceProcessingModeValues.Preserve }));
+
+    private static SdtBlock SignatureSdt(string tagValue = "Insert Signature") =>
+        new(
+            new SdtProperties(new DocumentFormat.OpenXml.Wordprocessing.Tag { Val = tagValue }),
+            new SdtContentBlock(new Paragraph(new Run(new Text("[signature]")))));
 
     #endregion
 }


### PR DESCRIPTION
…roximate "copy to notepad" conversion.


## Description

From discussion, the recommended way to create Oracle character set-safe text is copying that text into notepad before copying into the DB.

This implies a US7ASCII character set.

This line: var sanitized = text
    .Normalize(NormalizationForm.FormKC)
    .Replace("\r\n", "\n", StringComparison.Ordinal)
    .Replace('\r', '\n')
    .Transliterate();
    
should convert unicode characters into their ascii equivalents where possible.

Fixes # (issue)  

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Not tested yet, need to understand existing test bench.

**Test Configuration**:
If applicable

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   


## Documentation References  

Put any doc references here