### PR TITLE
JASPER-739: Counsel information not displaying in JASPER for Criminal and Family files

### DIFF
--- a/api/Services/Files/CivilFilesService.cs
+++ b/api/Services/Files/CivilFilesService.cs
@@ -19,6 +19,7 @@ using Scv.Models.Civil.Detail;
 using Scv.Models.Document;
 using Scv.Models.Search;
 using CivilAppearanceMethod = Scv.Models.Civil.AppearanceDetail.CivilAppearanceMethod;
+using CounselNameDescriptor = PCSSCommon.Models.CounselNameDescriptor;
 using PCSSFileDetailServices = PCSSCommon.Clients.FileDetailServices;
 
 namespace Scv.Api.Services.Files
@@ -607,16 +608,14 @@ namespace Scv.Api.Services.Files
             }
 
             // Mirror's PCSS's logic for determining counsel name. JC's counsel is inaccurate, which can mislead users.
-            if (pcssParty.SelfRepresentedYn == "Y")
+            if (CounselNameDescriptor.IsSelfRepresented(pcssParty.SelfRepresentedYn))
             {
-                return [new CvfcCounsel { FullNm = "Self-Represented" }];
+                return [new CvfcCounsel { FullNm = CounselNameDescriptor.SELF_REPRESENTED }];
             }
 
             if (pcssParty.Counsel is { } pcssCounsel)
             {
-                var fullNm = !string.IsNullOrWhiteSpace(pcssCounsel.PrefNm) ? pcssCounsel.PrefNm
-                    : !string.IsNullOrWhiteSpace(pcssCounsel.OrgNm) ? pcssCounsel.OrgNm
-                    : $"{pcssCounsel.GivenNm} {pcssCounsel.LastNm}".Trim();
+                var fullNm = CounselNameDescriptor.FullName(pcssCounsel);
 
                 return string.IsNullOrWhiteSpace(fullNm)
                     ? []
@@ -625,7 +624,7 @@ namespace Scv.Api.Services.Files
 
             if (pcssParty.CeisCounsel is { } ceisCounsel)
             {
-                return [.. ceisCounsel.Select(c => new CvfcCounsel { FullNm = $"CEIS: {c.FullNm}" })];
+                return [.. ceisCounsel.Where(c => c != null).Select(c => new CvfcCounsel { FullNm = $"CEIS: {c.FullNm}" })];
             }
 
             return [];

--- a/api/Services/Files/CivilFilesService.cs
+++ b/api/Services/Files/CivilFilesService.cs
@@ -19,6 +19,7 @@ using Scv.Models.Civil.Detail;
 using Scv.Models.Document;
 using Scv.Models.Search;
 using CivilAppearanceMethod = Scv.Models.Civil.AppearanceDetail.CivilAppearanceMethod;
+using PCSSFileDetailServices = PCSSCommon.Clients.FileDetailServices;
 
 namespace Scv.Api.Services.Files
 {
@@ -37,6 +38,7 @@ namespace Scv.Api.Services.Files
         private readonly string _requestPartId;
         private readonly List<string> _filterOutDocumentTypes;
         private readonly ClaimsPrincipal _currentUser;
+        private readonly PCSSFileDetailServices.FileDetailClient _pcssFileDetailClient;
 
         #endregion Variables
 
@@ -49,12 +51,14 @@ namespace Scv.Api.Services.Files
             LocationService locationService,
             IAppCache cache,
             ClaimsPrincipal user,
-            ILogger<CivilFilesService> logger)
+            ILogger<CivilFilesService> logger,
+            PCSSFileDetailServices.FileDetailClient pcssFileDetailClient)
         {
             _filesClient = filesClient;
             _filesClient.JsonSerializerSettings.ContractResolver = new SafeContractResolver { NamingStrategy = new CamelCaseNamingStrategy() };
             _lookupService = lookupService;
             _locationService = locationService;
+            _pcssFileDetailClient = pcssFileDetailClient;
             _mapper = mapper;
             _cache = cache;
             _applicationCode = configuration.GetNonEmptyValue("Request:ApplicationCd");
@@ -194,8 +198,9 @@ namespace Scv.Api.Services.Files
             var fileDetailTask = _cache.GetOrAddAsync($"CivilFileDetail-{fileId}-{_requestAgencyIdentifierId}", FileDetails);
             var fileContentTask = _cache.GetOrAddAsync($"CivilFileContent-{fileId}-{_requestAgencyIdentifierId}", FileContent);
             var appearancesTask = _cache.GetOrAddAsync($"CivilAppearancesFull-{fileId}-{_requestAgencyIdentifierId}", Appearances);
+            var pcssFileDetailTask = GetPcssCivilFileDetailAsync(fileId);
 
-            await Task.WhenAll(appearancesTask, fileContentTask, fileDetailTask);
+            await Task.WhenAll(appearancesTask, fileContentTask, fileDetailTask, pcssFileDetailTask);
 
             ValidUserHelper.CheckIfValidUser(fileDetailTask.Result.ResponseMessageTxt);
             if (fileDetailTask.Result?.PhysicalFileId == null)
@@ -239,7 +244,7 @@ namespace Scv.Api.Services.Files
             }
 
             var fileContentCivilFile = fileContentTask.Result?.CivilFile?.First(cf => cf.PhysicalFileID == fileId);
-            var partyTask = PopulateDetailParties(detail.Party, courtListParties);
+            var partyTask = PopulateDetailParties(detail.Party, courtListParties, pcssFileDetailTask.Result);
             var documentTask = PopulateDetailDocuments(detail.Document, detail, fileContentCivilFile, isVcUser, isStaff);
             var hearingRestrictionTask = PopulateDetailHearingRestrictions(fileDetailTask.Result.HearingRestriction);
 
@@ -525,11 +530,16 @@ namespace Scv.Api.Services.Files
             return documents;
         }
 
