### PR TITLE
Fix race condition in FileViewer by fetching order explicitly when viewing addtl supporting docs

### DIFF
--- a/api/Controllers/OrdersController.cs
+++ b/api/Controllers/OrdersController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Scv.Api.Infrastructure.Authorization;
+using Scv.Api.Infrastructure.Validation;
 using Scv.Api.Services;
 using Scv.Core.Helpers.Extensions;
 using Scv.Core.Infrastructure;
@@ -45,10 +46,14 @@ public class OrdersController(
     [HttpGet]
     [Authorize(AuthenticationSchemes = "SiteMinder, OpenIdConnect", Policy = nameof(ProviderAuthorizationHandler))]
     [Route("{id}")]
-    public async Task<IActionResult> GetOrder(string id)
+    public async Task<IActionResult> GetOrder([FromRoute, ObjectId] string id)
     {
-        var judgeOrders = await _orderService.GetOrderById(id, this.User.JudgeId());
-        return Ok(judgeOrders);
+        var judgeOrder = await _orderService.GetOrderByIdAsync(id, this.User.JudgeId());
+        if (judgeOrder == null)
+        {
+            return NotFound("Order not found.");
+        }
+        return Ok(judgeOrder);
     }
 
     /// <summary>
@@ -98,7 +103,9 @@ public class OrdersController(
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> ReviewOrder(string id, [FromBody] OrderReviewDto orderReview)
+    public async Task<IActionResult> ReviewOrder(
+        [FromRoute, ObjectId] string id,
+        [FromBody] OrderReviewDto orderReview)
     {
         var result = await _orderService.ReviewOrder(id, orderReview);
 

--- a/api/Controllers/OrdersController.cs
+++ b/api/Controllers/OrdersController.cs
@@ -38,6 +38,20 @@ public class OrdersController(
     }
 
     /// <summary>
+    /// Retrieves a specific order by its ID for the judge.
+    /// </summary>
+    /// <param name="id">The ID of the order.</param>
+    /// <returns>The order details.</returns>
+    [HttpGet]
+    [Authorize(AuthenticationSchemes = "SiteMinder, OpenIdConnect", Policy = nameof(ProviderAuthorizationHandler))]
+    [Route("{id}")]
+    public async Task<IActionResult> GetOrder(string id)
+    {
+        var judgeOrders = await _orderService.GetOrderById(id, this.User.JudgeId());
+        return Ok(judgeOrders);
+    }
+
+    /// <summary>
     /// Create/Update an order to notify that there is a document requiring annotation for a judge. This endpoint is used by external systems to create or update orders.
     /// </summary>
     /// <param name="orderRequestDto">The Order payload (supports snake_case, PascalCase, camelCase and case-insensitive)</param>

--- a/api/Infrastructure/Validation/ObjectIdAttribute.cs
+++ b/api/Infrastructure/Validation/ObjectIdAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson;
+
+namespace Scv.Api.Infrastructure.Validation;
+
+/// <summary>
+/// Validates that a route/query value is a well-formed MongoDB ObjectId.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
+public sealed class ObjectIdAttribute : ValidationAttribute
+{
+    public ObjectIdAttribute() : base("Invalid id.") { }
+
+    public override bool IsValid(object value) =>
+        value is string id && ObjectId.TryParse(id, out _);
+}

--- a/api/Services/OrderService.cs
+++ b/api/Services/OrderService.cs
@@ -33,6 +33,7 @@ public interface IOrderService : ICrudService<OrderDto>
     Task<OperationResult> ReviewOrder(string id, OrderReviewDto orderReview);
     Task<IEnumerable<OrderViewDto>> GetJudgeOrdersAsync(int judgeId);
     Task<OperationResult> SubmitOrder(string id);
+    Task<OrderViewDto> GetOrderById(string id, int judgeId);
 }
 
 public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, OrderDto>, IOrderService
@@ -303,9 +304,9 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
             double documentId = orderDto.OrderRequest?.Referral?.ReferredDocumentId.GetValueOrDefault() ?? 0;
 
             await _judicialClient.SaveJudicialActionAsync(
-                correlationId,
-                documentId,
-                actionDto);
+               correlationId,
+               documentId,
+               actionDto);
 
             // Cleanup the successful, submitted order to remove potentially private document data and comments.
             orderDto.DocumentData = null;
@@ -332,6 +333,16 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
                 ? OperationResult.Failure("Failed to submit order to CSO.")
                 : errorResult;
         }
+    }
+
+    public async Task<OrderViewDto> GetOrderById(string id, int judgeId)
+    {
+        var order = await Repo.GetByIdAsync(id);
+        if (order == null || order.JudgeId != judgeId)
+        {
+            return null;
+        }
+        return Mapper.Map<OrderViewDto>(order);
     }
 
     #region Private Methods

--- a/api/Services/OrderService.cs
+++ b/api/Services/OrderService.cs
@@ -304,9 +304,9 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
             double documentId = orderDto.OrderRequest?.Referral?.ReferredDocumentId.GetValueOrDefault() ?? 0;
 
             await _judicialClient.SaveJudicialActionAsync(
-               correlationId,
-               documentId,
-               actionDto);
+                correlationId,
+                documentId,
+                actionDto);
 
             // Cleanup the successful, submitted order to remove potentially private document data and comments.
             orderDto.DocumentData = null;

--- a/api/Services/OrderService.cs
+++ b/api/Services/OrderService.cs
@@ -33,7 +33,7 @@ public interface IOrderService : ICrudService<OrderDto>
     Task<OperationResult> ReviewOrder(string id, OrderReviewDto orderReview);
     Task<IEnumerable<OrderViewDto>> GetJudgeOrdersAsync(int judgeId);
     Task<OperationResult> SubmitOrder(string id);
-    Task<OrderViewDto> GetOrderById(string id, int judgeId);
+    Task<OrderViewDto> GetOrderByIdAsync(string id, int judgeId);
 }
 
 public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, OrderDto>, IOrderService
@@ -335,7 +335,7 @@ public class OrderService : CrudServiceBase<IRepositoryBase<Order>, Order, Order
         }
     }
 
