### PR TITLE
JASPER-852: Signing and Digital Workflow: Additional notification when an order/application is 9 days old to the assigned judge

### DIFF
--- a/api/Jobs/OrderReminderJob.cs
+++ b/api/Jobs/OrderReminderJob.cs
@@ -57,21 +57,34 @@ public class OrderReminderJob(
         var reassignmentThresholdDays = int.TryParse(Configuration.GetNonEmptyValue("ORDER_REASSIGNMENT_THRESHOLD_DAYS"), out var reassignDays)
             ? reassignDays : 10;
         var maxReminderNotifications = int.TryParse(Configuration.GetNonEmptyValue("ORDER_MAX_REMINDER_NOTIFICATIONS"), out var maxReminders)
-            ? maxReminders : 1;
+            ? maxReminders : 2;
         var maxReassignmentNotifications = int.TryParse(Configuration.GetNonEmptyValue("ORDER_MAX_REASSIGNMENT_NOTIFICATIONS"), out var maxReassignments)
             ? maxReassignments : 1;
 
-        var reminderFromNow = DateTime.UtcNow.AddDays(-reminderThresholdDays);
-        var reassignmentFromNow = DateTime.UtcNow.AddDays(-reassignmentThresholdDays);
+        var today = DateTime.UtcNow.Date;
+        var firstReminderCutoff = today.AddDays(-reminderThresholdDays);
+        var secondReminderCutoff = today.AddDays(-(reassignmentThresholdDays - 1));
+        var reassignmentCutoff = today.AddDays(-reassignmentThresholdDays);
 
         var ordersNeedingReminder = unresolvedOrders
-            .Where(o => o.Ent_Dtm <= reminderFromNow &&
-                       o.Ent_Dtm > reassignmentFromNow &&
-                       o.ReminderNotificationsSent < maxReminderNotifications)
+            .Where(o =>
+                o.ReminderNotificationsSent < maxReminderNotifications &&
+                (
+                    // 1st reminder: no reminders sent
+                    (o.Ent_Dtm.Date <= firstReminderCutoff &&
+                     o.Ent_Dtm.Date > secondReminderCutoff &&
+                     o.ReminderNotificationsSent == 0)
+                    ||
+                    // 2nd reminder: a day before reassignment, only 1 reminder sent so far.
+                    (o.Ent_Dtm.Date <= secondReminderCutoff &&
+                     o.Ent_Dtm.Date > reassignmentCutoff &&
+                     o.ReminderNotificationsSent == 1)
+                ))
             .ToList();
+
         var ordersNeedingReassignment = unresolvedOrders
-            .Where(o => o.Ent_Dtm <= reassignmentFromNow &&
-                       o.ReassignmentNotificationsSent < maxReassignmentNotifications)
+            .Where(o => o.Ent_Dtm.Date <= reassignmentCutoff &&
+                        o.ReassignmentNotificationsSent < maxReassignmentNotifications)
             .ToList();
 
         Logger.LogInformation(

--- a/tests/api/Jobs/OrderReminderJobTests.cs
+++ b/tests/api/Jobs/OrderReminderJobTests.cs
@@ -338,6 +338,120 @@ public class OrderReminderJobTests : ServiceTestBase
         });
     }
 