-        private async Task<ICollection<CivilParty>> PopulateDetailParties(ICollection<CivilParty> parties, ICollection<ClParty> courtListParties)
+        private async Task<ICollection<CivilParty>> PopulateDetailParties(
+            ICollection<CivilParty> parties,
+            ICollection<ClParty> courtListParties,
+            PCSSCommon.Models.CivilFileDetail pcssCivilFileDetail)
         {
             //Populate extra fields for party.
             foreach (var party in parties)
             {
+                party.Counsel = PopulatePartyCounsel(party, pcssCivilFileDetail);
+
                 var courtListParty = courtListParties.FirstOrDefault(clp => clp.PartyId == party.PartyId);
                 if (courtListParty != null)
                 {
@@ -586,6 +596,49 @@ namespace Scv.Api.Services.Files
                 hearing.HearingRestrictionTypeDsc = hearingRestrictionDescs[idx++];
             }
             return civilHearingRestrictions;
+        }
+
+        private static List<CvfcCounsel> PopulatePartyCounsel(CivilParty party, PCSSCommon.Models.CivilFileDetail pcssCivilFileDetail)
+        {
+            var pcssParty = pcssCivilFileDetail?.Party.FirstOrDefault(p => p.PartyId == party.PartyId);
+            if (pcssParty == null)
+            {
+                return [];
+            }
+
+            // Mirror's PCSS's logic for determining counsel name. JC's counsel is inaccurate, which can mislead users.
+            if (pcssParty.SelfRepresentedYn == "Y")
+            {
+                return [new CvfcCounsel { FullNm = "Self-Represented" }];
+            }
+
+            if (pcssParty.Counsel is { } pcssCounsel)
+            {
+                var fullNm = !string.IsNullOrWhiteSpace(pcssCounsel.PrefNm) ? pcssCounsel.PrefNm
+                    : !string.IsNullOrWhiteSpace(pcssCounsel.OrgNm) ? pcssCounsel.OrgNm
+                    : $"{pcssCounsel.GivenNm} {pcssCounsel.LastNm}".Trim();
+
+                return string.IsNullOrWhiteSpace(fullNm)
+                    ? []
+                    : [new CvfcCounsel { FullNm = fullNm }];
+            }
+
+            if (pcssParty.CeisCounsel is { } ceisCounsel)
+            {
+                return [.. ceisCounsel.Select(c => new CvfcCounsel { FullNm = $"CEIS: {c.FullNm}" })];
+            }
+
+            return [];
+        }
+
+        private async Task<PCSSCommon.Models.CivilFileDetail> GetPcssCivilFileDetailAsync(string fileId)
+        {
+            if (!double.TryParse(fileId, out double physicalFileid))
+            {
+                return null;
+            }
+            async Task<PCSSCommon.Models.CivilFileDetail> PcssCivilFileDetailAsync() => await _pcssFileDetailClient.GetCivilFileDetailAsync(physicalFileid);
+            return await _cache.GetOrAddAsync($"{nameof(PcssCivilFileDetailAsync)}-{physicalFileid}", PcssCivilFileDetailAsync);
         }
 
         #endregion Civil Details

--- a/api/Services/Files/CivilFilesService.cs
+++ b/api/Services/Files/CivilFilesService.cs
@@ -601,13 +601,15 @@ namespace Scv.Api.Services.Files
 
         private static List<CvfcCounsel> PopulatePartyCounsel(CivilParty party, PCSSCommon.Models.CivilFileDetail pcssCivilFileDetail)
         {
-            var pcssParty = pcssCivilFileDetail?.Party.FirstOrDefault(p => p.PartyId == party.PartyId);
+            var pcssParty = pcssCivilFileDetail?
+                .Party?
+                .FirstOrDefault(p => p.PartyId == party.PartyId);
             if (pcssParty == null)
             {
                 return [];
             }
 
-            // Mirror's PCSS's logic for determining counsel name. JC's counsel is inaccurate, which can mislead users.
+            // Mirrors PCSS's logic for determining counsel name. JC's counsel is inaccurate, which can mislead users.
             if (CounselNameDescriptor.IsSelfRepresented(pcssParty.SelfRepresentedYn))
             {
                 return [new CvfcCounsel { FullNm = CounselNameDescriptor.SELF_REPRESENTED }];

--- a/api/Services/Files/CivilFilesService.cs
+++ b/api/Services/Files/CivilFilesService.cs
@@ -199,9 +199,8 @@ namespace Scv.Api.Services.Files
             var fileDetailTask = _cache.GetOrAddAsync($"CivilFileDetail-{fileId}-{_requestAgencyIdentifierId}", FileDetails);
             var fileContentTask = _cache.GetOrAddAsync($"CivilFileContent-{fileId}-{_requestAgencyIdentifierId}", FileContent);
             var appearancesTask = _cache.GetOrAddAsync($"CivilAppearancesFull-{fileId}-{_requestAgencyIdentifierId}", Appearances);
-            var pcssFileDetailTask = GetPcssCivilFileDetailAsync(fileId);
 
-            await Task.WhenAll(appearancesTask, fileContentTask, fileDetailTask, pcssFileDetailTask);
+            await Task.WhenAll(appearancesTask, fileContentTask, fileDetailTask);
 
             ValidUserHelper.CheckIfValidUser(fileDetailTask.Result.ResponseMessageTxt);
             if (fileDetailTask.Result?.PhysicalFileId == null)
@@ -245,7 +244,7 @@ namespace Scv.Api.Services.Files
             }
 
             var fileContentCivilFile = fileContentTask.Result?.CivilFile?.First(cf => cf.PhysicalFileID == fileId);
-            var partyTask = PopulateDetailParties(detail.Party, courtListParties, pcssFileDetailTask.Result);
+            var partyTask = PopulateDetailParties(detail.PhysicalFileId, detail.Party, courtListParties);
             var documentTask = PopulateDetailDocuments(detail.Document, detail, fileContentCivilFile, isVcUser, isStaff);
             var hearingRestrictionTask = PopulateDetailHearingRestrictions(fileDetailTask.Result.HearingRestriction);
 
@@ -532,14 +531,19 @@ namespace Scv.Api.Services.Files
         }
 
         private async Task<ICollection<CivilParty>> PopulateDetailParties(
+            string fileId,
             ICollection<CivilParty> parties,
-            ICollection<ClParty> courtListParties,
-            PCSSCommon.Models.CivilFileDetail pcssCivilFileDetail)
+            ICollection<ClParty> courtListParties)
         {
+            var pcssFileDetail = await GetPcssCivilFileDetailAsync(fileId);
+
             //Populate extra fields for party.
             foreach (var party in parties)
             {
-                party.Counsel = PopulatePartyCounsel(party, pcssCivilFileDetail);
+                if (pcssFileDetail != null)
+                {
+                    party.Counsel = PopulatePartyCounsel(party, pcssFileDetail);
+                }
 
                 var courtListParty = courtListParties.FirstOrDefault(clp => clp.PartyId == party.PartyId);
                 if (courtListParty != null)
@@ -626,7 +630,10 @@ namespace Scv.Api.Services.Files
 
             if (pcssParty.CeisCounsel is { } ceisCounsel)
             {
-                return [.. ceisCounsel.Where(c => c != null).Select(c => new CvfcCounsel { FullNm = $"CEIS: {c.FullNm}" })];
+                return [.. ceisCounsel
+                    .Where(c => c != null
+                        && !string.IsNullOrWhiteSpace(c.FullNm))
+                    .Select(c => new CvfcCounsel { FullNm = $"CEIS: {c.FullNm}" })];
             }
 
             return [];
@@ -634,12 +641,12 @@ namespace Scv.Api.Services.Files
 
         private async Task<PCSSCommon.Models.CivilFileDetail> GetPcssCivilFileDetailAsync(string fileId)
         {
-            if (!double.TryParse(fileId, out double physicalFileid))
+            if (!double.TryParse(fileId, out double physicalFileId))
             {
                 return null;
             }
-            async Task<PCSSCommon.Models.CivilFileDetail> PcssCivilFileDetailAsync() => await _pcssFileDetailClient.GetCivilFileDetailAsync(physicalFileid);
-            return await _cache.GetOrAddAsync($"{nameof(PcssCivilFileDetailAsync)}-{physicalFileid}", PcssCivilFileDetailAsync);
+            async Task<PCSSCommon.Models.CivilFileDetail> PcssCivilFileDetailAsync() => await _pcssFileDetailClient.GetCivilFileDetailAsync(physicalFileId);
+            return await _cache.GetOrAddAsync($"{nameof(PcssCivilFileDetailAsync)}-{physicalFileId}", PcssCivilFileDetailAsync);
         }
 
         #endregion Civil Details

--- a/api/Services/Files/CriminalFilesService.cs
+++ b/api/Services/Files/CriminalFilesService.cs
@@ -17,6 +17,7 @@ using Scv.Models.Criminal.AppearanceDetail;
 using Scv.Models.Criminal.Appearances;
 using Scv.Models.Criminal.Detail;
 using Scv.Models.Search;
+using CounselNameDescriptor = PCSSCommon.Models.CounselNameDescriptor;
 using CriminalAppearanceDetail = Scv.Models.Criminal.AppearanceDetail.CriminalAppearanceDetail;
 using CriminalAppearanceMethod = Scv.Models.Criminal.AppearanceDetail.CriminalAppearanceMethod;
 using CriminalParticipant = Scv.Models.Criminal.Detail.CriminalParticipant;
@@ -421,32 +422,19 @@ namespace Scv.Api.Services.Files
                 return;
             }
 
-            // Mirror's PCSS's logic for determining counsel name. JC's counsel is inaccurate, which can mislead users.
             participant.CounselGivenNm = string.Empty;
-            if (pcssParticipant.SelfRepresentedYn == "Y")
+            if (CounselNameDescriptor.IsSelfRepresented(pcssParticipant.SelfRepresentedYn))
             {
-                participant.CounselLastNm = "Self-Represented";
+                participant.CounselLastNm = CounselNameDescriptor.SELF_REPRESENTED;
             }
             else if (pcssParticipant.Counsel is { } counsel)
             {
-                if (!string.IsNullOrWhiteSpace(counsel.PrefNm))
-                {
-                    participant.CounselLastNm = counsel.PrefNm;
-                }
-                else if (!string.IsNullOrWhiteSpace(counsel.OrgNm))
-                {
-                    participant.CounselLastNm = counsel.OrgNm;
-                }
-                else
-                {
-                    participant.CounselLastNm = counsel.LastNm;
-                    participant.CounselGivenNm = counsel.GivenNm;
-                }
+                (participant.CounselGivenNm, participant.CounselLastNm) = CounselNameDescriptor.ResolveName(counsel);
             }
             else if (pcssParticipant.JustinCounsel is { } justinCounsel)
             {
-                participant.CounselLastNm = $"JUSTIN: {justinCounsel.LastNm}";
-                participant.CounselGivenNm = justinCounsel.GivenNm;
+                participant.CounselGivenNm = $"JUSTIN: {justinCounsel.GivenNm}";
+                participant.CounselLastNm = $" {justinCounsel.LastNm}";
             }
         }
 

