### PR TITLE
JASPER-854: Signing and Digital Workflow: Remove the button "Awaiting Further Documentation" for orders.

### DIFF
--- a/web/src/components/documents/ReviewModal.vue
+++ b/web/src/components/documents/ReviewModal.vue
@@ -129,6 +129,7 @@
             <v-btn
               color="warning"
               variant="outlined"
+              v-if="isCurrentDeskOrder"
               :prepend-icon="mdiAccountClock"
               :disabled="!canReject || submitting"
               :loading="
@@ -163,6 +164,7 @@
 </template>
 
 <script setup lang="ts">
+  import { isDeskOrder } from '@/composables/useOrderCounts.js';
   import { useOrdersStore } from '@/stores';
   import { OrderReview } from '@/types';
   import { OrderCourtLisTypeEnum, OrderReviewStatus } from '@/types/common';
@@ -212,6 +214,10 @@
 
   const isFamilyDeskOrder = computed(
     () => currentOrder.value?.courtListType === OrderCourtLisTypeEnum.PFM
+  );
+
+  const isCurrentDeskOrder = computed(
+    () => !!currentOrder.value && isDeskOrder(currentOrder.value)
   );
 
   watch(show, (newVal) => {

--- a/web/src/components/shared/AppBar.vue
+++ b/web/src/components/shared/AppBar.vue
@@ -93,8 +93,8 @@
   import { mdiAccountCircle } from '@mdi/js';
   import { computed, inject, onMounted, ref, watch } from 'vue';
   import { useRoute } from 'vue-router';
-  import JudgeSelector from './JudgeSelector.vue';
   import OrdersTab from '../orders/OrdersTab.vue';
+  import JudgeSelector from './JudgeSelector.vue';
 
   const emit = defineEmits<(e: 'open-profile') => void>();
 
@@ -192,7 +192,8 @@
     () =>
       (selectedTab.value === 'dashboard' ||
         selectedTab.value === 'court-list' ||
-        selectedTab.value === 'orders') &&
+        selectedTab.value === 'orders' ||
+        selectedTab.value === 'desk-orders') &&
       judges.value &&
       judges.value.length > 0
   );

