### PR TITLE
JASPER-857: Case Details: Criminal - document category filter is showing "undefined" and a count of zero

### DIFF
--- a/web/src/components/case-details/criminal/CriminalDocumentsView.vue
+++ b/web/src/components/case-details/criminal/CriminalDocumentsView.vue
@@ -20,11 +20,13 @@
           placeholder="All documents"
           hide-details
           :items="documentCategories"
+          item-title="title"
+          item-value="value"
         >
-          <template v-slot:[`item`]="{ props: itemProps, item }">
+          <template v-slot:item="{ props: itemProps, item }">
             <v-list-item
               v-bind="itemProps"
-              :title="item.title + ' (' + categoryCount(item.value) + ')'"
+              :title="`${item.title} (${item.count})`"
             ></v-list-item>
           </template>
         </v-select>
@@ -227,13 +229,21 @@
     return selectedCategory.value ? selectedCategory.value : 'All Documents';
   };
 
-  const documentCategories = computed<string[]>(() => [
-    ...new Set(
-      (unfilteredDocuments.value ?? [])
-        .filter((doc) => doc.category)
-        .map((doc) => doc.category)
-    ),
-  ]);
+  const documentCategories = computed<
+    { title: string; value: string; count: number }[]
+  >(() =>
+    [
+      ...new Set(
+        (unfilteredDocuments.value ?? [])
+          .filter((doc) => doc.category)
+          .map((doc) => doc.category)
+      ),
+    ].map((category) => ({
+      title: category,
+      value: category,
+      count: categoryCount(category),
+    }))
+  );
 
   const groupBy = ref([
     {


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-857

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-857

## Description
When we migrated to Vuetify v4, there was a [breaking change](https://vuetifyjs.com/en/getting-started/upgrade-guide/#vselect-vcombobox-vautocomplete) to the #item slot of v-select (and v-autocomplete/v-combobox): item is now an alias for internalItem.raw, so slot access to item.title/item.value no longer works for primitive string items. The implementation was updated to pass objects with explicit item-title/item-value and to compute the count once.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Local

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules   

## Screenshots:
<img width="263" height="132" alt="image" src="https://github.com/user-attachments/assets/304ad90a-60e5-4783-ae02-ba6a2da7b3ea" />
