### PR TITLE
JASPER-597: Case Details: Criminal - Ban popup not showing the description

### DIFF
--- a/api/Services/Files/CriminalFilesService.cs
+++ b/api/Services/Files/CriminalFilesService.cs
@@ -326,10 +326,15 @@ namespace Scv.Api.Services.Files
 
         private string GetParticipantIdFromDetail(string partId, RedactedCriminalFileDetailResponse detail) => detail.Participant?.FirstOrDefault(p => p != null && p.PartId == partId)?.PartId;
 
-        private List<CriminalBan> PopulateBans(CfcAccusedFile accusedFile)
+        private async Task<List<CriminalBan>> PopulateBans(CfcAccusedFile accusedFile)
         {
+            var banStatutes = await _lookupService.GetCriminalBanStatutesAsync();
             var bans = _mapper.Map<List<CriminalBan>>(accusedFile.Ban.Where(b => b != null));
-            bans.ForEach(b => b.PartId = accusedFile.PartId);
+            bans.ForEach(b =>
+            {
+                b.PartId = accusedFile.PartId;
+                b.BanStatuteDesc = banStatutes?.FirstOrDefault(bs => bs.Code == b.BanStatuteId)?.LongDesc;
+            });
             return bans;
         }
 
@@ -391,7 +396,7 @@ namespace Scv.Api.Services.Files
                 foreach (var accusedFile in (accusedFiles ?? []).Where(af => af?.PartId == participant.PartId))
                 {
                     participant.Count.AddRange(await PopulateCounts(accusedFile, detail));
-                    participant.Ban.AddRange(PopulateBans(accusedFile));
+                    participant.Ban.AddRange(await PopulateBans(accusedFile));
                 }
             }
             return detail.Participant;

--- a/api/Services/Files/CriminalFilesService.cs
+++ b/api/Services/Files/CriminalFilesService.cs
@@ -333,7 +333,7 @@ namespace Scv.Api.Services.Files
             bans.ForEach(b =>
             {
                 b.PartId = accusedFile.PartId;
-                b.BanStatuteDesc = banStatutes?.FirstOrDefault(bs => bs.Code == b.BanStatuteId)?.LongDesc;
+                b.BanStatuteDesc = banStatutes?.FirstOrDefault(bs => bs.Code == b.BanStatuteId)?.LongDesc ?? b.BanStatuteId;
             });
             return bans;
         }

--- a/api/Services/LookupService.cs
+++ b/api/Services/LookupService.cs
@@ -309,8 +309,8 @@ namespace Scv.Api.Services
 
         public virtual async Task<CodeLookup> GetCriminalBanStatutesAsync()
         {
-            return await GetDataFromCache("GetCriminalBanStatutesAsync",
-                async () => await _lookupClient.CodesCriminalBanstatutesGetAsync());
+            return await GetDataFromCache(nameof(GetCriminalBanStatutesAsync),
+                () => _lookupClient.CodesCriminalBanstatutesGetAsync());
         }
 
         #endregion Lookup Methods

--- a/api/Services/LookupService.cs
+++ b/api/Services/LookupService.cs
@@ -307,6 +307,12 @@ namespace Scv.Api.Services
                     : null;
         }
 
+        public virtual async Task<CodeLookup> GetCriminalBanStatutesAsync()
+        {
+            return await GetDataFromCache("GetCriminalBanStatutesAsync",
+                async () => await _lookupClient.CodesCriminalBanstatutesGetAsync());
+        }
+
         #endregion Lookup Methods
 
         #region Helpers

--- a/jc-interface-client/Criminal/Detail/CriminalBan.cs
+++ b/jc-interface-client/Criminal/Detail/CriminalBan.cs
@@ -8,5 +8,6 @@ namespace Scv.Models.Criminal.Detail;
 public class CriminalBan : CfcBan
 {
     public string PartId { get; set; }
+    public string BanStatuteDesc { get; set; }
 }
 

--- a/web/src/components/case-details/common/accused/Bans.vue
+++ b/web/src/components/case-details/common/accused/Bans.vue
@@ -23,7 +23,7 @@
               <td>{{ ban.banTypeAct }}</td>
               <td>{{ ban.banTypeSection }}</td>
               <td>{{ ban.banTypeSubSection }}</td>
-              <td>{{ ban.banCommentText }}</td>
+              <td>{{ ban.banStatuteDesc ?? ban.banStatuteId }}</td>
             </tr>
           </tbody>
         </v-table>
@@ -36,9 +36,10 @@
 </template>
 
 <script setup lang="ts">
+  import { banType } from '@/types/criminal/jsonTypes';
   import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
 
-  defineProps<{ bans: any }>();
+  defineProps<{ bans: banType[] }>();
 
   const show = defineModel<boolean>({ type: Boolean, required: true });
 </script>

--- a/web/src/components/case-details/common/accused/Bans.vue
+++ b/web/src/components/case-details/common/accused/Bans.vue
@@ -23,7 +23,7 @@
               <td>{{ ban.banTypeAct }}</td>
               <td>{{ ban.banTypeSection }}</td>
               <td>{{ ban.banTypeSubSection }}</td>