--- a/api/Services/Files/CriminalFilesService.cs
+++ b/api/Services/Files/CriminalFilesService.cs
@@ -21,6 +21,7 @@ using CriminalAppearanceDetail = Scv.Models.Criminal.AppearanceDetail.CriminalAp
 using CriminalAppearanceMethod = Scv.Models.Criminal.AppearanceDetail.CriminalAppearanceMethod;
 using CriminalParticipant = Scv.Models.Criminal.Detail.CriminalParticipant;
 using CriminalWitness = Scv.Models.Criminal.Detail.CriminalWitness;
+using PCSSFileDetailServices = PCSSCommon.Clients.FileDetailServices;
 
 namespace Scv.Api.Services.Files
 {
@@ -38,13 +39,21 @@ namespace Scv.Api.Services.Files
         private readonly string _requestPartId;
         private readonly ClaimsPrincipal _currentUser;
         private readonly IDocumentConverter _documentConverter;
-
+        private readonly PCSSFileDetailServices.FileDetailClient _pcssFileDetailClient;
         #endregion
 
         #region Constructor
 
-        public CriminalFilesService(IConfiguration configuration, FileServicesClient filesClient, IMapper mapper, LookupService lookupService, LocationService locationService, IAppCache cache,
-            ClaimsPrincipal user, IDocumentConverter documentConverter)
+        public CriminalFilesService(
+            IConfiguration configuration,
+            FileServicesClient filesClient,
+            IMapper mapper,
+            LookupService lookupService,
+            LocationService locationService,
+            IAppCache cache,
+            ClaimsPrincipal user,
+            IDocumentConverter documentConverter,
+            PCSSFileDetailServices.FileDetailClient pcssFileDetailClient)
         {
             _filesClient = filesClient;
             _filesClient.JsonSerializerSettings.ContractResolver = new SafeContractResolver { NamingStrategy = new CamelCaseNamingStrategy() };
@@ -57,6 +66,7 @@ namespace Scv.Api.Services.Files
             _cache = cache;
             _currentUser = user;
             _documentConverter = documentConverter;
+            _pcssFileDetailClient = pcssFileDetailClient;
         }
 
         #endregion Constructor
@@ -132,11 +142,11 @@ namespace Scv.Api.Services.Files
                 return null;
 
             var detail = _mapper.Map<RedactedCriminalFileDetailResponse>(fileDetail);
-            var (documents, criminalCourtLists) = await GetDocumentsAndCourtListsAsync(fileDetail, fileContent, appearances);
+            var (documents, criminalCourtLists, pcssCriminalFileDetail) = await GetDocumentsCourtListsAndPcssCaseDetailsAsync(fileDetail, fileContent, appearances);
             detail = await PopulateBaseDetail(detail);
             detail.Appearances = appearances;
             detail.Witness = await PopulateDetailWitnesses(detail);
-            detail.Participant = await PopulateDetailParticipants(detail, documents, fileContent.AccusedFile, criminalCourtLists);
+            detail.Participant = await PopulateDetailParticipants(detail, documents, fileContent.AccusedFile, criminalCourtLists, pcssCriminalFileDetail);
             detail.HearingRestriction = await PopulateDetailHearingRestrictions(detail);
             detail.Crown = PopulateDetailCrown(detail);
             return detail;
@@ -178,8 +188,8 @@ namespace Scv.Api.Services.Files
                 return null;
 
             var detail = _mapper.Map<RedactedCriminalFileDetailResponse>(fileDetail);
-            var (documents, criminalCourtLists) = await GetDocumentsAndCourtListsAsync(fileDetail, fileContent, appearances);
-            detail.Participant = await PopulateDetailParticipants(detail, documents, fileContent.AccusedFile, criminalCourtLists);
+            var (documents, criminalCourtLists, pcssCriminalFileDetail) = await GetDocumentsCourtListsAndPcssCaseDetailsAsync(fileDetail, fileContent, appearances);
+            detail.Participant = await PopulateDetailParticipants(detail, documents, fileContent.AccusedFile, criminalCourtLists, pcssCriminalFileDetail);
 
             return detail.Participant;
         }
@@ -378,7 +388,12 @@ namespace Scv.Api.Services.Files
             return detail.Witness;
         }
 
-        private async Task<ICollection<CriminalParticipant>> PopulateDetailParticipants(RedactedCriminalFileDetailResponse detail, ICollection<CriminalDocument> documents, ICollection<CfcAccusedFile> accusedFiles, IEnumerable<ClCriminalCourtList> courtLists)
+        private async Task<ICollection<CriminalParticipant>> PopulateDetailParticipants(
+            RedactedCriminalFileDetailResponse detail,
+            ICollection<CriminalDocument> documents,
+            ICollection<CfcAccusedFile> accusedFiles,
+            IEnumerable<ClCriminalCourtList> courtLists,
+            PCSSCommon.Models.CriminalFileDetail pcssCriminalFileDetail)
         {
             foreach (var participant in detail.Participant)
             {
@@ -386,8 +401,9 @@ namespace Scv.Api.Services.Files
                     .SelectMany(cl => cl.AgeNotice)
                     .ToList();
                 participant.Document = [.. (documents ?? []).Where(doc => doc.PartId == participant.PartId)];
-                participant.HideJustinCounsel = false;   //TODO tie this to a permission. View Witness List permission
-                //TODO COUNSEL? This would have to come from law society data, which is stored in a CSV file. 
+
+                PopulateParticipantCounsel(pcssCriminalFileDetail, participant);
+
                 foreach (var accusedFile in (accusedFiles ?? []).Where(af => af?.PartId == participant.PartId))
                 {
                     participant.Count.AddRange(await PopulateCounts(accusedFile, detail));
@@ -395,6 +411,43 @@ namespace Scv.Api.Services.Files
                 }
             }
             return detail.Participant;
+        }
+
+        private static void PopulateParticipantCounsel(PCSSCommon.Models.CriminalFileDetail pcssCriminalFileDetail, CriminalParticipant participant)
+        {
+            var pcssParticipant = pcssCriminalFileDetail?.Participant.FirstOrDefault(p => p.PartId == participant.PartId);
+            if (pcssParticipant == null)
+            {
+                return;
+            }
+
+            // Mirror's PCSS's logic for determining counsel name. JC's counsel is inaccurate, which can mislead users.
+            participant.CounselGivenNm = string.Empty;
+            if (pcssParticipant.SelfRepresentedYn == "Y")
+            {
+                participant.CounselLastNm = "Self-Represented";
+            }
+            else if (pcssParticipant.Counsel is { } counsel)
+            {
+                if (!string.IsNullOrWhiteSpace(counsel.PrefNm))
+                {
+                    participant.CounselLastNm = counsel.PrefNm;
+                }
+                else if (!string.IsNullOrWhiteSpace(counsel.OrgNm))
+                {
+                    participant.CounselLastNm = counsel.OrgNm;
+                }
+                else
+                {
+                    participant.CounselLastNm = counsel.LastNm;
+                    participant.CounselGivenNm = counsel.GivenNm;
+                }
+            }
+            else if (pcssParticipant.JustinCounsel is { } justinCounsel)
+            {
+                participant.CounselLastNm = $"JUSTIN: {justinCounsel.LastNm}";
+                participant.CounselGivenNm = justinCounsel.GivenNm;
+            }
         }
 
         private async Task<RedactedCriminalFileDetailResponse> PopulateBaseDetail(RedactedCriminalFileDetailResponse detail)
@@ -517,17 +570,19 @@ namespace Scv.Api.Services.Files
             return (fileDetailTask.Result, fileContentTask.Result, appearancesTask.Result);
         }
 
-        private async Task<(ICollection<CriminalDocument> documents, IEnumerable<ClCriminalCourtList> criminalCourtLists)> GetDocumentsAndCourtListsAsync(
-            CriminalFileDetailResponse fileDetail,
-            CriminalFileContent fileContent,
-            CriminalFileAppearances appearances)
+        private async Task<(ICollection<CriminalDocument> documents, IEnumerable<ClCriminalCourtList> criminalCourtLists, PCSSCommon.Models.CriminalFileDetail pcssCriminalFileDetail)>
+            GetDocumentsCourtListsAndPcssCaseDetailsAsync(
+                CriminalFileDetailResponse fileDetail,
+                CriminalFileContent fileContent,
+                CriminalFileAppearances appearances)
         {
             var documentsTask = PopulateDetailDocuments(fileContent);
             var criminalCourtListsTask = GetCourtListsAsync(fileDetail, appearances);
+            var pcssCriminalFileDetailTask = GetPcssCriminalFileDetailAsync(fileDetail.JustinNo);
 
-            await Task.WhenAll(documentsTask, criminalCourtListsTask);
+            await Task.WhenAll(documentsTask, criminalCourtListsTask, pcssCriminalFileDetailTask);
 
-            return (documentsTask.Result, criminalCourtListsTask.Result);
+            return (documentsTask.Result, criminalCourtListsTask.Result, pcssCriminalFileDetailTask.Result);
         }
 
         private async Task<IEnumerable<ClCriminalCourtList>> GetCourtListsAsync(CriminalFileDetailResponse fileDetail, CriminalFileAppearances appearances)