-    public async Task<OrderViewDto> GetOrderById(string id, int judgeId)
+    public async Task<OrderViewDto> GetOrderByIdAsync(string id, int judgeId)
     {
         var order = await Repo.GetByIdAsync(id);
         if (order == null || order.JudgeId != judgeId)

--- a/models/Order/OrderViewDto.cs
+++ b/models/Order/OrderViewDto.cs
@@ -19,4 +19,5 @@ public class OrderViewDto : BaseDto
     public string ReferralNotes { get; set; }
     public List<PackageDocumentDto> PackageDocuments { get; set; } = [];
     public List<RelevantCeisDocumentDto> RelevantCeisDocuments { get; set; } = [];
+    public bool HasSupportingDocs => (this.PackageDocuments?.Any(pd => !pd.ReferredDocument) == true) || (this.RelevantCeisDocuments?.Count > 0);
 }

--- a/tests/api/Controllers/OrdersControllerTests.cs
+++ b/tests/api/Controllers/OrdersControllerTests.cs
@@ -518,30 +518,30 @@ public class OrdersControllerTests
         var order = new OrderViewDto();
 
         _mockOrderService
-            .Setup(s => s.GetOrderById(orderId, _judgeId))
+            .Setup(s => s.GetOrderByIdAsync(orderId, _judgeId))
             .ReturnsAsync(order);
 
         var result = await _controller.GetOrder(orderId);
 
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.Same(order, okResult.Value);
-        _mockOrderService.Verify(s => s.GetOrderById(orderId, _judgeId), Times.Once);
+        _mockOrderService.Verify(s => s.GetOrderByIdAsync(orderId, _judgeId), Times.Once);
     }
 
     [Fact]
-    public async Task GetOrder_ReturnsOk_WithNull_WhenOrderDoesNotExist()
+    public async Task GetOrder_ReturnsNotFound_WhenOrderDoesNotExist()
     {
         var orderId = _faker.Random.AlphaNumeric(24);
 
         _mockOrderService
-            .Setup(s => s.GetOrderById(orderId, _judgeId))
+            .Setup(s => s.GetOrderByIdAsync(orderId, _judgeId))
             .ReturnsAsync((OrderViewDto)null);
 
         var result = await _controller.GetOrder(orderId);
 
-        var okResult = Assert.IsType<OkObjectResult>(result);
-        Assert.Null(okResult.Value);
-        _mockOrderService.Verify(s => s.GetOrderById(orderId, _judgeId), Times.Once);
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.NotNull(notFoundResult.Value);
+        _mockOrderService.Verify(s => s.GetOrderByIdAsync(orderId, _judgeId), Times.Once);
     }
 
     [Fact]
@@ -550,12 +550,12 @@ public class OrdersControllerTests
         var orderId = _faker.Random.AlphaNumeric(24);
 
         _mockOrderService
-            .Setup(s => s.GetOrderById(It.IsAny<string>(), It.IsAny<int>()))
+            .Setup(s => s.GetOrderByIdAsync(It.IsAny<string>(), It.IsAny<int>()))
             .ReturnsAsync(new OrderViewDto());
 
         await _controller.GetOrder(orderId);
 
-        _mockOrderService.Verify(s => s.GetOrderById(orderId, _judgeId), Times.Once);
+        _mockOrderService.Verify(s => s.GetOrderByIdAsync(orderId, _judgeId), Times.Once);
     }
 
     #endregion

--- a/tests/api/Controllers/OrdersControllerTests.cs
+++ b/tests/api/Controllers/OrdersControllerTests.cs
@@ -509,6 +509,57 @@ public class OrdersControllerTests
 
     #endregion
 