-              <td>{{ ban.banStatuteDesc ?? ban.banStatuteId }}</td>
+              <td>{{ ban.banStatuteDesc }}</td>
             </tr>
           </tbody>
         </v-table>

--- a/web/src/types/criminal/jsonTypes/index.ts
+++ b/web/src/types/criminal/jsonTypes/index.ts
@@ -80,6 +80,7 @@ export interface banType {
   banTypeSection: string;
   banTypeSubSection: string;
   banStatuteId: string;
+  banStatuteDesc: string;
   banCommentText: string;
   banOrderedDate: string;
   banSeqNo: string;

--- a/web/tests/components/case-details/common/accused/Bans.test.ts
+++ b/web/tests/components/case-details/common/accused/Bans.test.ts
@@ -18,6 +18,7 @@ describe('Bans.vue', () => {
     } as banType,
     {
       banStatuteId: '2',
+      banStatuteDesc: 'Statute2',
       banTypeCd: 'Type2',
       banOrderedDate: '2005-06-16 00:00:00.0',
       banTypeAct: 'Act2',
@@ -37,7 +38,7 @@ describe('Bans.vue', () => {
     });
 
     const rows = wrapper.findAll('tbody tr');
-    expect(rows.length).toBe(bansMock.length);
+    expect(rows).toHaveLength(bansMock.length);
   });
 
   it('renders the correct data in the table', () => {
@@ -62,6 +63,6 @@ describe('Bans.vue', () => {
     expect(secondRowCells?.at(2)?.text()).toBe(bansMock[1].banTypeAct);
     expect(secondRowCells?.at(3)?.text()).toBe(bansMock[1].banTypeSection);
     expect(secondRowCells?.at(4)?.text()).toBe(bansMock[1].banTypeSubSection);
-    expect(secondRowCells?.at(5)?.text()).toBe(bansMock[1].banStatuteId);
+    expect(secondRowCells?.at(5)?.text()).toBe(bansMock[1].banStatuteDesc);
   });
 });

--- a/web/tests/components/case-details/common/accused/Bans.test.ts
+++ b/web/tests/components/case-details/common/accused/Bans.test.ts
@@ -1,11 +1,13 @@
 import Bans from '@/components/case-details/common/accused/Bans.vue';
+import { banType } from '@/types/criminal/jsonTypes';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 
 describe('Bans.vue', () => {
   const bansMock = [
     {
-      banStatuteId: 1,
+      banStatuteId: '1',
+      banStatuteDesc: 'Statute1',
       banTypeCd: 'Type1',
       banOrderedDate: '2025-01-01 00:00:00.0',
       banTypeAct: 'Act1',
@@ -13,9 +15,9 @@ describe('Bans.vue', () => {
       banTypeSubSection: 'Sub1',
       banTypeDescription: 'Description1',
       banCommentText: 'Comment1',
-    },
+    } as banType,
     {
-      banStatuteId: 2,
+      banStatuteId: '2',
       banTypeCd: 'Type2',
       banOrderedDate: '2005-06-16 00:00:00.0',
       banTypeAct: 'Act2',
@@ -23,7 +25,7 @@ describe('Bans.vue', () => {
       banTypeSubSection: 'Sub2',
       banTypeDescription: 'Description2',
       banCommentText: 'Comment2',
-    },
+    } as banType,
   ];
 
   it('renders the correct number of rows in the table', () => {
@@ -52,6 +54,14 @@ describe('Bans.vue', () => {
     expect(firstRowCells?.at(2)?.text()).toBe(bansMock[0].banTypeAct);
     expect(firstRowCells?.at(3)?.text()).toBe(bansMock[0].banTypeSection);
     expect(firstRowCells?.at(4)?.text()).toBe(bansMock[0].banTypeSubSection);
-    expect(firstRowCells?.at(5)?.text()).toBe(bansMock[0].banCommentText);
+    expect(firstRowCells?.at(5)?.text()).toBe(bansMock[0].banStatuteDesc);
+
+    const secondRowCells = wrapper.findAll('tbody tr').at(1)?.findAll('td');
+    expect(secondRowCells?.at(0)?.text()).toBe(bansMock[1].banTypeDescription);
+    expect(secondRowCells?.at(1)?.text()).toBe('16-Jun-2005');
+    expect(secondRowCells?.at(2)?.text()).toBe(bansMock[1].banTypeAct);
+    expect(secondRowCells?.at(3)?.text()).toBe(bansMock[1].banTypeSection);
+    expect(secondRowCells?.at(4)?.text()).toBe(bansMock[1].banTypeSubSection);
+    expect(secondRowCells?.at(5)?.text()).toBe(bansMock[1].banStatuteId);
   });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-597

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-597

## Description
This implementation follows PCSS' behavior when showing the ban's description. PCSS pulls the "long description" from the `banStatutes` lookup using the `statuteId`. If the `id` exists in the lookup, the long description is displayed. Otherwise, the `id` is displayed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Local

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   

## Screen Shots
<img width="975" height="297" alt="image" src="https://github.com/user-attachments/assets/6303346d-68fd-4e86-943d-ae589e0fd8bd" />

<img width="975" height="276" alt="image" src="https://github.com/user-attachments/assets/5551b15d-85b0-4336-99d2-23f9e770ad5a" />