@@ -546,6 +601,16 @@ namespace Scv.Api.Services.Files
             async Task<CourtList> CourtList() => await _filesClient.FilesCourtlistAsync(_requestAgencyIdentifierId, _requestPartId, _applicationCode, agencyId, latestAppearance.CourtRoomCd, latestAppearance.AppearanceDt, "CR", fileDetail.FileNumberTxt);
             var courtList = await _cache.GetOrAddAsync($"CriminalCourtList-{agencyId}-{latestAppearance.CourtRoomCd}-{latestAppearance.AppearanceDt}-{fileDetail.FileNumberTxt}-{_requestAgencyIdentifierId}", CourtList);
             return courtList?.CriminalCourtList;
+        }
+
+        private async Task<PCSSCommon.Models.CriminalFileDetail> GetPcssCriminalFileDetailAsync(string justinNo)
+        {
+            if (!int.TryParse(justinNo, out int justinNoInt))
+            {
+                return null;
+            }
+            async Task<PCSSCommon.Models.CriminalFileDetail> PcssCriminalFileDetailAsync() => await _pcssFileDetailClient.GetCriminalFileDetailAsync(justinNoInt);
+            return await _cache.GetOrAddAsync($"{nameof(PcssCriminalFileDetailAsync)}-{justinNoInt}", PcssCriminalFileDetailAsync);
         }
 
         #endregion Criminal Details

--- a/api/Services/Files/CriminalFilesService.cs
+++ b/api/Services/Files/CriminalFilesService.cs
@@ -429,10 +429,10 @@ namespace Scv.Api.Services.Files
                 return;
             }
 
-            participant.CounselGivenNm = string.Empty;
             if (CounselNameDescriptor.IsSelfRepresented(pcssParticipant.SelfRepresentedYn))
             {
                 participant.CounselLastNm = CounselNameDescriptor.SELF_REPRESENTED;
+                participant.CounselGivenNm = string.Empty;
             }
             else if (pcssParticipant.Counsel is { } counsel)
             {

--- a/api/Services/Files/CriminalFilesService.cs
+++ b/api/Services/Files/CriminalFilesService.cs
@@ -416,7 +416,9 @@ namespace Scv.Api.Services.Files
 
         private static void PopulateParticipantCounsel(PCSSCommon.Models.CriminalFileDetail pcssCriminalFileDetail, CriminalParticipant participant)
         {
-            var pcssParticipant = pcssCriminalFileDetail?.Participant.FirstOrDefault(p => p.PartId == participant.PartId);
+            var pcssParticipant = pcssCriminalFileDetail?
+                .Participant?
+                .FirstOrDefault(p => p.PartId == participant.PartId);
             if (pcssParticipant == null)
             {
                 return;
@@ -433,8 +435,8 @@ namespace Scv.Api.Services.Files
             }
             else if (pcssParticipant.JustinCounsel is { } justinCounsel)
             {
-                participant.CounselGivenNm = $"JUSTIN: {justinCounsel.GivenNm}";
-                participant.CounselLastNm = $" {justinCounsel.LastNm}";
+                participant.CounselGivenNm = $"JUSTIN: {justinCounsel.GivenNm}".Trim();
+                participant.CounselLastNm = justinCounsel.LastNm?.Trim() ?? string.Empty;
             }
         }
 

--- a/api/Services/Files/FilesService.cs
+++ b/api/Services/Files/FilesService.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Serialization;
 using Scv.Api.Documents;
 using Scv.Core.ContractResolver;
 using Scv.Core.Helpers.Extensions;
+using PCSSFileDetailServices = PCSSCommon.Clients.FileDetailServices;
 
 namespace Scv.Api.Services.Files
 {
@@ -39,7 +40,8 @@ namespace Scv.Api.Services.Files
             IAppCache cache,
             ClaimsPrincipal claimsPrincipal,
             ILoggerFactory factory,
-            IDocumentConverter documentConverter)
+            IDocumentConverter documentConverter,
+            PCSSFileDetailServices.FileDetailClient pcssFileDetailClient)
         {
             _filesClient = filesClient;
             _filesClient.JsonSerializerSettings.ContractResolver = new SafeContractResolver { NamingStrategy = new CamelCaseNamingStrategy() };
@@ -52,8 +54,9 @@ namespace Scv.Api.Services.Files
                 locationService,
                 cache,
                 claimsPrincipal,
-                factory.CreateLogger<CivilFilesService>());
-            Criminal = new CriminalFilesService(configuration, filesClient, mapper, lookupService, locationService, cache, claimsPrincipal, documentConverter);
+                factory.CreateLogger<CivilFilesService>(),
+                pcssFileDetailClient);
+            Criminal = new CriminalFilesService(configuration, filesClient, mapper, lookupService, locationService, cache, claimsPrincipal, documentConverter, pcssFileDetailClient);
 
             _applicationCode = configuration.GetNonEmptyValue("Request:ApplicationCd");
             _requestAgencyIdentifierId = claimsPrincipal?.AgencyCode() ?? configuration.GetNonEmptyValue("Request:AgencyIdentifierId");

--- a/pcss-client/Clients/FileDetailServicesClient.cs
+++ b/pcss-client/Clients/FileDetailServicesClient.cs
@@ -61,7 +61,7 @@ public partial class FileDetailClient
 
     /// <returns>OK</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task<object> GetCriminalFileDetailAsync(int justinNo)
+    public virtual System.Threading.Tasks.Task<CriminalFileDetail> GetCriminalFileDetailAsync(int justinNo)
     {
         return GetCriminalFileDetailAsync(justinNo, System.Threading.CancellationToken.None);
     }