+    [Fact]
+    public async Task Execute_SendsSecondReminder_WhenOrderIs9DaysOldAndOneReminderAlreadySent()
+    {
+        SetupConfiguration("5", "10", maxReminders: "2");
+
+        var judgeId = _faker.Random.Int(min: 1, max: 10);
+        var participantId = _faker.Random.Double();
+        var entryDate = DateTime.UtcNow.Date.AddDays(-9);
+        var order = CreateTestOrder(judgeId, participantId, entryDate);
+        order.ReminderNotificationsSent = 1;
+
+        var judge = CreateTestJudge(judgeId);
+        var user = CreateTestUser(judgeId, _faker.Person.Email);
+
+        _mockOrderRepo.Setup(r => r.FindAsync(It.IsAny<Expression<Func<Order, bool>>>()))
+            .ReturnsAsync([order]);
+        _mockJudgeService.Setup(j => j.GetJudge(judgeId)).ReturnsAsync(judge);
+        _mockUserService.Setup(u => u.GetByJudgeIdAsync(judgeId)).ReturnsAsync(user);
+        _mockEmailTemplateService.Setup(e => e.SendEmailTemplateAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object>()))
+            .Returns(Task.CompletedTask);
+        _mockOrderRepo.Setup(r => r.UpdateAsync(It.IsAny<Order>())).Returns(Task.CompletedTask);
+
+        await _job.Execute();
+
+        _mockEmailTemplateService.Verify(e => e.SendEmailTemplateAsync(
+            EmailTemplate.ORDER_REMINDER, user.Email, It.IsAny<object>()), Times.Once);
+        _mockOrderRepo.Verify(
+            r => r.UpdateAsync(It.Is<Order>(o => o.ReminderNotificationsSent == 2)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_DoesNotSendReminder_WhenOrderIs9DaysOldButNoReminderYetSent()
+    {
+        SetupConfiguration("5", "10", maxReminders: "2");
+
+        var judgeId = _faker.Random.Int(min: 1, max: 10);
+        var participantId = _faker.Random.Double();
+        var entryDate = DateTime.UtcNow.Date.AddDays(-9);
+        var order = CreateTestOrder(judgeId, participantId, entryDate);
+        order.ReminderNotificationsSent = 0;
+
+        _mockOrderRepo.Setup(r => r.FindAsync(It.IsAny<Expression<Func<Order, bool>>>()))
+            .ReturnsAsync([order]);
+
+        await _job.Execute();
+
+        _mockJudgeService.Verify(j => j.GetJudge(It.IsAny<int>()), Times.Never);
+        _mockEmailTemplateService.Verify(e => e.SendEmailTemplateAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_DoesNotSendReminder_WhenOrderIn1stWindowButReminderAlreadySent()
+    {
+        SetupConfiguration("5", "10", maxReminders: "2");
+
+        var judgeId = _faker.Random.Int(min: 1, max: 10);
+        var participantId = _faker.Random.Double();
+        var entryDate = DateTime.UtcNow.Date.AddDays(-6);
+        var order = CreateTestOrder(judgeId, participantId, entryDate);
+        order.ReminderNotificationsSent = 1;
+
+        _mockOrderRepo.Setup(r => r.FindAsync(It.IsAny<Expression<Func<Order, bool>>>()))
+            .ReturnsAsync([order]);
+
+        await _job.Execute();
+
+        _mockEmailTemplateService.Verify(e => e.SendEmailTemplateAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_DoesNotSendReminder_ForOrdersPastReassignmentThreshold()
+    {
+        SetupConfiguration("5", "10", maxReminders: "2");
+
+        var judgeId = _faker.Random.Int(min: 1, max: 10);
+        var participantId = _faker.Random.Double();
+        var entryDate = DateTime.UtcNow.Date.AddDays(-11);
+        var order = CreateTestOrder(judgeId, participantId, entryDate);
+        order.ReminderNotificationsSent = 0;
+
+        var judge = CreateTestJudge(judgeId);
+
+        _mockOrderRepo.Setup(r => r.FindAsync(It.IsAny<Expression<Func<Order, bool>>>()))
+            .ReturnsAsync([order]);
+        _mockJudgeService.Setup(j => j.GetJudge(judgeId)).ReturnsAsync(judge);
+        _mockJudgeService.Setup(j => j.GetJudges(It.IsAny<List<string>>(), It.IsAny<List<string>>()))
+            .ReturnsAsync([]);
+
+        await _job.Execute();
+
+        _mockEmailTemplateService.Verify(e => e.SendEmailTemplateAsync(
+            EmailTemplate.ORDER_REMINDER, It.IsAny<string>(), It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_DoesNotSendReminder_WhenOrderIsYoungerThanReminderThreshold()
+    {
+        SetupConfiguration("5", "10", maxReminders: "2");
+
+        var order = CreateTestOrder(_faker.Random.Int(min: 1, max: 10), _faker.Random.Double(), DateTime.UtcNow.Date.AddDays(-4));
+        _mockOrderRepo.Setup(r => r.FindAsync(It.IsAny<Expression<Func<Order, bool>>>()))
+            .ReturnsAsync([order]);
+
+        await _job.Execute();
+
+        _mockJudgeService.Verify(j => j.GetJudge(It.IsAny<int>()), Times.Never);
+        _mockEmailTemplateService.Verify(e => e.SendEmailTemplateAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object>()), Times.Never);
+    }
+
     #endregion
 
     #region SendReminderToJudge Tests


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-852

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-852

## Description
Update existing logic to allow sending of reminder notification twice (ideally 5th and 9th day) if the order has not been actioned by the judge.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Local - db has been manually updated to verify the 5th and 9th day reminder notification.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screen Grab
### 5th Day
<img width="929" height="310" alt="image" src="https://github.com/user-attachments/assets/cec42288-ad20-4709-8c03-95b920a164f8" />

### 9th Day
<img width="931" height="368" alt="image" src="https://github.com/user-attachments/assets/2132ac4b-ff6d-472f-8919-bb3f9fc4d716" />
