### PR TITLE
Ensure correct judge id is passed when viewing an order

### DIFF
--- a/api/Controllers/OrdersController.cs
+++ b/api/Controllers/OrdersController.cs
@@ -42,13 +42,14 @@ public class OrdersController(
     /// Retrieves a specific order by its ID for the judge.
     /// </summary>
     /// <param name="id">The ID of the order.</param>
+    /// <param name="judgeId">The override judge id.</param>
     /// <returns>The order details.</returns>
     [HttpGet]
     [Authorize(AuthenticationSchemes = "SiteMinder, OpenIdConnect", Policy = nameof(ProviderAuthorizationHandler))]
     [Route("{id}")]
-    public async Task<IActionResult> GetOrder([FromRoute, ObjectId] string id)
+    public async Task<IActionResult> GetOrder([FromRoute, ObjectId] string id, int? judgeId = null)
     {
-        var judgeOrder = await _orderService.GetOrderByIdAsync(id, this.User.JudgeId());
+        var judgeOrder = await _orderService.GetOrderByIdAsync(id, this.User.JudgeId(judgeId));
         if (judgeOrder == null)
         {
             return NotFound("Order not found.");

--- a/tests/api/Controllers/OrdersControllerTests.cs
+++ b/tests/api/Controllers/OrdersControllerTests.cs
@@ -558,9 +558,87 @@ public class OrdersControllerTests
         _mockOrderService.Verify(s => s.GetOrderByIdAsync(orderId, _judgeId), Times.Once);
     }
 
+    [Fact]
+    public async Task GetOrder_UsesOverrideJudgeId_WhenUserCanViewOthersSchedule()
+    {
+        var orderId = _faker.Random.AlphaNumeric(24);
+        var overrideJudgeId = _judgeId + 1;
+        var controller = CreateController(CreatePrincipal(_judgeId, canViewOthersSchedule: true));
+
+        _mockOrderService
+            .Setup(s => s.GetOrderByIdAsync(orderId, overrideJudgeId))
+            .ReturnsAsync(new OrderViewDto());
+
+        var result = await controller.GetOrder(orderId, overrideJudgeId);
+
+        Assert.IsType<OkObjectResult>(result);
+        _mockOrderService.Verify(s => s.GetOrderByIdAsync(orderId, overrideJudgeId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrder_IgnoresOverrideJudgeId_WhenUserCannotViewOthersSchedule()
+    {
+        var orderId = _faker.Random.AlphaNumeric(24);
+        var overrideJudgeId = _judgeId + 1;
+
+        _mockOrderService
+            .Setup(s => s.GetOrderByIdAsync(orderId, _judgeId))
+            .ReturnsAsync(new OrderViewDto());
+
+        var result = await _controller.GetOrder(orderId, overrideJudgeId);
+
+        Assert.IsType<OkObjectResult>(result);
+        _mockOrderService.Verify(s => s.GetOrderByIdAsync(orderId, _judgeId), Times.Once);
+        _mockOrderService.Verify(s => s.GetOrderByIdAsync(orderId, overrideJudgeId), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetOrder_UsesAuthenticatedJudgeId_WhenOverrideIsNull_AndUserCanViewOthersSchedule()
+    {
+        var orderId = _faker.Random.AlphaNumeric(24);
+        var controller = CreateController(CreatePrincipal(_judgeId, canViewOthersSchedule: true));
+
+        _mockOrderService
+            .Setup(s => s.GetOrderByIdAsync(orderId, _judgeId))
+            .ReturnsAsync(new OrderViewDto());
+
+        var result = await controller.GetOrder(orderId, null);
+
+        Assert.IsType<OkObjectResult>(result);
+        _mockOrderService.Verify(s => s.GetOrderByIdAsync(orderId, _judgeId), Times.Once);
+    }
+
     #endregion
 
     #region Helper Methods
+
+    private OrdersController CreateController(ClaimsPrincipal principal) =>
+        new(
+            _mockOrderRequestValidator.Object,
+            _mockOrderService.Object,
+            _mockAntiVirusService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = principal }
+            }
+        };
+
+    private static ClaimsPrincipal CreatePrincipal(int judgeId, bool canViewOthersSchedule = false)
+    {
+        var claims = new List<Claim>
+        {
+            new(CustomClaimTypes.JudgeId, judgeId.ToString())
+        };
+
+        if (canViewOthersSchedule)
+        {
+            claims.Add(new(CustomClaimTypes.Groups, "jasper-view-others-schedule"));
+        }
+
+        var identity = new ClaimsIdentity(claims, "TestAuthType");
+        return new ClaimsPrincipal(identity);
+    }
 
     private OrderRequestDto CreateValidOrderRequestDto()
     {

--- a/web/src/components/documents/strategies/OrderPDFStrategy.ts
+++ b/web/src/components/documents/strategies/OrderPDFStrategy.ts
@@ -6,7 +6,7 @@ import { OrderReviewStatus } from '@/types/common';
 import { viewOrderSupportingDocuments } from '@/utils/orderDetails';
 import { mdiFileDocumentMultipleOutline } from '@mdi/js';
 import { ToolbarItem } from '@nutrient-sdk/viewer';
-import { inject } from 'vue';
+import { inject, watch, WatchStopHandle } from 'vue';
 import { FilePDFStrategy } from './FilePDFStrategy';
 
 export class OrderPDFStrategy extends FilePDFStrategy {
@@ -18,6 +18,8 @@ export class OrderPDFStrategy extends FilePDFStrategy {
   private readonly orderId: string | null;
   private readonly isShowingSupportingDocuments: boolean = false;
   private currentOrder: Order | null = null;
+  private judgeId: number | null = null;
+  private readonly stopJudgeIdWatch: WatchStopHandle;
 
   constructor() {
     super();
@@ -32,6 +34,7 @@ export class OrderPDFStrategy extends FilePDFStrategy {
     this.showOrderReviewOptions =
       this.commonStore.userInfo?.judgeId ===
       this.commonStore.loggedInUserInfo?.judgeId;
+    this.judgeId = this.commonStore.userInfo?.judgeId ?? null;
 
     const urlParams = new URLSearchParams(globalThis.location.search);
     this.orderId = urlParams.get('id');
@@ -41,6 +44,18 @@ export class OrderPDFStrategy extends FilePDFStrategy {
 
     this.isShowingSupportingDocuments =
       urlParams.get('isShowingSupportingDocs') === 'true';
+
+    this.stopJudgeIdWatch = watch(
+      () => this.commonStore.userInfo?.judgeId,
+      (newJudgeId) => {
+        this.judgeId = newJudgeId ?? null;
+      }
+    );
+  }
+
+  override cleanup(sessionId?: string): void {
+    this.stopJudgeIdWatch();
+    super.cleanup(sessionId);
   }
 
   protected override getOutlineDocumentTitle(document: StoreDocument): string {
@@ -127,11 +142,10 @@ export class OrderPDFStrategy extends FilePDFStrategy {
   }
 
   async initialize(): Promise<void> {
-    const order = await this.orderService.getOrder(this.orderId!);
+    const order = await this.orderService.getOrder(this.orderId!, this.judgeId);
     if (!order) {
       throw new Error(`Order with ID ${this.orderId} not found.`);
     }
-
     this.currentOrder = order;
   }
 }

--- a/web/src/services/OrderService.ts
+++ b/web/src/services/OrderService.ts
@@ -17,7 +17,9 @@ export class OrderService extends ServiceBase {
     return this.httpService.get<Order[]>(`api/orders?judgeId=${judgeId ?? ''}`);
   }
 
-  getOrder(orderId: string): Promise<Order> {
-    return this.httpService.get<Order>(`api/orders/${orderId}`);
+  getOrder(orderId: string, judgeId: number | null): Promise<Order> {
+    return this.httpService.get<Order>(
+      `api/orders/${orderId}?judgeId=${judgeId ?? ''}`
+    );
   }
 }

--- a/web/tests/components/documents/strategies/OrderPDFStrategy.test.ts
+++ b/web/tests/components/documents/strategies/OrderPDFStrategy.test.ts
@@ -14,7 +14,7 @@ import { viewOrderSupportingDocuments } from '@/utils/orderDetails';
 import { ToolbarItem } from '@nutrient-sdk/viewer';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-import { inject } from 'vue';
+import { inject, nextTick, reactive } from 'vue';
 
 vi.mock('@/stores', () => ({
   usePDFViewerStore: vi.fn(),
@@ -303,6 +303,24 @@ describe('OrderPDFStrategy', () => {
     expect(mockPDFViewerStore.clearPdfItems).toHaveBeenCalled();
   });
 
+  it('cleanup stops watching for judge ID changes', async () => {
+    const commonStore = reactive({
+      userInfo: { judgeId: 11 },
+      loggedInUserInfo: { judgeId: 11 },
+    });
+    mockedUseCommonStore.mockReturnValueOnce(commonStore);
+    mockOrderService.getOrder.mockResolvedValue(createMockOrder('123'));
+
+    const strategy = new OrderPDFStrategy();
+    strategy.cleanup();
+
+    commonStore.userInfo.judgeId = 99;
+    await nextTick();
+    await strategy.initialize();
+
+    expect(mockOrderService.getOrder).toHaveBeenCalledWith('123', 11);
+  });
+
   it('showOrderReviewOptions is true when judge IDs match', () => {
     const strategy = new OrderPDFStrategy();
 
@@ -408,8 +426,24 @@ describe('OrderPDFStrategy', () => {
       const strategy = new OrderPDFStrategy();
       await strategy.initialize();
 
-      expect(mockOrderService.getOrder).toHaveBeenCalledWith('123');
+      expect(mockOrderService.getOrder).toHaveBeenCalledWith('123', 11);
       expect(strategy.additionalToolbarItems()).toHaveLength(1);
+    });
+
+    it('passes the updated judge ID to getOrder after the judge changes', async () => {
+      const commonStore = reactive({
+        userInfo: { judgeId: 11 },
+        loggedInUserInfo: { judgeId: 11 },
+      });
+      mockedUseCommonStore.mockReturnValueOnce(commonStore);
+      mockOrderService.getOrder.mockResolvedValue(createMockOrder('123'));
+
+      const strategy = new OrderPDFStrategy();
+      commonStore.userInfo.judgeId = 42;
+      await nextTick();
+      await strategy.initialize();
+
+      expect(mockOrderService.getOrder).toHaveBeenCalledWith('123', 42);
     });
 
     it('throws when the order cannot be found', async () => {
@@ -475,7 +509,7 @@ describe('OrderPDFStrategy', () => {
 
       await (button as unknown as { onPress: () => Promise<void> }).onPress();
 
-      expect(mockOrderService.getOrder).toHaveBeenCalledWith('123');
+      expect(mockOrderService.getOrder).toHaveBeenCalledWith('123', 11);
       expect(mockedViewOrderSupportingDocuments).toHaveBeenCalledWith(order);
     });
   });

--- a/web/tests/services/OrdersService.test.ts
+++ b/web/tests/services/OrdersService.test.ts
@@ -1,6 +1,6 @@
 import { IHttpService } from '@/services/HttpService';
 import { OrderService } from '@/services/OrderService';
-import { Order } from '@/types';
+import { Order, OrderReview } from '@/types';
 import { OrderReviewStatus } from '@/types/common';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
@@ -8,6 +8,7 @@ const mockHttpService = {
   get: vi.fn(),
   post: vi.fn(),
   put: vi.fn(),
+  patch: vi.fn(),
   delete: vi.fn(),
 } as unknown as IHttpService;
 
@@ -38,6 +39,11 @@ describe('OrderService', () => {
       styleOfCause: 'R v Smith',
       physicalFileId: 'file-001',
       status: OrderReviewStatus.Pending,
+      priorityType: '',
+      courtListType: '',
+      packageDocuments: [],
+      relevantCeisDocuments: [],
+      hasSupportingDocs: false,
     },
     {
       id: '2',
@@ -51,6 +57,11 @@ describe('OrderService', () => {
       styleOfCause: 'Jones v Brown',
       physicalFileId: 'file-002',
       status: OrderReviewStatus.Approved,
+      priorityType: '',
+      courtListType: '',
+      packageDocuments: [],
+      relevantCeisDocuments: [],
+      hasSupportingDocs: false,
     },
   ];
 
@@ -113,6 +124,86 @@ describe('OrderService', () => {
 
       expect(mockHttpService.get).toHaveBeenCalledWith('api/orders?judgeId=0');
       expect(result).toEqual(mockOrders);
+    });
+  });
+
+  describe('getOrder', () => {
+    it('should fetch a single order with judgeId when provided', async () => {
+      const order = mockOrders[0];
+      (mockHttpService.get as Mock).mockResolvedValueOnce(order);
+
+      const result = await service.getOrder('1', 123);
+
+      expect(mockHttpService.get).toHaveBeenCalledWith(
+        'api/orders/1?judgeId=123'
+      );
+      expect(result).toEqual(order);
+    });
+
+    it('should fetch a single order with empty judgeId when null is provided', async () => {
+      const order = mockOrders[0];
+      (mockHttpService.get as Mock).mockResolvedValueOnce(order);
+
+      const result = await service.getOrder('1', null);
+
+      expect(mockHttpService.get).toHaveBeenCalledWith('api/orders/1?judgeId=');
+      expect(result).toEqual(order);
+    });
+
+    it('should fetch a single order with judgeId 0', async () => {
+      const order = mockOrders[0];
+      (mockHttpService.get as Mock).mockResolvedValueOnce(order);
+
+      const result = await service.getOrder('1', 0);
+
+      expect(mockHttpService.get).toHaveBeenCalledWith(
+        'api/orders/1?judgeId=0'
+      );
+      expect(result).toEqual(order);
+    });
+
+    it('should handle API errors', async () => {
+      const error = new Error('API Error');
+      (mockHttpService.get as Mock).mockRejectedValueOnce(error);
+
+      await expect(service.getOrder('1', 123)).rejects.toThrow('API Error');
+      expect(mockHttpService.get).toHaveBeenCalledWith(
+        'api/orders/1?judgeId=123'
+      );
+    });
+  });
+
+  describe('review', () => {
+    const mockReview: OrderReview = {
+      comments: 'Looks good',
+      signed: true,
+      status: OrderReviewStatus.Approved,
+      documentData: 'doc-data',
+      supportingDocumentData: 'supporting-doc-data',
+    };
+
+    it('should patch the order review for the given orderId', async () => {
+      (mockHttpService.patch as Mock).mockResolvedValueOnce(undefined);
+
+      await service.review('1', mockReview);
+
+      expect(mockHttpService.patch).toHaveBeenCalledWith(
+        'api/orders/1/review',
+        mockReview
+      );
+    });
+
+    it('should handle API errors', async () => {
+      const error = new Error('API Error');
+      (mockHttpService.patch as Mock).mockRejectedValueOnce(error);
+
+      await expect(service.review('1', mockReview)).rejects.toThrow(
+        'API Error'
+      );
+      expect(mockHttpService.patch).toHaveBeenCalledWith(
+        'api/orders/1/review',
+        mockReview
+      );
     });
   });
 });


### PR DESCRIPTION
This update is related to this [PR](https://github.com/bcgov/jasper/pull/1272) which did not account for the scenario where a judge (with correct permissions) can view another person's orders.