@@ -69,7 +69,7 @@ public partial class FileDetailClient
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>OK</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task<object> GetCriminalFileDetailAsync(int justinNo, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task<CriminalFileDetail> GetCriminalFileDetailAsync(int justinNo, System.Threading.CancellationToken cancellationToken)
     {
         if (justinNo == null)
             throw new System.ArgumentNullException("justinNo");
@@ -114,7 +114,7 @@ public partial class FileDetailClient
                     var status_ = (int)response_.StatusCode;
                     if (status_ == 200)
                     {
-                        var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                        var objectResponse_ = await ReadObjectResponseAsync<CriminalFileDetail>(response_, headers_, cancellationToken).ConfigureAwait(false);
                         if (objectResponse_.Object == null)
                         {
                             throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -143,7 +143,7 @@ public partial class FileDetailClient
 
     /// <returns>OK</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task<object> GetCivilFileDetailAsync(double physicalFileId)
+    public virtual System.Threading.Tasks.Task<CivilFileDetail> GetCivilFileDetailAsync(double physicalFileId)
     {
         return GetCivilFileDetailAsync(physicalFileId, System.Threading.CancellationToken.None);
     }
@@ -151,7 +151,7 @@ public partial class FileDetailClient
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>OK</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task<object> GetCivilFileDetailAsync(double physicalFileId, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task<CivilFileDetail> GetCivilFileDetailAsync(double physicalFileId, System.Threading.CancellationToken cancellationToken)
     {
         if (physicalFileId == null)
             throw new System.ArgumentNullException("physicalFileId");
@@ -196,7 +196,7 @@ public partial class FileDetailClient
                     var status_ = (int)response_.StatusCode;
                     if (status_ == 200)
                     {
-                        var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                        var objectResponse_ = await ReadObjectResponseAsync<CivilFileDetail>(response_, headers_, cancellationToken).ConfigureAwait(false);
                         if (objectResponse_.Object == null)
                         {
                             throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -1141,7 +1141,7 @@ public partial class FileDetailClient
         return result == null ? "" : result;
     }
 
-        [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))")]
+    [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class ApiException : System.Exception
     {
         public int StatusCode { get; private set; }

--- a/pcss-client/Models/ActivityAppearanceDetail.cs
+++ b/pcss-client/Models/ActivityAppearanceDetail.cs
@@ -1,0 +1,38 @@
+﻿namespace PCSSCommon.Models;
+
+public partial class ActivityClassUsage
+{
+    public partial class PcssCounsel
+    {
+        public partial class ActivityAppearanceDetail
+        {
+            public List<string> CounselNames
+            {
+                get
+                {
+                    if (CounselNameDescriptor.IsSelfRepresented(SelfRepresentedYn))
+                    {
+                        return [CounselNameDescriptor.SELF_REPRESENTED];
+                    }
+
+                    if (Counsel is { Count: > 0 })
+                    {
+                        return [.. Counsel.Where(c => c != null).Select(CounselNameDescriptor.FullName)];
+                    }
+
+                    if (JustinCounsel is { } justinCounsel)
+                    {
+                        return [$"{justinCounsel.GivenNm} {justinCounsel.LastNm}".Trim()];
+                    }
+
+                    if (CeisCounsel is { } ceisCounsel)
+                    {
+                        return [.. ceisCounsel.Where(c => c != null).Select(c => c.FullNm)];
+                    }
+
+                    return [];
+                }
+            }
+        }
+    }
+}

--- a/pcss-client/Models/CivilFileDetails.cs
+++ b/pcss-client/Models/CivilFileDetails.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public class CivilFileDetail
 {
-    public List<CivilParty> Party { get; set; }
+    public List<CivilParty> Party { get; set; } = [];
 }
 
 public class CivilParty

--- a/pcss-client/Models/CivilFileDetails.cs
+++ b/pcss-client/Models/CivilFileDetails.cs
@@ -1,0 +1,22 @@
+﻿namespace PCSSCommon.Models;
+
+/// <summary>
+/// CivilFileDetail has been stripped-down to only the properties JASPER needs.
+/// </summary>
+public class CivilFileDetail
+{
+    public List<CivilParty> Party { get; set; }
+}
+
+public class CivilParty
+{
+    public string PartyId { get; set; }
+    public string SelfRepresentedYn { get; set; }
+    public Counsel Counsel { get; set; }
+    public List<CeisCounsel> CeisCounsel { get; set; }
+}
+
+public class CeisCounsel
+{
+    public string FullNm { get; set; }
+}

--- a/pcss-client/Models/CounselNameDescriptor.cs
+++ b/pcss-client/Models/CounselNameDescriptor.cs
@@ -1,0 +1,55 @@
+﻿using static PCSSCommon.Models.ActivityClassUsage;
+
+namespace PCSSCommon.Models;
+
+public static class CounselNameDescriptor
+{
+    public const string SELF_REPRESENTED = "Self-Represented";
+
+    public static bool IsSelfRepresented(string selfRepresentedYn) =>
+        string.Equals(selfRepresentedYn, "Y", StringComparison.OrdinalIgnoreCase);
+
+    public static (string givenName, string lastName) ResolveName(Counsel counsel)
+    {
+        return Resolve(counsel.PrefNm, counsel.OrgNm, counsel.GivenNm, counsel.LastNm);
+    }
+
+    public static (string givenName, string lastName) ResolveName(PcssCounsel counsel)
+    {
+        return Resolve(counsel.PrefNm, counsel.OrgNm, counsel.GivenNm, counsel.LastNm);
+    }
+
+    public static string FullName(Counsel counsel)
+    {
+        var (givenName, lastName) = ResolveName(counsel);
+        return $"{givenName} {lastName}".Trim();
+    }
+
+    public static string FullName(PcssCounsel counsel)
+    {
+        var (givenName, lastName) = ResolveName(counsel);
+        return $"{givenName} {lastName}".Trim();
+    }
+
+
+    /// <summary>
+    // Mirrors PCSS's precedence for determining counsel name: PrefNm -> OrgNm -> person name.
+    /// </summary>
+    /// <param name="prefName">The preferred name of the counsel.</param>
+    /// <param name="orgName">The organization name of the counsel.</param>
+    /// <param name="givenName">The given name of the counsel.</param>
+    /// <param name="lastName">The last name of the counsel.</param>
+    /// <returns>A tuple containing the resolved given name and last name.</returns>
+    private static (string givenName, string lastName) Resolve(string prefName, string orgName, string givenName, string lastName)
+    {
+        if (!string.IsNullOrWhiteSpace(prefName))
+        {
+            return (string.Empty, prefName);
+        }
+        if (!string.IsNullOrWhiteSpace(orgName))
+        {
+            return (string.Empty, orgName);
+        }
+        return (givenName, lastName);
+    }
+}

--- a/pcss-client/Models/CounselNameDescriptor.cs
+++ b/pcss-client/Models/CounselNameDescriptor.cs
@@ -33,7 +33,7 @@ public static class CounselNameDescriptor
 
 
     /// <summary>
-    // Mirrors PCSS's precedence for determining counsel name: PrefNm -> OrgNm -> person name.
+    /// Mirrors PCSS's precedence for determining counsel name: PrefNm -> OrgNm -> person name.
     /// </summary>
     /// <param name="prefName">The preferred name of the counsel.</param>
     /// <param name="orgName">The organization name of the counsel.</param>

--- a/pcss-client/Models/CriminalFileDetail.cs
+++ b/pcss-client/Models/CriminalFileDetail.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public class CriminalFileDetail
 {
-    public List<Participant> Participant { get; set; }
+    public List<Participant> Participant { get; set; } = [];
 }
 
 public partial class Participant

--- a/pcss-client/Models/CriminalFileDetail.cs
+++ b/pcss-client/Models/CriminalFileDetail.cs
@@ -1,0 +1,31 @@
+﻿namespace PCSSCommon.Models;
+
+/// <summary>
+/// CriminalFileDetail has been stripped-down to only the properties JASPER needs.
+/// </summary>
+public class CriminalFileDetail
+{
+    public List<Participant> Participant { get; set; }
+}
+
+public partial class Participant
+{
+    public string PartId { get; set; }
+    public string SelfRepresentedYn { get; set; }
+    public Counsel Counsel { get; set; }
+    public JustinCounsel JustinCounsel { get; set; }
+}
+
+public class JustinCounsel
+{
+    public string LastNm { get; set; }
+    public string GivenNm { get; set; }
+}
+
+public class Counsel
+{
+    public string LastNm { get; set; }
+    public string GivenNm { get; set; }
+    public string PrefNm { get; set; }
+    public string OrgNm { get; set; }
+}

--- a/pcss-client/Models/Models.cs
+++ b/pcss-client/Models/Models.cs
@@ -3462,7 +3462,7 @@ public partial class ActivityClassUsage
             public string RemoteLocationNm { get; set; }
 
             [Newtonsoft.Json.JsonProperty("ceisCounsel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-            public object CeisCounsel { get; set; }
+            public List<CeisCounsel> CeisCounsel { get; set; }
 
             [Newtonsoft.Json.JsonProperty("justinApprId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
             public string JustinApprId { get; set; }

--- a/tests/api/Controllers/FilesControllerTests.cs
+++ b/tests/api/Controllers/FilesControllerTests.cs
@@ -28,6 +28,7 @@ using Scv.Models.Archive;
 using Scv.Models.Search;
 using tests.api.Helpers;
 using Xunit;
+using PCSSFileDetailServices = PCSSCommon.Clients.FileDetailServices;
 using PCSSLocationServices = PCSSCommon.Clients.LocationServices;
 using PCSSLookupServices = PCSSCommon.Clients.LookupServices;
 
@@ -105,7 +106,8 @@ namespace tests.api.Controllers
                 new CachingService(),
                 principal,
                 fileServices.LogFactory,
-                new Mock<IDocumentConverter>().Object);
+                new Mock<IDocumentConverter>().Object,
+                new Mock<PCSSFileDetailServices.FileDetailClient>().Object);
 
             var mockDocumentMerger = new Mock<IDocumentMerger>();
 

--- a/tests/api/Fixtures/FilesServiceFixture.cs
+++ b/tests/api/Fixtures/FilesServiceFixture.cs
@@ -16,6 +16,7 @@ using Scv.Api.Documents;
 using Scv.Api.Services;
 using Scv.Api.Services.Files;
 using Scv.Core.Helpers;
+using PCSSFileDetailServices = PCSSCommon.Clients.FileDetailServices;
 using PCSSLocationServices = PCSSCommon.Clients.LocationServices;
 using PCSSLookupServices = PCSSCommon.Clients.LookupServices;
 
@@ -40,6 +41,7 @@ public class FilesServiceFixture : IDisposable
     public Mock<ILoggerFactory> MockLoggerFactory { get; }
     public Mock<ILogger<CivilFilesService>> MockCivilLogger { get; }
     public Mock<IDocumentConverter> MockDocumentConverter { get; }
+    public Mock<PCSSFileDetailServices.FileDetailClient> MockPCSSFileDetailClient { get; }
     public IAppCache Cache { get; }
     public IMapper Mapper { get; }
     public ClaimsPrincipal Principal { get; private set; }
@@ -95,6 +97,7 @@ public class FilesServiceFixture : IDisposable
         // Client and service mocks
         MockFileServicesClient = new Mock<FileServicesClient>(MockBehavior.Strict, _httpClient);
         MockDocumentConverter = new Mock<IDocumentConverter>();
+        MockPCSSFileDetailClient = new Mock<PCSSFileDetailServices.FileDetailClient>(MockBehavior.Strict, _httpClient);
 
         // Logger setup
         MockLoggerFactory = new Mock<ILoggerFactory>();
@@ -164,7 +167,8 @@ public class FilesServiceFixture : IDisposable
             Cache,
             Principal,
             MockLoggerFactory.Object,
-            MockDocumentConverter.Object);
+            MockDocumentConverter.Object,
+            MockPCSSFileDetailClient.Object);
     }
 
     public FilesServiceFixture WithPrincipal(ClaimsPrincipal principal)

--- a/tests/api/Services/CivilFilesServiceTests.cs
+++ b/tests/api/Services/CivilFilesServiceTests.cs
@@ -150,6 +150,7 @@ public class CivilFilesServiceTests(FilesServiceFixture filesServiceFixture)
             _filesServiceFixture.MockLocationService.Object,
             _filesServiceFixture.Cache,
             _filesServiceFixture.Principal,
-            _filesServiceFixture.MockCivilLogger.Object);
+            _filesServiceFixture.MockCivilLogger.Object,
+            _filesServiceFixture.MockPCSSFileDetailClient.Object);
     }
 }

--- a/tests/pcss-client/Models/CounselNameDescriptorTests.cs
+++ b/tests/pcss-client/Models/CounselNameDescriptorTests.cs
@@ -1,0 +1,134 @@
+﻿using Bogus;
+using PCSSCommon.Models;
+using Xunit;
+using static PCSSCommon.Models.ActivityClassUsage;
+
+namespace tests.pcss_client.Models;
+
+public class CounselNameDescriptorTests
+{
+    private readonly Faker _faker = new();
+
+    [Theory]
+    [InlineData("Y", true)]
+    [InlineData("y", true)]
+    [InlineData("N", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("Yes", false)]
+    public void IsSelfRepresented_ReturnsExpected(string input, bool expected)
+    {
+        Assert.Equal(expected, CounselNameDescriptor.IsSelfRepresented(input));
+    }
+
+    [Fact]
+    public void ResolveName_PrefersPrefNm_OverEverything()
+    {
+        var prefNm = _faker.Name.FullName();
+        var counsel = new Counsel
+        {
+            PrefNm = prefNm,
+            OrgNm = _faker.Company.CompanyName(),
+            GivenNm = _faker.Name.FirstName(),
+            LastNm = _faker.Name.LastName()
+        };
+
+        var (given, last) = CounselNameDescriptor.ResolveName(counsel);
+
+        Assert.Equal(string.Empty, given);
+        Assert.Equal(prefNm, last);
+    }
+
+    [Fact]
+    public void ResolveName_UsesOrgNm_WhenPrefNmMissing()
+    {
+        var orgNm = _faker.Company.CompanyName();
+        var counsel = new Counsel
+        {
+            PrefNm = "   ",
+            OrgNm = orgNm,
+            GivenNm = _faker.Name.FirstName(),
+            LastNm = _faker.Name.LastName()
+        };
+
+        var (given, last) = CounselNameDescriptor.ResolveName(counsel);
+
+        Assert.Equal(string.Empty, given);
+        Assert.Equal(orgNm, last);
+    }
+
+    [Fact]
+    public void ResolveName_FallsBackToPersonName_WhenPrefAndOrgMissing()
+    {
+        var givenNm = _faker.Name.FirstName();
+        var lastNm = _faker.Name.LastName();
+        var counsel = new Counsel
+        {
+            PrefNm = null,
+            OrgNm = "",
+            GivenNm = givenNm,
+            LastNm = lastNm
+        };
+
+        var (given, last) = CounselNameDescriptor.ResolveName(counsel);
+
+        Assert.Equal(givenNm, given);
+        Assert.Equal(lastNm, last);
+    }
+
+    [Fact]
+    public void FullName_CombinesGivenAndLast()
+    {
+        var givenNm = _faker.Name.FirstName();
+        var lastNm = _faker.Name.LastName();
+        var counsel = new Counsel { GivenNm = givenNm, LastNm = lastNm };
+
+        Assert.Equal($"{givenNm} {lastNm}", CounselNameDescriptor.FullName(counsel));
+    }
+
+    [Fact]
+    public void FullName_TrimsWhenGivenNameIsEmpty()
+    {
+        var prefNm = _faker.Name.FullName();
+        var counsel = new Counsel { PrefNm = prefNm };
+
+        Assert.Equal(prefNm, CounselNameDescriptor.FullName(counsel));
+    }
+
+    [Fact]
+    public void FullName_UsesOrgName_WithoutLeadingSpace()
+    {
+        var orgNm = _faker.Company.CompanyName();
+        var counsel = new Counsel { OrgNm = orgNm };
+
+        Assert.Equal(orgNm, CounselNameDescriptor.FullName(counsel));
+    }
+
+    [Fact]
+    public void ResolveName_PcssCounsel_PrefersPrefNm()
+    {
+        var prefNm = _faker.Name.FullName();
+        var counsel = new PcssCounsel
+        {
+            PrefNm = prefNm,
+            OrgNm = _faker.Company.CompanyName(),
+            GivenNm = _faker.Name.FirstName(),
+            LastNm = _faker.Name.LastName()
+        };
+
+        var (given, last) = CounselNameDescriptor.ResolveName(counsel);
+
+        Assert.Equal(string.Empty, given);
+        Assert.Equal(prefNm, last);
+    }
+
+    [Fact]
+    public void FullName_PcssCounsel_CombinesPersonName()
+    {
+        var givenNm = _faker.Name.FirstName();
+        var lastNm = _faker.Name.LastName();
+        var counsel = new PcssCounsel { GivenNm = givenNm, LastNm = lastNm };
+
+        Assert.Equal($"{givenNm} {lastNm}", CounselNameDescriptor.FullName(counsel));
+    }
+}

--- a/web/src/components/case-details/civil/children/Child.vue
+++ b/web/src/components/case-details/civil/children/Child.vue
@@ -40,7 +40,7 @@
     child: partyType;
   }>();
 
-  const counselNames = props.child.counsel?.map((c) => c.counselFullName) ?? [];
+  const counselNames = props.child.counsel?.map((c) => c.fullNm) ?? [];
   const name = computed(() => {
     const { lastNm, givenNm, orgNm } = props.child;
     return lastNm ? formatToFullName(lastNm, givenNm) : orgNm;

--- a/web/src/components/case-details/civil/parties/Party.vue
+++ b/web/src/components/case-details/civil/parties/Party.vue
@@ -53,10 +53,7 @@
     smallClaims.includes(props.courtClassCd) &&
     props.party.aliases &&
     props.party.aliases.length > 0;
-  const counselNames =
-    props.party.selfRepresentedYN === 'Y'
-      ? ['Self-Represented']
-      : (props.party.counsel?.map((c) => c.counselFullName) ?? []);
+  const counselNames = props.party.counsel?.map((c) => c.fullNm) ?? [];
   const aliases =
     props.party.aliases?.map((a) =>
       a.surnameNm && a.firstGivenNm

--- a/web/src/components/case-details/common/accused/Accused.vue
+++ b/web/src/components/case-details/common/accused/Accused.vue
@@ -73,16 +73,16 @@
 
 <script setup lang="ts">
   import FileMarkers from '@/components/shared/FileMarkers.vue';
-import { CourtClassEnum, FileMarkerEnum } from '@/types/common';
-import {
-  ClAgeNotice,
-  criminalParticipantType,
-} from '@/types/criminal/jsonTypes';
-import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
-import { getEnumName } from '@/utils/utils';
-import { mdiInformationSlabCircleOutline } from '@mdi/js';
-import { computed, ref } from 'vue';
-import Bans from './Bans.vue';
+  import { CourtClassEnum, FileMarkerEnum } from '@/types/common';
+  import {
+    ClAgeNotice,
+    criminalParticipantType,
+  } from '@/types/criminal/jsonTypes';
+  import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
+  import { getEnumName } from '@/utils/utils';
+  import { mdiInformationSlabCircleOutline } from '@mdi/js';
+  import { computed, ref } from 'vue';
+  import Bans from './Bans.vue';
 
   const props = defineProps<{
     accused: criminalParticipantType;
@@ -109,7 +109,7 @@ import Bans from './Bans.vue';
       return '';
     }
     return counselGivenNm
-      ? `${counselLastNm}, ${counselGivenNm}`
+      ? `${counselGivenNm} ${counselLastNm}`
       : counselLastNm;
   });
   const groupedBans = computed(() =>

--- a/web/src/components/case-details/common/accused/Accused.vue
+++ b/web/src/components/case-details/common/accused/Accused.vue
@@ -73,16 +73,16 @@
 
 <script setup lang="ts">
   import FileMarkers from '@/components/shared/FileMarkers.vue';
-  import { CourtClassEnum, FileMarkerEnum } from '@/types/common';
-  import {
-    ClAgeNotice,
-    criminalParticipantType,
-  } from '@/types/criminal/jsonTypes';
-  import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
-  import { getEnumName } from '@/utils/utils';
-  import { mdiInformationSlabCircleOutline } from '@mdi/js';
-  import { computed, ref } from 'vue';
-  import Bans from './Bans.vue';
+import { CourtClassEnum, FileMarkerEnum } from '@/types/common';
+import {
+  ClAgeNotice,
+  criminalParticipantType,
+} from '@/types/criminal/jsonTypes';
+import { formatDateToDDMMMYYYY } from '@/utils/dateUtils';
+import { getEnumName } from '@/utils/utils';
+import { mdiInformationSlabCircleOutline } from '@mdi/js';
+import { computed, ref } from 'vue';
+import Bans from './Bans.vue';
 
   const props = defineProps<{
     accused: criminalParticipantType;
@@ -103,11 +103,15 @@
     return hasNoticeTo && hasProofOfAge ? 'Yes' : 'No';
   });
   const showBanModal = ref(false);
-  const counselName = computed(() =>
-    props.accused.counselLastNm && props.accused.counselGivenNm
-      ? `${props.accused.counselLastNm.toUpperCase()}, ${props.accused.counselGivenNm}`
-      : ''
-  );
+  const counselName = computed(() => {
+    const { counselLastNm, counselGivenNm } = props.accused;
+    if (!counselLastNm) {
+      return '';
+    }
+    return counselGivenNm
+      ? `${counselLastNm}, ${counselGivenNm}`
+      : counselLastNm;
+  });
   const groupedBans = computed(() =>
     props.accused.ban.reduce(
       (acc, ban) => {

--- a/web/src/components/courtlist/CourtListTable.vue
+++ b/web/src/components/courtlist/CourtListTable.vue
@@ -269,7 +269,7 @@
       title: 'COUNSEL',
       key: 'counselNames',
       value: (item: CourtListAppearance) =>
-        renderCounselNames(item.counselNames ?? []),
+        renderCounselNames(item.counselNames),
     },
     { title: 'CROWN', key: 'crown' },
     {

--- a/web/src/components/courtlist/CourtListTable.vue
+++ b/web/src/components/courtlist/CourtListTable.vue
@@ -111,27 +111,19 @@
         </template>
       </v-tooltip>
     </template>
-    <template v-slot:[`item.counsel`]="{ item, value }">
+    <template v-slot:[`item.counselNames`]="{ item, value }">
       <v-tooltip
-        :disabled="
-          (item.counsel?.length ?? 0) + (item.accusedCounselNm ? 1 : 0) < 2
-        "
+        :disabled="(item.counselNames?.length ?? 0) < 2"
         location="top"
       >
         <template #activator="{ props }">
           <span
             v-bind="props"
-            :class="{
-              'has-tooltip':
-                (item?.accusedCounselNm ? 1 : 0) + (item.counsel?.length ?? 0) >
-                1,
-            }"
+            :class="{ 'has-tooltip': (item.counselNames?.length ?? 0) > 1 }"
             >{{ value }}</span
           >
         </template>
-        <span
-          v-html="renderCounselTooltip(item.accusedCounselNm, item.counsel)"
-        ></span>
+        <span v-html="renderCounselTooltip(item.counselNames)"></span>
       </v-tooltip>
     </template>
     <template v-slot:[`item.crown`]="{ value }">
@@ -171,17 +163,18 @@
   import { bannerClasses } from '@/constants/bannerClasses';
   import { useCourtFileSearchStore } from '@/stores';
   import {
-    CourtLevelEnum,
     CourtClassEnum,
+    CourtLevelEnum,
     DivisionEnum,
     FileMarkerEnum,
     KeyValueInfo,
   } from '@/types/common';
-  import { CourtListAppearance, PcssCounsel } from '@/types/courtlist';
+  import { CourtListAppearance } from '@/types/courtlist';
   import { BinderRequest } from '@/types/DocumentBundleRequest';
   import { hoursMinsFormatter } from '@/utils/dateUtils';
   import { getCourtClassLabel, getEnumName } from '@/utils/utils';
   import {
+    mdiBank,
     mdiCheck,
     mdiChevronDown,
     mdiChevronUp,
@@ -189,7 +182,6 @@
     mdiHomeOutline,
     mdiNotebookOutline,
     mdiTrashCanOutline,
-    mdiBank,
   } from '@mdi/js';
   import { computed, ref } from 'vue';
 
@@ -266,9 +258,9 @@
     { title: 'FILE MARKERS', key: 'fileMarkers', sortable: false },
     {
       title: 'COUNSEL',
-      key: 'counsel',
+      key: 'counselNames',
       value: (item: CourtListAppearance) =>
-        renderName(item.counsel ?? [], item.accusedCounselNm),
+        renderCounselNames(item.counselNames ?? []),
     },
     { title: 'CROWN', key: 'crown' },
     {
@@ -301,10 +293,16 @@
     return count > 1 ? `${name} +${count - 1}` : name;
   };
 
-  const renderCounselTooltip = (
-    accusedCounselNm: string,
-    counsel: PcssCounsel[] | undefined
-  ) => renderTooltip(counsel ?? [], accusedCounselNm);
+  const renderCounselNames = (names: string[]) => {
+    if (!names.length) {
+      return '';
+    }
+    const [first] = names;
+    return names.length > 1 ? `${first} +${names.length - 1}` : first;
+  };
+
+  const renderCounselTooltip = (names: string[] | undefined) =>
+    names?.join('<br/>') ?? '';
 
   const splitNames = (name: string) => {
     const [firstName, lastName] = name.split(' ');

--- a/web/src/components/courtlist/CourtListTable.vue
+++ b/web/src/components/courtlist/CourtListTable.vue
@@ -125,8 +125,7 @@
         </template>
         <span>
           <template v-for="(name, i) in item.counselNames" :key="i">
-            {{ name
-            }}<br v-if="i < (item.counselNames?.length ?? 0) - 1" />
+            {{ name }}<br v-if="i < (item.counselNames?.length ?? 0) - 1" />
           </template>
         </span>
       </v-tooltip>

--- a/web/src/components/courtlist/CourtListTable.vue
+++ b/web/src/components/courtlist/CourtListTable.vue
@@ -123,7 +123,12 @@
             >{{ value }}</span
           >
         </template>
-        <span v-html="renderCounselTooltip(item.counselNames)"></span>
+        <span>
+          <template v-for="(name, i) in item.counselNames" :key="i">
+            {{ name
+            }}<br v-if="i < (item.counselNames?.length ?? 0) - 1" />
+          </template>
+        </span>
       </v-tooltip>
     </template>
     <template v-slot:[`item.crown`]="{ value }">
@@ -133,7 +138,12 @@
             {{ renderName(value) }}
           </span>
         </template>
-        <span v-html="renderTooltip(value)"></span>
+        <span>
+          <template v-for="(person, i) in value" :key="i">
+            {{ person?.lastNm }}, {{ person?.givenNm
+            }}<br v-if="Number(i) < value.length - 1" />
+          </template>
+        </span>
       </v-tooltip>
     </template>
     <template v-slot:[`item.actions`]="{ item }">
@@ -271,16 +281,6 @@
     { title: 'NOTES', key: 'actions', width: '5%', sortable: false },
   ]);
 
-  const renderTooltip = (items: any[], additionalItem?: string) => {
-    let tooltip =
-      items?.map((item) => `${item?.lastNm}, ${item?.givenNm}`).join('<br/>') ||
-      '';
-    if (additionalItem) {
-      tooltip += `${tooltip ? '<br/>' : ''}${splitNames(additionalItem)}`;
-    }
-    return tooltip;
-  };
-
   const renderName = (items: any[], additionalItem?: string) => {
     if (!items?.length && !additionalItem) {
       return '';
@@ -300,9 +300,6 @@
     const [first] = names;
     return names.length > 1 ? `${first} +${names.length - 1}` : first;
   };
-
-  const renderCounselTooltip = (names: string[] | undefined) =>
-    names?.join('<br/>') ?? '';
 
   const splitNames = (name: string) => {
     const [firstName, lastName] = name.split(' ');

--- a/web/src/types/civil/jsonTypes/index.ts
+++ b/web/src/types/civil/jsonTypes/index.ts
@@ -15,7 +15,7 @@ export interface partyAliasType {
 
 export interface partyCounselType {
   counselId: string;
-  counselFullName: string;
+  fullNm: string;
 }
 
 export interface partyType {

--- a/web/src/types/courtlist/index.ts
+++ b/web/src/types/courtlist/index.ts
@@ -301,6 +301,7 @@ export interface CourtListAppearance {
   otherRepresentedYn: string;
   linkedCounsel?: PcssCounsel;
   aslFeederAdjudicators?: any[];
+  counselNames: string[];
 }
 
 export interface CourtActivityDetail {

--- a/web/tests/components/case-details/civil/parties/Party.test.ts
+++ b/web/tests/components/case-details/civil/parties/Party.test.ts
@@ -1,5 +1,9 @@
 import Party from '@/components/case-details/civil/parties/Party.vue';
-import { partyAliasType, partyType } from '@/types/civil/jsonTypes';
+import {
+  partyAliasType,
+  partyCounselType,
+  partyType,
+} from '@/types/civil/jsonTypes';
 import { CourtClassEnum } from '@/types/common';
 import { faker } from '@faker-js/faker';
 import { shallowMount } from '@vue/test-utils';
@@ -50,11 +54,15 @@ describe('Party.vue', () => {
     expect(labelWithTooltip.length).toBe(1);
   });
 
-  it('renders Party component with "Self-Represented" Counsel', () => {
+  it('renders Party component with Counsel info', () => {
     const mockParty = {
       givenNm: faker.person.firstName(),
       lastNm: faker.person.lastName(),
-      selfRepresentedYN: 'Y',
+      counsel: [
+        {
+          fullNm: faker.person.fullName(),
+        },
+      ],
     } as partyType;
     const wrapper = shallowMount(Party, {
       props: {
@@ -67,7 +75,7 @@ describe('Party.vue', () => {
     const lastRow = rows[rows.length - 1];
     const label = lastRow.findComponent({ name: 'LabelWithTooltip' });
 
-    expect(label.attributes('values')).toBe('Self-Represented');
+    expect(label.attributes('values')).toBe(mockParty.counsel[0].fullNm);
   });
 
   it('renders Party with alias data for Small Claims case', () => {

--- a/web/tests/components/case-details/civil/parties/Party.test.ts
+++ b/web/tests/components/case-details/civil/parties/Party.test.ts
@@ -1,9 +1,5 @@
 import Party from '@/components/case-details/civil/parties/Party.vue';
-import {
-  partyAliasType,
-  partyCounselType,
-  partyType,
-} from '@/types/civil/jsonTypes';
+import { partyAliasType, partyType } from '@/types/civil/jsonTypes';
 import { CourtClassEnum } from '@/types/common';
 import { faker } from '@faker-js/faker';
 import { shallowMount } from '@vue/test-utils';

--- a/web/tests/components/case-details/common/accused/Accused.test.ts
+++ b/web/tests/components/case-details/common/accused/Accused.test.ts
@@ -6,23 +6,23 @@ import { beforeEach, describe, expect, it } from 'vitest';
 describe('Accused.vue', () => {
   const ageNoticeMock = [
     {
-      eventDate: "2022-08-10 00:00:00.0",
-      eventTypeDsc: "Notice to",
-      noticeTo: "Garrett Green (social worker)",
-      DOB: "",
-      relationship: "",
-      provenBy: "",
-      detailText: ""
+      eventDate: '2022-08-10 00:00:00.0',
+      eventTypeDsc: 'Notice to',
+      noticeTo: 'Garrett Green (social worker)',
+      DOB: '',
+      relationship: '',
+      provenBy: '',
+      detailText: '',
     },
     {
-      eventDate: "2022-08-10 00:00:00.0",
-      eventTypeDsc: "Proof of Age",
-      noticeTo: "",
-      DOB: "2005-02-25 00:00:00.0",
-      relationship: "SOWORKER",
-      provenBy: "Garrett GREEN",
-      detailText: ""
-    }
+      eventDate: '2022-08-10 00:00:00.0',
+      eventTypeDsc: 'Proof of Age',
+      noticeTo: '',
+      DOB: '2005-02-25 00:00:00.0',
+      relationship: 'SOWORKER',
+      provenBy: 'Garrett GREEN',
+      detailText: '',
+    },
   ];
   const accusedMock = {
     lastNm: 'Doe',
@@ -36,7 +36,7 @@ describe('Accused.vue', () => {
     counselLastNm: 'Smith',
     counselGivenNm: 'Jane',
     designatedCounselYN: 'Yes',
-    ageNotice: ageNoticeMock
+    ageNotice: ageNoticeMock,
   } as criminalParticipantType;
 
   const appearancesMock = [{}, {}, {}];
@@ -45,7 +45,11 @@ describe('Accused.vue', () => {
 
   beforeEach(() => {
     wrapper = mount(Accused, {
-      props: { accused: accusedMock, appearances: appearancesMock, courtClassCd: 'A' },
+      props: {
+        accused: accusedMock,
+        appearances: appearancesMock,
+        courtClassCd: 'A',
+      },
     });
   });
 
@@ -76,12 +80,14 @@ describe('Accused.vue', () => {
     expect(dobText).toBe('01-Jan-1990');
   });
 
-  it('renders counsel last name in uppercase', () => {
+  it('renders counsel first and last name', () => {
     const counselText = wrapper
       .findAll('v-row')[4]
       .find('v-col:last-child')
       .text();
-    expect(counselText).toBe('SMITH, Jane');
+    expect(counselText).toBe(
+      `${accusedMock.counselGivenNm} ${accusedMock.counselLastNm}`
+    );
   });
 
   it('renders designated counsel status', () => {
@@ -107,27 +113,39 @@ describe('Accused.vue', () => {
   });
 
   it('does not render Age/Notice when non youth file', () => {
-    const ageNoticeLabel = wrapper.findAll('v-col.data-label').filter(col => col.text() === 'Age/Notice');
+    const ageNoticeLabel = wrapper
+      .findAll('v-col.data-label')
+      .filter((col) => col.text() === 'Age/Notice');
     expect(ageNoticeLabel.length).toBe(0);
   });
 
   it('renders Age/Notice when youth file', () => {
-      wrapper = mount(Accused, {
-        props: { accused: accusedMock, appearances: appearancesMock, courtClassCd: 'Y' },
-      });
-      const ageNoticeLabel = wrapper.findAll('v-col.data-label').filter(col => col.text() === 'Age/Notice');
-      expect(ageNoticeLabel.length).toBe(1);
+    wrapper = mount(Accused, {
+      props: {
+        accused: accusedMock,
+        appearances: appearancesMock,
+        courtClassCd: 'Y',
+      },
+    });
+    const ageNoticeLabel = wrapper
+      .findAll('v-col.data-label')
+      .filter((col) => col.text() === 'Age/Notice');
+    expect(ageNoticeLabel.length).toBe(1);
   });
 
-    it('computes Age/Notice as Yes', () => {
-      expect(wrapper.vm.ageNotice).toEqual('Yes');
-    });
+  it('computes Age/Notice as Yes', () => {
+    expect(wrapper.vm.ageNotice).toEqual('Yes');
+  });
 
-    it('computes Age/Notice as No', () => {
-      ageNoticeMock[0].eventTypeDsc = 'Nope';
-      wrapper = mount(Accused, {
-        props: { accused: accusedMock, appearances: appearancesMock, courtClassCd: 'Y' },
-      });
-      expect(wrapper.vm.ageNotice).toEqual('No');
+  it('computes Age/Notice as No', () => {
+    ageNoticeMock[0].eventTypeDsc = 'Nope';
+    wrapper = mount(Accused, {
+      props: {
+        accused: accusedMock,
+        appearances: appearancesMock,
+        courtClassCd: 'Y',
+      },
     });
+    expect(wrapper.vm.ageNotice).toEqual('No');
+  });
 });


### PR DESCRIPTION
# Pull Request for JIRA Ticket: JASPER-739

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-739

## Description
The counsel information displayed in JASPER was inconsistent with what appears in PCSS. After investigation, we found that the counsel data returned by JC can be inaccurate. To ensure consistency, this change updates JASPER to source counsel information from PCSS instead.

During the fix, we also discovered that PCSS applies specific logic to determine the correct counsel to display. This PR replicates that logic so JASPER matches the behavior seen in PCSS.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Local

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x]  Any dependent changes have been merged and published in downstream modules   