--- a/web/tests/components/documents/ReviewModal.test.ts
+++ b/web/tests/components/documents/ReviewModal.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mount, flushPromises } from '@vue/test-utils';
-import { createPinia, setActivePinia } from 'pinia';
-import { nextTick } from 'vue';
 import ReviewModal from '@/components/documents/ReviewModal.vue';
 import type { OrderReview } from '@/types';
 import { OrderCourtLisTypeEnum, OrderReviewStatus } from '@/types/common';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
 
 const mockRoute: { query: Record<string, string | undefined> } = { query: {} };
 vi.mock('vue-router', () => ({
@@ -200,7 +200,11 @@ describe('ReviewModal.vue', () => {
     });
   });
 
-  describe('Action buttons', () => {
+  describe('Action buttons - Applications', () => {
+    beforeEach(() => {
+      setOrders(createFamilyDeskOrder());
+    });
+
     it('should render all three action buttons', () => {
       const wrapper = createWrapper();
       expect(wrapper.text()).toContain('Reject');
@@ -230,6 +234,40 @@ describe('ReviewModal.vue', () => {
       expect(
         wrapper.find('[color="warning"]').attributes('disabled')
       ).toBeDefined();
+    });
+  });
+
+  describe('Action buttons - Orders', () => {
+    beforeEach(() => {
+      setOrders(createNonFamilyDeskOrder());
+    });
+
+    it('should render two action buttons', () => {
+      const wrapper = createWrapper();
+      expect(wrapper.text()).toContain('Reject');
+      expect(wrapper.text()).not.toContain('Awaiting documentation');
+      expect(wrapper.text()).toContain('Approve');
+    });
+
+    it('should render Reject button with proper attributes', () => {
+      const wrapper = createWrapper();
+      const rejectButton = wrapper.find('[color="error"]');
+      expect(rejectButton.exists()).toBe(true);
+      expect(rejectButton.text()).toContain('Reject');
+    });
+
+    it('should not render Awaiting documentation button', () => {
+      const wrapper = createWrapper();
+      const pendingButton = wrapper.find('[color="warning"]');
+      expect(pendingButton.exists()).toBe(false);
+    });
+
+    it('should disable Reject when comments are empty', () => {
+      const wrapper = createWrapper();
+      expect(
+        wrapper.find('[color="error"]').attributes('disabled')
+      ).toBeDefined();
+      expect(wrapper.find('[color="warning"]').exists()).toBe(false);
     });
   });
 
@@ -380,6 +418,8 @@ describe('ReviewModal.vue', () => {
   });
 
   describe('Reject and Awaiting documentation submissions', () => {
+    beforeEach(() => setOrders(createFamilyDeskOrder()));
+
     const createCommentsWrapper = (canApprove = false) =>
       mount(ReviewModal, {
         props: {

--- a/web/tests/components/shared/AppBar.test.ts
+++ b/web/tests/components/shared/AppBar.test.ts
@@ -14,7 +14,6 @@ import { flushPromises, mount } from '@vue/test-utils';
 import AppBar from 'CMP/shared/AppBar.vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { nextTick } from 'vue';
 import { createRouter, createWebHistory } from 'vue-router';
 
 // Mock the JudgeSelector component
@@ -600,6 +599,39 @@ describe('AppBar.vue', () => {
       expect(judgeSelector.exists()).toBe(true);
     });
 
+    it('should show judge selector on desk-orders tab', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
+
+      const judges: PersonSearchItem[] = [generateJudge()];
+
+      const wrapper = createWrapper();
+      await flushPromises();
+      (wrapper.vm as any).judges = judges;
+      (wrapper.vm as any).selectedTab = 'desk-orders';
+      await wrapper.vm.$nextTick();
+
+      const judgeSelector = wrapper.find('[data-testid="judge-selector"]');
+      expect(judgeSelector.exists()).toBe(true);
+      expect((wrapper.vm as any).showJudgeSelector).toBe(true);
+    });
+
+    it('should pass judges to the JudgeSelector when shown', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo();
+
+      const judges: PersonSearchItem[] = [generateJudge(), generateJudge()];
+
+      const wrapper = createWrapper();
+      (wrapper.vm as any).judges = judges;
+      (wrapper.vm as any).selectedTab = 'dashboard';
+      await wrapper.vm.$nextTick();
+
+      const judgeSelector = wrapper.findComponent({ name: 'JudgeSelector' });
+      expect(judgeSelector.exists()).toBe(true);
+      expect(judgeSelector.props('judges')).toEqual(judges);
+    });
+
     it('should not show judge selector when there are no judges', async () => {
       const commonStore = useCommonStore();
       commonStore.userInfo = generateUserInfo();
@@ -626,6 +658,38 @@ describe('AppBar.vue', () => {
 
       const judgeSelector = wrapper.find('[data-testid="judge-selector"]');
       expect(judgeSelector.exists()).toBe(false);
+    });
+
+    it('should not show judge selector on desk-orders tab when there are no judges', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo({ roles: [RolesEnum.Admin] });
+
+      const wrapper = createWrapper();
+      await flushPromises();
+      (wrapper.vm as any).judges = [];
+      (wrapper.vm as any).selectedTab = 'desk-orders';
+      await wrapper.vm.$nextTick();
+
+      const judgeSelector = wrapper.find('[data-testid="judge-selector"]');
+      expect(judgeSelector.exists()).toBe(false);
+      expect((wrapper.vm as any).showJudgeSelector).toBe(false);
+    });
+
+    it('should not show judge selector on an unrelated tab even with judges', async () => {
+      const commonStore = useCommonStore();
+      commonStore.userInfo = generateUserInfo();
+
+      const judges: PersonSearchItem[] = [generateJudge()];
+
+      const wrapper = createWrapper();
+      await flushPromises();
+      (wrapper.vm as any).judges = judges;
+      (wrapper.vm as any).selectedTab = 'some-other-tab';
+      await wrapper.vm.$nextTick();
+
+      const judgeSelector = wrapper.find('[data-testid="judge-selector"]');
+      expect(judgeSelector.exists()).toBe(false);
+      expect((wrapper.vm as any).showJudgeSelector).toBe(false);
     });
   });
 


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-854

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-854

## Description
- This updates shows the `Awaiting For Documentation` button for orders under "Applications" tab while hide for orders under "For Signing" tab.
- This also fixes a bug where the Judge Selector is hidden when "Applications" tab is active.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Local

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screenshots
"For Signing"
<img width="975" height="564" alt="image" src="https://github.com/user-attachments/assets/6656e667-3b25-4b45-9a07-0a5595eefefd" />

"Applications"
<img width="975" height="996" alt="image" src="https://github.com/user-attachments/assets/eb7cee8e-990d-4abe-9db0-ed028d069d56" />