+    #region GetOrder Tests
+
+    [Fact]
+    public async Task GetOrder_ReturnsOk_WithOrder_WhenOrderExists()
+    {
+        var orderId = _faker.Random.AlphaNumeric(24);
+        var order = new OrderViewDto();
+
+        _mockOrderService
+            .Setup(s => s.GetOrderById(orderId, _judgeId))
+            .ReturnsAsync(order);
+
+        var result = await _controller.GetOrder(orderId);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(order, okResult.Value);
+        _mockOrderService.Verify(s => s.GetOrderById(orderId, _judgeId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrder_ReturnsOk_WithNull_WhenOrderDoesNotExist()
+    {
+        var orderId = _faker.Random.AlphaNumeric(24);
+
+        _mockOrderService
+            .Setup(s => s.GetOrderById(orderId, _judgeId))
+            .ReturnsAsync((OrderViewDto)null);
+
+        var result = await _controller.GetOrder(orderId);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Null(okResult.Value);
+        _mockOrderService.Verify(s => s.GetOrderById(orderId, _judgeId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrder_UsesAuthenticatedJudgeId()
+    {
+        var orderId = _faker.Random.AlphaNumeric(24);
+
+        _mockOrderService
+            .Setup(s => s.GetOrderById(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync(new OrderViewDto());
+
+        await _controller.GetOrder(orderId);
+
+        _mockOrderService.Verify(s => s.GetOrderById(orderId, _judgeId), Times.Once);
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private OrderRequestDto CreateValidOrderRequestDto()

--- a/tests/api/Infrastructure/Validation/ObjectIdAttributeTests.cs
+++ b/tests/api/Infrastructure/Validation/ObjectIdAttributeTests.cs
@@ -1,0 +1,48 @@
+using MongoDB.Bson;
+using Scv.Api.Infrastructure.Validation;
+using Xunit;
+
+namespace tests.api.Infrastructure.Validation;
+
+public class ObjectIdAttributeTests
+{
+    private readonly ObjectIdAttribute _attribute = new();
+
+    [Fact]
+    public void IsValid_ReturnsTrue_ForWellFormedObjectId()
+    {
+        var id = ObjectId.GenerateNewId().ToString();
+
+        Assert.True(_attribute.IsValid(id));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-an-object-id")]
+    [InlineData("123")]
+    [InlineData("zzzzzzzzzzzzzzzzzzzzzzzz")]
+    [InlineData("507f1f77bcf86cd79943901")]
+    [InlineData("507f1f77bcf86cd7994390111")]
+    public void IsValid_ReturnsFalse_ForMalformedId(string id)
+    {
+        Assert.False(_attribute.IsValid(id));
+    }
+
+    [Fact]
+    public void IsValid_ReturnsFalse_ForNull()
+    {
+        Assert.False(_attribute.IsValid(null));
+    }
+
+    [Fact]
+    public void IsValid_ReturnsFalse_ForNonStringValue()
+    {
+        Assert.False(_attribute.IsValid(12345));
+    }
+
+    [Fact]
+    public void DefaultErrorMessage_IsInvalidId()
+    {
+        Assert.Equal("Invalid id.", _attribute.FormatErrorMessage("id"));
+    }
+}

--- a/tests/api/Services/OrderServiceTests.cs
+++ b/tests/api/Services/OrderServiceTests.cs
@@ -1281,7 +1281,7 @@ public class OrderServiceTests : ServiceTestBase
             .Setup(r => r.GetByIdAsync(orderId))
             .ReturnsAsync((Order)null);
 
-        var result = await _orderService.GetOrderById(orderId, judgeId);
+        var result = await _orderService.GetOrderByIdAsync(orderId, judgeId);
 
         Assert.Null(result);
         _mockOrderRepo.Verify(r => r.GetByIdAsync(orderId), Times.Once);
@@ -1298,7 +1298,7 @@ public class OrderServiceTests : ServiceTestBase
             .Setup(r => r.GetByIdAsync(order.Id))
             .ReturnsAsync(order);
 
-        var result = await _orderService.GetOrderById(order.Id, differentJudgeId);
+        var result = await _orderService.GetOrderByIdAsync(order.Id, differentJudgeId);
 
         Assert.Null(result);
         _mockOrderRepo.Verify(r => r.GetByIdAsync(order.Id), Times.Once);
@@ -1314,7 +1314,7 @@ public class OrderServiceTests : ServiceTestBase
             .Setup(r => r.GetByIdAsync(order.Id))
             .ReturnsAsync(order);
 
-        var result = await _orderService.GetOrderById(order.Id, judgeId);
+        var result = await _orderService.GetOrderByIdAsync(order.Id, judgeId);
 
         Assert.NotNull(result);
         Assert.Equal(order.Id, result.Id);

--- a/tests/api/Services/OrderServiceTests.cs
+++ b/tests/api/Services/OrderServiceTests.cs
@@ -1269,6 +1269,60 @@ public class OrderServiceTests : ServiceTestBase
 
     #endregion
 
+    #region GetOrderById Tests
+
+    [Fact]
+    public async Task GetOrderById_ReturnsNull_WhenOrderDoesNotExist()
+    {
+        var orderId = MongoDB.Bson.ObjectId.GenerateNewId().ToString();
+        var judgeId = _faker.Random.Int(1, 100);
+
+        _mockOrderRepo
+            .Setup(r => r.GetByIdAsync(orderId))
+            .ReturnsAsync((Order)null);
+
+        var result = await _orderService.GetOrderById(orderId, judgeId);
+
+        Assert.Null(result);
+        _mockOrderRepo.Verify(r => r.GetByIdAsync(orderId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrderById_ReturnsNull_WhenJudgeIdDoesNotMatch()
+    {
+        var order = CreateOrder();
+        order.JudgeId = _faker.Random.Int(1, 100);
+        var differentJudgeId = order.JudgeId + 1;
+
+        _mockOrderRepo
+            .Setup(r => r.GetByIdAsync(order.Id))
+            .ReturnsAsync(order);
+
+        var result = await _orderService.GetOrderById(order.Id, differentJudgeId);
+
+        Assert.Null(result);
+        _mockOrderRepo.Verify(r => r.GetByIdAsync(order.Id), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrderById_ReturnsMappedOrder_WhenOrderExistsAndJudgeIdMatches()
+    {
+        var order = CreateOrder();
+        var judgeId = order.JudgeId;
+
+        _mockOrderRepo
+            .Setup(r => r.GetByIdAsync(order.Id))
+            .ReturnsAsync(order);
+
+        var result = await _orderService.GetOrderById(order.Id, judgeId);
+
+        Assert.NotNull(result);
+        Assert.Equal(order.Id, result.Id);
+        _mockOrderRepo.Verify(r => r.GetByIdAsync(order.Id), Times.Once);
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private OrderRequestDto CreateValidOrderRequestDto()

--- a/web/src/components/documents/FileViewer.vue
+++ b/web/src/components/documents/FileViewer.vue
@@ -99,7 +99,11 @@
       // Follow the strategy pattern workflow
       const rawData = props.strategy.getRawData(sessionId.value);
       const processedData = props.strategy.processDataForAPI(rawData);
-      const apiResponse = await props.strategy.generatePDF(processedData);
+
+      const [apiResponse] = await Promise.all([
+        props.strategy.generatePDF(processedData),
+        props.strategy.initialize?.(),
+      ]);
 
       loading.value = false;
 

--- a/web/src/components/documents/strategies/OrderPDFStrategy.ts
+++ b/web/src/components/documents/strategies/OrderPDFStrategy.ts
@@ -1,7 +1,7 @@
 import { OrderService } from '@/services';
 import { useCommonStore, useSnackbarStore } from '@/stores';
 import { StoreDocument } from '@/stores/PDFViewerStore';
-import { OrderReview } from '@/types';
+import { Order, OrderReview } from '@/types';
 import { OrderReviewStatus } from '@/types/common';
 import { viewOrderSupportingDocuments } from '@/utils/orderDetails';
 import { mdiFileDocumentMultipleOutline } from '@mdi/js';
@@ -17,7 +17,7 @@ export class OrderPDFStrategy extends FilePDFStrategy {
   private readonly orderService: OrderService;
   private readonly orderId: string | null;
   private readonly isShowingSupportingDocuments: boolean = false;
-  private readonly hasSupportingDocuments: boolean = false;
+  private currentOrder: Order | null = null;
 
   constructor() {
     super();
@@ -41,7 +41,6 @@ export class OrderPDFStrategy extends FilePDFStrategy {
 
     this.isShowingSupportingDocuments =
       urlParams.get('isShowingSupportingDocs') === 'true';
-    this.hasSupportingDocuments = urlParams.get('hasSupportingDocs') === 'true';
   }
 
   protected override getOutlineDocumentTitle(document: StoreDocument): string {
@@ -112,7 +111,7 @@ export class OrderPDFStrategy extends FilePDFStrategy {
   }
 
   additionalToolbarItems(): ToolbarItem[] {
-    if (!this.hasSupportingDocuments) {
+    if (!this.currentOrder?.hasSupportingDocs) {
       return [];
     }
 
@@ -128,17 +127,15 @@ export class OrderPDFStrategy extends FilePDFStrategy {
   }
 
   async viewSupportingDocs(): Promise<void> {
-    if (!this.orderId) {
-      throw new Error(
-        'Order ID is not defined. Cannot view supporting documents.'
-      );
-    }
+    await viewOrderSupportingDocuments(this.currentOrder!);
+  }
 
-    const order = await this.orderService.getOrder(this.orderId);
+  async initialize(): Promise<void> {
+    const order = await this.orderService.getOrder(this.orderId!);
     if (!order) {
       throw new Error(`Order with ID ${this.orderId} not found.`);
     }
 
-    await viewOrderSupportingDocuments(order);
+    this.currentOrder = order;
   }
 }

--- a/web/src/components/documents/strategies/OrderPDFStrategy.ts
+++ b/web/src/components/documents/strategies/OrderPDFStrategy.ts
@@ -121,13 +121,9 @@ export class OrderPDFStrategy extends FilePDFStrategy {
         id: 'open-supporting-documents',
         title: 'View Supporting Documents',
         icon: `<svg><path d="${mdiFileDocumentMultipleOutline}"/></svg>`,
-        onPress: this.viewSupportingDocs.bind(this),
+        onPress: () => viewOrderSupportingDocuments(this.currentOrder!),
       },
     ];
-  }
-
-  async viewSupportingDocs(): Promise<void> {
-    await viewOrderSupportingDocuments(this.currentOrder!);
   }
 
   async initialize(): Promise<void> {

--- a/web/src/components/documents/strategies/OrderPDFStrategy.ts
+++ b/web/src/components/documents/strategies/OrderPDFStrategy.ts
@@ -129,8 +129,9 @@ export class OrderPDFStrategy extends FilePDFStrategy {
 
   async viewSupportingDocs(): Promise<void> {
     if (!this.orderId) {
-      console.warn('No order id found. Cannot view supporting documents.');
-      return;
+      throw new Error(
+        'Order ID is not defined. Cannot view supporting documents.'
+      );
     }
 
     const order = await this.orderService.getOrder(this.orderId);

--- a/web/src/components/documents/strategies/OrderPDFStrategy.ts
+++ b/web/src/components/documents/strategies/OrderPDFStrategy.ts
@@ -1,7 +1,7 @@
 import { OrderService } from '@/services';
-import { useCommonStore, useOrdersStore, useSnackbarStore } from '@/stores';
+import { useCommonStore, useSnackbarStore } from '@/stores';
 import { StoreDocument } from '@/stores/PDFViewerStore';
-import { Order, OrderReview } from '@/types';
+import { OrderReview } from '@/types';
 import { OrderReviewStatus } from '@/types/common';
 import { viewOrderSupportingDocuments } from '@/utils/orderDetails';
 import { mdiFileDocumentMultipleOutline } from '@mdi/js';
@@ -14,10 +14,9 @@ export class OrderPDFStrategy extends FilePDFStrategy {
 
   private readonly snackBarStore = useSnackbarStore();
   private readonly commonStore = useCommonStore();
-  private readonly ordersStore = useOrdersStore();
   private readonly orderService: OrderService;
-  private readonly currentOrder: Order | undefined;
-  private readonly isShowingSupportingDocuments: boolean;
+  private readonly orderId: string | null;
+  private readonly isShowingSupportingDocuments: boolean = false;
   private readonly hasSupportingDocuments: boolean = false;
 
   constructor() {
@@ -35,22 +34,14 @@ export class OrderPDFStrategy extends FilePDFStrategy {
       this.commonStore.loggedInUserInfo?.judgeId;
 
     const urlParams = new URLSearchParams(globalThis.location.search);
-    const orderId = urlParams.get('id');
+    this.orderId = urlParams.get('id');
+    if (!this.orderId) {
+      throw new Error('Order ID is not defined in the URL parameters.');
+    }
+
     this.isShowingSupportingDocuments =
       urlParams.get('isShowingSupportingDocs') === 'true';
-
-    this.currentOrder = this.ordersStore.orders.find((o) => o.id === orderId);
-    if (!this.currentOrder) {
-      console.error(`Order with ID ${orderId} not found.`);
-      return;
-    }
-    this.hasSupportingDocuments =
-      [
-        ...(this.currentOrder.packageDocuments ?? []).filter(
-          (pd) => !pd.referredDocument
-        ),
-        ...(this.currentOrder.relevantCeisDocuments ?? []),
-      ].length > 0;
+    this.hasSupportingDocuments = urlParams.get('hasSupportingDocs') === 'true';
   }
 
   protected override getOutlineDocumentTitle(document: StoreDocument): string {
@@ -58,12 +49,11 @@ export class OrderPDFStrategy extends FilePDFStrategy {
   }
 
   async reviewOrder(review: OrderReview): Promise<void> {
-    if (!this.currentOrder) {
-      console.warn('No current order found. Cannot review order.');
-      return;
+    if (!this.orderId) {
+      throw new Error(`Order ID is not defined.`);
     }
 
-    await this.orderService.review(this.currentOrder!.id, review);
+    await this.orderService.review(this.orderId, review);
 
     switch (review.status) {
       case OrderReviewStatus.Approved:
@@ -132,8 +122,22 @@ export class OrderPDFStrategy extends FilePDFStrategy {
         id: 'open-supporting-documents',
         title: 'View Supporting Documents',
         icon: `<svg><path d="${mdiFileDocumentMultipleOutline}"/></svg>`,
-        onPress: () => viewOrderSupportingDocuments(this.currentOrder!),
+        onPress: this.viewSupportingDocs.bind(this),
       },
     ];
+  }
+
+  async viewSupportingDocs(): Promise<void> {
+    if (!this.orderId) {
+      console.warn('No order id found. Cannot view supporting documents.');
+      return;
+    }
+
+    const order = await this.orderService.getOrder(this.orderId);
+    if (!order) {
+      throw new Error(`Order with ID ${this.orderId} not found.`);
+    }
+
+    await viewOrderSupportingDocuments(order);
   }
 }

--- a/web/src/components/documents/strategies/PDFViewerTypes.ts
+++ b/web/src/components/documents/strategies/PDFViewerTypes.ts
@@ -26,6 +26,8 @@ export interface PDFViewerStrategy<
 
   extractBase64PDF(apiResponse: TApiResponse): string;
 
+  initialize?(): Promise<void>;
+
   extractPageRanges(
     apiResponse: TApiResponse
   ): Array<{ start: number; end?: number }> | undefined;

--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -429,6 +429,7 @@ export default {
     orderId: string,
     title: string,
     documentData: DocumentData[],
+    hasSupportingDocs: boolean = false,
     isShowingSupportingDocs: boolean = false
   ): void {
     if (!documentData || documentData.length === 0) {
@@ -449,6 +450,7 @@ export default {
     const newWindow = window.open(
       this.buildFileViewerUrl('order', sessionId, {
         id: orderId,
+        hasSupportingDocs: hasSupportingDocs ? 'true' : 'false',
         isShowingSupportingDocs: isShowingSupportingDocs ? 'true' : 'false',
       }),
       '_blank'

--- a/web/src/components/shared.ts
+++ b/web/src/components/shared.ts
@@ -429,8 +429,7 @@ export default {
     orderId: string,
     title: string,
     documentData: DocumentData[],
-    hasSupportingDocs: boolean = false,
-    isShowingSupportingDocs: boolean = false
+    params: Record<string, string | string[] | undefined> = {}
   ): void {
     if (!documentData || documentData.length === 0) {
       return;
@@ -450,8 +449,7 @@ export default {
     const newWindow = window.open(
       this.buildFileViewerUrl('order', sessionId, {
         id: orderId,
-        hasSupportingDocs: hasSupportingDocs ? 'true' : 'false',
-        isShowingSupportingDocs: isShowingSupportingDocs ? 'true' : 'false',
+        ...params,
       }),
       '_blank'
     );

--- a/web/src/services/OrderService.ts
+++ b/web/src/services/OrderService.ts
@@ -16,4 +16,8 @@ export class OrderService extends ServiceBase {
   getOrders(judgeId: number | null = null): Promise<Order[]> {
     return this.httpService.get<Order[]>(`api/orders?judgeId=${judgeId ?? ''}`);
   }
+
+  getOrder(orderId: string): Promise<Order> {
+    return this.httpService.get<Order>(`api/orders/${orderId}`);
+  }
 }

--- a/web/src/types/Order.ts
+++ b/web/src/types/Order.ts
@@ -18,6 +18,7 @@ export interface Order {
   status: OrderReviewStatus;
   packageDocuments: PackageDocument[];
   relevantCeisDocuments: RelevantCeisDocument[];
+  hasSupportingDocs: boolean;
 }
 
 export interface PackageDocument {

--- a/web/src/utils/orderDetails.ts
+++ b/web/src/utils/orderDetails.ts
@@ -10,16 +10,29 @@ export const viewOrderDetails = (order: Order): void => {
       pd.referredDocument &&
       pd.documentId?.toString() === order.packageDocumentId.toString()
   );
-  shared.openOrderDocuments(order.id, order.courtFileNumber, [
-    {
-      ...documentData,
-      documentId: order.packageDocumentId,
-      documentDescription: referredDocument?.documentTypeDesc,
-    },
-  ]);
+  const hasSupportingDocuments =
+    [
+      ...(order.packageDocuments ?? []).filter((pd) => !pd.referredDocument),
+      ...(order.relevantCeisDocuments ?? []),
+    ].length > 0;
+  shared.openOrderDocuments(
+    order.id,
+    order.courtFileNumber,
+    [
+      {
+        ...documentData,
+        documentId: order.packageDocumentId,
+        documentDescription: referredDocument?.documentTypeDesc,
+      },
+    ],
+    hasSupportingDocuments,
+    false
+  );
 };
 
-export const viewOrderSupportingDocuments = (order: Order): void => {
+export const viewOrderSupportingDocuments = async (
+  order: Order
+): Promise<void> => {
   const baseDocumentData = getBaseDocumentData(order);
   const packageDocs = (order.packageDocuments ?? []).filter(
     (pd) => !pd.referredDocument && pd.documentId
@@ -44,6 +57,7 @@ export const viewOrderSupportingDocuments = (order: Order): void => {
     order.id,
     `${order.courtFileNumber} - Supporting Documents`,
     supportingDocumentsData,
+    false,
     true
   );
 };

--- a/web/src/utils/orderDetails.ts
+++ b/web/src/utils/orderDetails.ts
@@ -10,11 +10,6 @@ export const viewOrderDetails = (order: Order): void => {
       pd.referredDocument &&
       pd.documentId?.toString() === order.packageDocumentId.toString()
   );
-  const hasSupportingDocuments =
-    [
-      ...(order.packageDocuments ?? []).filter((pd) => !pd.referredDocument),
-      ...(order.relevantCeisDocuments ?? []),
-    ].length > 0;
   shared.openOrderDocuments(
     order.id,
     order.courtFileNumber,
@@ -25,14 +20,13 @@ export const viewOrderDetails = (order: Order): void => {
         documentDescription: referredDocument?.documentTypeDesc,
       },
     ],
-    hasSupportingDocuments,
-    false
+    {
+      isShowingSupportingDocs: 'false',
+    }
   );
 };
 
-export const viewOrderSupportingDocuments = async (
-  order: Order
-): Promise<void> => {
+export const viewOrderSupportingDocuments = (order: Order): void => {
   const baseDocumentData = getBaseDocumentData(order);
   const packageDocs = (order.packageDocuments ?? []).filter(
     (pd) => !pd.referredDocument && pd.documentId
@@ -57,8 +51,9 @@ export const viewOrderSupportingDocuments = async (
     order.id,
     `${order.courtFileNumber} - Supporting Documents`,
     supportingDocumentsData,
-    false,
-    true
+    {
+      isShowingSupportingDocs: 'true',
+    }
   );
 };
 

--- a/web/tests/components/documents/strategies/OrderPDFStrategy.test.ts
+++ b/web/tests/components/documents/strategies/OrderPDFStrategy.test.ts
@@ -108,6 +108,7 @@ const mockFilesService = {
 
 const mockOrderService = {
   review: vi.fn(),
+  getOrder: vi.fn(),
 };
 
 const mockSnackbarStore = {
@@ -162,6 +163,7 @@ describe('OrderPDFStrategy', () => {
     mockPDFViewerStore.clearPdfItems.mockClear();
     mockFilesService.generatePdf.mockClear();
     mockOrderService.review.mockClear();
+    mockOrderService.getOrder.mockReset();
     mockSnackbarStore.showSnackbar.mockClear();
     mockedViewOrderSupportingDocuments.mockClear();
   });
@@ -175,32 +177,12 @@ describe('OrderPDFStrategy', () => {
     expect(() => new OrderPDFStrategy()).toThrow('Service(s) is undefined.');
   });
 
-  it('does not throw and logs an error if the current order is not found in the store', () => {
-    mockedUseOrdersStore.mockReturnValueOnce({ orders: [] });
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-
-    expect(() => new OrderPDFStrategy()).not.toThrow();
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Order with ID 123 not found.'
-    );
-
-    consoleErrorSpy.mockRestore();
-  });
-
-  it('does not throw and logs an error if the order ID is not present in the URL', () => {
+  it('throws if the order ID is not present in the URL', () => {
     setLocationSearch('');
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
 
-    expect(() => new OrderPDFStrategy()).not.toThrow();
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Order with ID null not found.'
+    expect(() => new OrderPDFStrategy()).toThrow(
+      'Order ID is not defined in the URL parameters.'
     );
-
-    consoleErrorSpy.mockRestore();
   });
 
   it('hasData returns true if documents exist', () => {
@@ -419,19 +401,7 @@ describe('OrderPDFStrategy', () => {
 
   describe('additionalToolbarItems', () => {
     it('returns a supporting-documents button when the order has supporting documents', () => {
-      mockedUseOrdersStore.mockReturnValueOnce({
-        orders: [
-          createMockOrder('123', {
-            packageDocuments: [
-              {
-                documentId: 1,
-                documentTypeDesc: 'Doc A',
-                referredDocument: false,
-              },
-            ],
-          }),
-        ],
-      });
+      setLocationSearch('?id=123&hasSupportingDocs=true');
 
       const strategy = new OrderPDFStrategy();
       const extras = strategy.additionalToolbarItems();
@@ -449,46 +419,8 @@ describe('OrderPDFStrategy', () => {
       expect(strategy.additionalToolbarItems()).toEqual([]);
     });
 
-    it('ignores referred package documents when determining supporting documents', () => {
-      mockedUseOrdersStore.mockReturnValueOnce({
-        orders: [
-          createMockOrder('123', {
-            packageDocuments: [
-              {
-                documentId: 1,
-                documentTypeDesc: 'Doc A',
-                referredDocument: true,
-              },
-            ],
-          }),
-        ],
-      });
-
-      const strategy = new OrderPDFStrategy();
-
-      expect(strategy.additionalToolbarItems()).toEqual([]);
-    });
-
-    it('counts relevant CEIS documents as supporting documents', () => {
-      mockedUseOrdersStore.mockReturnValueOnce({
-        orders: [
-          createMockOrder('123', {
-            relevantCeisDocuments: [
-              {
-                civilDocumentId: 2,
-                documentTypeDesc: 'Doc B',
-              },
-            ],
-          }),
-        ],
-      });
-
-      const strategy = new OrderPDFStrategy();
-
-      expect(strategy.additionalToolbarItems()).toHaveLength(1);
-    });
-
-    it('invokes viewOrderSupportingDocuments when the button is pressed', () => {
+    it('invokes viewOrderSupportingDocuments when the button is pressed', async () => {
+      setLocationSearch('?id=123&hasSupportingDocs=true');
       const order = createMockOrder('123', {
         relevantCeisDocuments: [
           {
@@ -497,13 +429,14 @@ describe('OrderPDFStrategy', () => {
           },
         ],
       });
-      mockedUseOrdersStore.mockReturnValueOnce({ orders: [order] });
+      mockOrderService.getOrder.mockResolvedValue(order);
 
       const strategy = new OrderPDFStrategy();
       const [button] = strategy.additionalToolbarItems();
 
-      (button as unknown as { onPress: () => void }).onPress();
+      await (button as unknown as { onPress: () => Promise<void> }).onPress();
 
+      expect(mockOrderService.getOrder).toHaveBeenCalledWith('123');
       expect(mockedViewOrderSupportingDocuments).toHaveBeenCalledWith(order);
     });
   });
@@ -633,18 +566,7 @@ describe('OrderPDFStrategy', () => {
     });
 
     it('inserts extras in the expected order: spacer, open-supporting-documents, open-information, image, open-document-review', () => {
-      mockedUseOrdersStore.mockReturnValueOnce({
-        orders: [
-          createMockOrder('123', {
-            relevantCeisDocuments: [
-              {
-                civilDocumentId: 2,
-                documentTypeDesc: 'Doc B',
-              },
-            ],
-          }),
-        ],
-      });
+      setLocationSearch('?id=123&hasSupportingDocs=true');
 
       const strategy = new OrderPDFStrategy();
       const openInformation = { id: 'open-information', type: 'custom' };

--- a/web/tests/components/documents/strategies/OrderPDFStrategy.test.ts
+++ b/web/tests/components/documents/strategies/OrderPDFStrategy.test.ts
@@ -87,6 +87,7 @@ const createMockOrder = (
   status: OrderReviewStatus.Unapproved,
   packageDocuments: [],
   relevantCeisDocuments: [],
+  hasSupportingDocs: false,
   ...overrides,
 });
 
@@ -334,7 +335,7 @@ describe('OrderPDFStrategy', () => {
     expect(mockOrderService.review).toHaveBeenCalledWith('123', review);
     expect(mockSnackbarStore.showSnackbar).toHaveBeenCalledWith(
       'The order has been approved.',
-        'success',
+      'success',
       '✅ Approved!'
     );
   });
@@ -354,7 +355,7 @@ describe('OrderPDFStrategy', () => {
     expect(mockOrderService.review).toHaveBeenCalledWith('123', review);
     expect(mockSnackbarStore.showSnackbar).toHaveBeenCalledWith(
       'The order has been rejected.',
-        'success',
+      'success',
       '📋 Rejected'
     );
   });
@@ -374,7 +375,7 @@ describe('OrderPDFStrategy', () => {
     expect(mockOrderService.review).toHaveBeenCalledWith('123', review);
     expect(mockSnackbarStore.showSnackbar).toHaveBeenCalledWith(
       'The order review is awaiting documentation.',
-        'success',
+      'success',
       '⏳ Pending'
     );
   });
@@ -399,11 +400,37 @@ describe('OrderPDFStrategy', () => {
     expect(mockOrderService.review).toHaveBeenCalledWith('order-abc', review);
   });
 
-  describe('additionalToolbarItems', () => {
-    it('returns a supporting-documents button when the order has supporting documents', () => {
-      setLocationSearch('?id=123&hasSupportingDocs=true');
+  describe('initialize', () => {
+    it('fetches the order and stores it as the current order', async () => {
+      const order = createMockOrder('123', { hasSupportingDocs: true });
+      mockOrderService.getOrder.mockResolvedValue(order);
 
       const strategy = new OrderPDFStrategy();
+      await strategy.initialize();
+
+      expect(mockOrderService.getOrder).toHaveBeenCalledWith('123');
+      expect(strategy.additionalToolbarItems()).toHaveLength(1);
+    });
+
+    it('throws when the order cannot be found', async () => {
+      mockOrderService.getOrder.mockResolvedValue(undefined);
+
+      const strategy = new OrderPDFStrategy();
+
+      await expect(strategy.initialize()).rejects.toThrow(
+        'Order with ID 123 not found.'
+      );
+    });
+  });
+
+  describe('additionalToolbarItems', () => {
+    it('returns a supporting-documents button when the order has supporting documents', async () => {
+      mockOrderService.getOrder.mockResolvedValue(
+        createMockOrder('123', { hasSupportingDocs: true })
+      );
+
+      const strategy = new OrderPDFStrategy();
+      await strategy.initialize();
       const extras = strategy.additionalToolbarItems();
 
       expect(extras).toHaveLength(1);
@@ -413,15 +440,26 @@ describe('OrderPDFStrategy', () => {
       });
     });
 
-    it('returns an empty array when the order has no supporting documents', () => {
+    it('returns an empty array when the order has no supporting documents', async () => {
+      mockOrderService.getOrder.mockResolvedValue(
+        createMockOrder('123', { hasSupportingDocs: false })
+      );
+
+      const strategy = new OrderPDFStrategy();
+      await strategy.initialize();
+
+      expect(strategy.additionalToolbarItems()).toEqual([]);
+    });
+
+    it('returns an empty array before the order has been initialized', () => {
       const strategy = new OrderPDFStrategy();
 
       expect(strategy.additionalToolbarItems()).toEqual([]);
     });
 
     it('invokes viewOrderSupportingDocuments when the button is pressed', async () => {
-      setLocationSearch('?id=123&hasSupportingDocs=true');
       const order = createMockOrder('123', {
+        hasSupportingDocs: true,
         relevantCeisDocuments: [
           {
             civilDocumentId: 2,
@@ -432,6 +470,7 @@ describe('OrderPDFStrategy', () => {
       mockOrderService.getOrder.mockResolvedValue(order);
 
       const strategy = new OrderPDFStrategy();
+      await strategy.initialize();
       const [button] = strategy.additionalToolbarItems();
 
       await (button as unknown as { onPress: () => Promise<void> }).onPress();
@@ -565,10 +604,13 @@ describe('OrderPDFStrategy', () => {
       expect(baseTypes).toEqual(['pan', 'zoom-in', 'zoom-out']);
     });
 
-    it('inserts extras in the expected order: spacer, open-supporting-documents, open-information, image, open-document-review', () => {
-      setLocationSearch('?id=123&hasSupportingDocs=true');
+    it('inserts extras in the expected order: spacer, open-supporting-documents, open-information, image, open-document-review', async () => {
+      mockOrderService.getOrder.mockResolvedValue(
+        createMockOrder('123', { hasSupportingDocs: true })
+      );
 
       const strategy = new OrderPDFStrategy();
+      await strategy.initialize();
       const openInformation = { id: 'open-information', type: 'custom' };
       const imageItem = { type: 'image' };
       const openDocumentReview = {

--- a/web/tests/components/shared.test.ts
+++ b/web/tests/components/shared.test.ts
@@ -1181,7 +1181,7 @@ describe('shared.openOrderDocuments', () => {
     ]);
   });
 
-  it('should open the file-viewer with order type and default isShowingSupportingDocs', () => {
+  it('should open the file-viewer with order type and no extra params by default', () => {
     const documentData: any[] = [
       {
         fileNumberText: 'FN001',
@@ -1193,12 +1193,12 @@ describe('shared.openOrderDocuments', () => {
     shared.openOrderDocuments('ORDER1', 'My Order', documentData);
 
     expect(mockWindowOpen).toHaveBeenCalledWith(
-      '/file-viewer?type=order&sessionId=order-session-id&id=ORDER1&hasSupportingDocs=false&isShowingSupportingDocs=false',
+      '/file-viewer?type=order&sessionId=order-session-id&id=ORDER1',
       '_blank'
     );
   });
 
-  it('should set isShowingSupportingDocs to true in the URL when specified', () => {
+  it('should include the provided params in the URL', () => {
     const documentData: any[] = [
       {
         fileNumberText: 'FN001',
@@ -1207,10 +1207,12 @@ describe('shared.openOrderDocuments', () => {
       },
     ];
 
-    shared.openOrderDocuments('ORDER1', 'My Order', documentData, false, true);
+    shared.openOrderDocuments('ORDER1', 'My Order', documentData, {
+      isShowingSupportingDocs: 'true',
+    });
 
     expect(mockWindowOpen).toHaveBeenCalledWith(
-      '/file-viewer?type=order&sessionId=order-session-id&id=ORDER1&hasSupportingDocs=false&isShowingSupportingDocs=true',
+      '/file-viewer?type=order&sessionId=order-session-id&id=ORDER1&isShowingSupportingDocs=true',
       '_blank'
     );
   });

--- a/web/tests/components/shared.test.ts
+++ b/web/tests/components/shared.test.ts
@@ -1193,7 +1193,7 @@ describe('shared.openOrderDocuments', () => {
     shared.openOrderDocuments('ORDER1', 'My Order', documentData);
 
     expect(mockWindowOpen).toHaveBeenCalledWith(
-      '/file-viewer?type=order&sessionId=order-session-id&id=ORDER1&isShowingSupportingDocs=false',
+      '/file-viewer?type=order&sessionId=order-session-id&id=ORDER1&hasSupportingDocs=false&isShowingSupportingDocs=false',
       '_blank'
     );
   });
@@ -1207,10 +1207,10 @@ describe('shared.openOrderDocuments', () => {
       },
     ];
 
-    shared.openOrderDocuments('ORDER1', 'My Order', documentData, true);
+    shared.openOrderDocuments('ORDER1', 'My Order', documentData, false, true);
 
     expect(mockWindowOpen).toHaveBeenCalledWith(
-      '/file-viewer?type=order&sessionId=order-session-id&id=ORDER1&isShowingSupportingDocs=true',
+      '/file-viewer?type=order&sessionId=order-session-id&id=ORDER1&hasSupportingDocs=false&isShowingSupportingDocs=true',
       '_blank'
     );
   });

--- a/web/tests/utils/orderDetails.test.ts
+++ b/web/tests/utils/orderDetails.test.ts
@@ -83,8 +83,7 @@ describe('orderDetails', () => {
             documentDescription: 'Order for Custody',
           },
         ],
-        true,
-        false
+        { isShowingSupportingDocs: 'false' }
       );
     });
 
@@ -118,8 +117,7 @@ describe('orderDetails', () => {
             documentDescription: undefined,
           },
         ],
-        true,
-        false
+        { isShowingSupportingDocs: 'false' }
       );
     });
 
@@ -144,8 +142,7 @@ describe('orderDetails', () => {
             documentDescription: 'Matched By Coercion',
           }),
         ]),
-        false,
-        false
+        { isShowingSupportingDocs: 'false' }
       );
     });
 
@@ -159,7 +156,7 @@ describe('orderDetails', () => {
         physicalFileId: 'file-1',
         packageDocuments: [
           {
-            documentId: 'doc-1',
+            documentId: 1,
             documentTypeDesc: 'Order package',
             referredDocument: true,
           },
@@ -185,7 +182,8 @@ describe('orderDetails', () => {
             isCriminal: true,
             orderId: 'order-1',
           }),
-        ])
+        ]),
+        { isShowingSupportingDocs: 'false' }
       );
     });
 
@@ -212,7 +210,8 @@ describe('orderDetails', () => {
             isCriminal: false,
             orderId: 'order-2',
           }),
-        ])
+        ]),
+        { isShowingSupportingDocs: 'false' }
       );
     });
   });
@@ -268,8 +267,7 @@ describe('orderDetails', () => {
             documentDescription: 'CEIS Doc',
           },
         ],
-        false,
-        true
+        { isShowingSupportingDocs: 'true' }
       );
     });
 
@@ -290,8 +288,7 @@ describe('orderDetails', () => {
         'ORDER1',
         'FN001 - Supporting Documents',
         [],
-        false,
-        true
+        { isShowingSupportingDocs: 'true' }
       );
     });
 
@@ -302,8 +299,7 @@ describe('orderDetails', () => {
         'ORDER1',
         'FN001 - Supporting Documents',
         [],
-        false,
-        true
+        { isShowingSupportingDocs: 'true' }
       );
     });
 
@@ -331,8 +327,7 @@ describe('orderDetails', () => {
             isCriminal: true,
           }),
         ],
-        false,
-        true
+        { isShowingSupportingDocs: 'true' }
       );
     });
   });

--- a/web/tests/utils/orderDetails.test.ts
+++ b/web/tests/utils/orderDetails.test.ts
@@ -69,17 +69,23 @@ describe('orderDetails', () => {
 
       viewOrderDetails(order);
 
-      expect(openOrderDocumentsMock).toHaveBeenCalledWith('ORDER1', 'FN001', [
-        {
-          courtClass: 'A',
-          fileId: 'PHYS1',
-          fileNumberText: 'FN001',
-          isCriminal: true,
-          orderId: 'ORDER1',
-          documentId: '100',
-          documentDescription: 'Order for Custody',
-        },
-      ]);
+      expect(openOrderDocumentsMock).toHaveBeenCalledWith(
+        'ORDER1',
+        'FN001',
+        [
+          {
+            courtClass: 'A',
+            fileId: 'PHYS1',
+            fileNumberText: 'FN001',
+            isCriminal: true,
+            orderId: 'ORDER1',
+            documentId: '100',
+            documentDescription: 'Order for Custody',
+          },
+        ],
+        true,
+        false
+      );
     });
 
     it('leaves the document description undefined when no referred document matches', () => {
@@ -98,17 +104,23 @@ describe('orderDetails', () => {
 
       viewOrderDetails(order);
 
-      expect(openOrderDocumentsMock).toHaveBeenCalledWith('ORDER1', 'FN001', [
-        {
-          courtClass: 'F',
-          fileId: 'PHYS1',
-          fileNumberText: 'FN001',
-          isCriminal: false,
-          orderId: 'ORDER1',
-          documentId: '100',
-          documentDescription: undefined,
-        },
-      ]);
+      expect(openOrderDocumentsMock).toHaveBeenCalledWith(
+        'ORDER1',
+        'FN001',
+        [
+          {
+            courtClass: 'F',
+            fileId: 'PHYS1',
+            fileNumberText: 'FN001',
+            isCriminal: false,
+            orderId: 'ORDER1',
+            documentId: '100',
+            documentDescription: undefined,
+          },
+        ],
+        true,
+        false
+      );
     });
 
     it('matches package documents by string-coerced document id', () => {
@@ -131,7 +143,9 @@ describe('orderDetails', () => {
           expect.objectContaining({
             documentDescription: 'Matched By Coercion',
           }),
-        ])
+        ]),
+        false,
+        false
       );
     });
 
@@ -254,6 +268,7 @@ describe('orderDetails', () => {
             documentDescription: 'CEIS Doc',
           },
         ],
+        false,
         true
       );
     });
@@ -275,6 +290,7 @@ describe('orderDetails', () => {
         'ORDER1',
         'FN001 - Supporting Documents',
         [],
+        false,
         true
       );
     });
@@ -286,6 +302,7 @@ describe('orderDetails', () => {
         'ORDER1',
         'FN001 - Supporting Documents',
         [],
+        false,
         true
       );
     });
@@ -314,6 +331,7 @@ describe('orderDetails', () => {
             isCriminal: true,
           }),
         ],
+        false,
         true
       );
     });

--- a/web/tests/utils/orderDetails.test.ts
+++ b/web/tests/utils/orderDetails.test.ts
@@ -149,7 +149,7 @@ describe('orderDetails', () => {
     it('maps order fields and opens order document for criminal files', () => {
       const order = createOrder({
         id: 'order-1',
-        packageDocumentId: 'doc-1',
+        packageDocumentId: '1',
         packageName: 'Order package',
         courtClass: 'CC',
         courtFileNumber: 'CF-1234',
@@ -177,7 +177,7 @@ describe('orderDetails', () => {
             courtClass: 'CC',
             fileId: 'file-1',
             fileNumberText: 'CF-1234',
-            documentId: 'doc-1',
+            documentId: '1',
             documentDescription: 'Order package',
             isCriminal: true,
             orderId: 'order-1',


### PR DESCRIPTION
The previous implementation assumed that the order data was already loaded in the `orderStore` by the time the `FileViewer` mounted. This assumption created a race condition: the async call fetching the order hadn't completed before the component rendered. As a result, approving or rejecting an order had no effect, since no order was actually available.

The fix introduces an explicit async call to fetch the order when viewing additional supporting documents. This guarantees that the order exists and reflects the most recent data before any actions are performed.