### PR TITLE
transitory documents - display data recency.

### DIFF
--- a/api/Controllers/TransitoryDocumentsController.cs
+++ b/api/Controllers/TransitoryDocumentsController.cs
@@ -92,11 +92,12 @@ namespace Scv.Api.Controllers
                 forceRefresh);
 
             logger.LogInformation(
-                "Found {Count} transitory document(s) - LocationId: {LocationId}, RoomCd: {RoomCd}, Date: {Date}",
-                result?.Count() ?? 0,
+                "Found {Count} transitory document(s) - LocationId: {LocationId}, RoomCd: {RoomCd}, Date: {Date}, IsCached: {IsCached}",
+                result.Documents.Count,
                 sanitizedLocationId,
                 sanitizedRoomCd,
-                date);
+                date,
+                result.IsCached);
 
             return Ok(result);
         }
@@ -198,11 +199,12 @@ namespace Scv.Api.Controllers
                 return BadRequest(validationResult.Errors.Select(e => e.ErrorMessage));
             }
 
-            var searchResults = (await transitoryDocumentsService.ListSharedDocuments(
+            var searchResponse = await transitoryDocumentsService.ListSharedDocuments(
                 request?.LocationId,
                 request?.RoomCd,
                 request?.Date.ToString("yyyy-MM-dd"),
-                cancellationToken))?.ToList() ?? [];
+                cancellationToken);
+            var searchResults = searchResponse.Documents.ToList();
 
             logger.LogInformation(
                 "Transitory merge reconciliation - RequestedFileCount: {RequestedFileCount}, SearchResultCount: {SearchResultCount}, LocationId: {LocationId}, RoomCd: {RoomCd}, Date: {Date}",

--- a/api/Services/ITransitoryDocumentsService.cs
+++ b/api/Services/ITransitoryDocumentsService.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Scv.Models;
+using Scv.Models.Document;
 using TDCommon.Clients.DocumentsServices;
 
 namespace Scv.Api.Services
@@ -19,9 +20,9 @@ namespace Scv.Api.Services
         /// <param name="date">The date to retrieve files.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
         /// <param name="forceRefresh">Whether to discard the cached result for this search before retrieving documents.</param>
-        /// <returns>The collection of file metadata from the API.</returns>
+        /// <returns>The documents and metadata that identify when and whether the search result was cached.</returns>
         /// <exception cref="ApiException">A server-side error occurred.</exception>
-        Task<IEnumerable<Scv.Models.Document.FileMetadataDto>> ListSharedDocuments(
+        Task<TransitoryDocumentSearchResponse> ListSharedDocuments(
             string locationId,
             string roomCode,
             string date,

--- a/api/Services/TransitoryDocumentsService.cs
+++ b/api/Services/TransitoryDocumentsService.cs
@@ -17,6 +17,7 @@ using Scv.Api.Infrastructure.Authentication;
 using Scv.Api.Infrastructure.Options;
 using Scv.Core.Exceptions;
 using Scv.Models;
+using Scv.Models.Document;
 using TDCommon.Clients.DocumentsServices;
 
 namespace Scv.Api.Services
@@ -64,9 +65,9 @@ namespace Scv.Api.Services
         /// <param name="date">The date to retrieve files.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
         /// <param name="forceRefresh">Force the cache to be ignored for this request.</param>
-        /// <returns>The collection of file metadata from the API.</returns>
+        /// <returns>The documents and metadata that identify when and whether the search result was cached.</returns>
         /// <exception cref="ApiException">A server-side error occurred.</exception>
-        public async Task<IEnumerable<Scv.Models.Document.FileMetadataDto>> ListSharedDocuments(
+        public async Task<TransitoryDocumentSearchResponse> ListSharedDocuments(
             string locationId,
             string roomCode,
             string date,
@@ -89,10 +90,12 @@ namespace Scv.Api.Services
                         date);
                 }
 
-                return await _cache.GetOrAddAsync(
+                var isCached = true;
+                var cachedSearch = await _cache.GetOrAddAsync(
                     cacheKey,
                     async _ =>
                     {
+                        isCached = false;
                         var bearer = await _keycloakTokenService.GetServiceAccountTokenAsync(_tdKeycloakOptions.Value, cancellationToken);
                         _tdClient.SetBearerToken(bearer);
 
@@ -136,12 +139,21 @@ namespace Scv.Api.Services
                             cancellationToken);
 
                         // Use Mapster to map generated client DTOs to shared model DTOs.
-                        return _mapper.Map<IEnumerable<Scv.Models.Document.FileMetadataDto>>(clientResult).ToList();
+                        return new CachedTransitoryDocumentSearch(
+                            _mapper.Map<IEnumerable<Scv.Models.Document.FileMetadataDto>>(clientResult).ToList(),
+                            DateTimeOffset.UtcNow);
                     },
                     new MemoryCacheEntryOptions
                     {
                         AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(_tdSearchExpiryMinutes)
                     });
+
+                return new TransitoryDocumentSearchResponse
+                {
+                    Documents = cachedSearch.Documents,
+                    RetrievedAtUtc = cachedSearch.RetrievedAtUtc,
+                    IsCached = isCached
+                };
             }
             catch (ApiException<string> apiEx)
             {
@@ -296,6 +308,10 @@ namespace Scv.Api.Services
 
             return "application/octet-stream";
         }
+
+        private sealed record CachedTransitoryDocumentSearch(
+            IReadOnlyList<Scv.Models.Document.FileMetadataDto> Documents,
+            DateTimeOffset RetrievedAtUtc);
 
 
     }

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -23,7 +23,7 @@
     "RegionExpiryMinutes": "60",
     "FileExpiryMinutes": "2",
     "UserExpiryMinutes": "480",
-    "TdSearchExpiryMinutes": "480"
+    "TdSearchExpiryMinutes": "60"
   },
   "TDKeycloak": {
     "Authority": "https://common-sso.justice.gov.bc.ca/auth/realms/Judiciary",

--- a/models/Document/TransitoryDocumentSearchResponse.cs
+++ b/models/Document/TransitoryDocumentSearchResponse.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace Scv.Models.Document;
+
+public sealed class TransitoryDocumentSearchResponse
+{
+    public required IReadOnlyList<FileMetadataDto> Documents { get; init; }
+    public required DateTimeOffset RetrievedAtUtc { get; init; }
+    public required bool IsCached { get; init; }
+}

--- a/tests/api/Controllers/TransitoryDocumentsControllerTests.cs
+++ b/tests/api/Controllers/TransitoryDocumentsControllerTests.cs
@@ -136,15 +136,16 @@ public class TransitoryDocumentsControllerTests
 
         _mockTransitoryDocumentsService
             .Setup(s => s.ListSharedDocuments(locationId, roomCd, date.ToString("yyyy-MM-dd")))
-            .ReturnsAsync(expectedDocuments);
+            .ReturnsAsync(CreateSearchResponse(expectedDocuments));
 
         // Act
         var result = await _controller.DocumentGet(locationId, roomCd, date);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);
-        var actualDocuments = Assert.IsType<IEnumerable<SearchFileMetadata>>(okResult.Value, false);
-        Assert.Equal(expectedDocuments.Count, actualDocuments.Count());
+        var searchResponse = Assert.IsType<TransitoryDocumentSearchResponse>(okResult.Value);
+        Assert.Equal(expectedDocuments.Count, searchResponse.Documents.Count);
+        Assert.False(searchResponse.IsCached);
 
         _mockTransitoryDocumentsService.Verify(
             s => s.ListSharedDocuments(locationId, roomCd, date.ToString("yyyy-MM-dd")),
@@ -165,15 +166,15 @@ public class TransitoryDocumentsControllerTests
 
         _mockTransitoryDocumentsService
             .Setup(s => s.ListSharedDocuments(locationId, roomCd, It.IsAny<string>()))
-            .ReturnsAsync([]);
+            .ReturnsAsync(CreateSearchResponse([]));
 
         // Act
         var result = await _controller.DocumentGet(locationId, roomCd, date);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);
-        var actualDocuments = Assert.IsType<IEnumerable<SearchFileMetadata>>(okResult.Value, false);
-        Assert.Empty(actualDocuments);
+        var searchResponse = Assert.IsType<TransitoryDocumentSearchResponse>(okResult.Value);
+        Assert.Empty(searchResponse.Documents);
     }
 
     [Fact]
@@ -194,7 +195,7 @@ public class TransitoryDocumentsControllerTests
                 date.ToString("yyyy-MM-dd"),
                 It.IsAny<CancellationToken>(),
                 true))
-            .ReturnsAsync([]);
+            .ReturnsAsync(CreateSearchResponse([]));
 
         // Act
         var result = await _controller.DocumentGet(locationId, roomCd, date, true);
@@ -225,7 +226,7 @@ public class TransitoryDocumentsControllerTests
 
         _mockTransitoryDocumentsService
             .Setup(s => s.ListSharedDocuments(locationId, roomCd, "2025-10-31"))
-            .ReturnsAsync([]);
+            .ReturnsAsync(CreateSearchResponse([]));
 
         // Act
         await _controller.DocumentGet(locationId, roomCd, date);
@@ -696,7 +697,7 @@ public class TransitoryDocumentsControllerTests
 
         _mockTransitoryDocumentsService
             .Setup(s => s.ListSharedDocuments(request.LocationId, request.RoomCd, request.Date.ToString("yyyy-MM-dd"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(request.Files.Select(ToSearchFileMetadata));
+            .ReturnsAsync(CreateSearchResponse(request.Files.Select(ToSearchFileMetadata)));
 
         _mockDocumentMerger
             .Setup(m => m.MergeDocuments(It.IsAny<PdfDocumentRequest[]>()))
@@ -736,7 +737,7 @@ public class TransitoryDocumentsControllerTests
 
         _mockTransitoryDocumentsService
             .Setup(s => s.ListSharedDocuments(request.LocationId, request.RoomCd, request.Date.ToString("yyyy-MM-dd"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(request.Files.Select(ToSearchFileMetadata));
+            .ReturnsAsync(CreateSearchResponse(request.Files.Select(ToSearchFileMetadata)));
 
         _mockDocumentMerger
             .Setup(m => m.MergeDocuments(It.IsAny<PdfDocumentRequest[]>()))
@@ -778,7 +779,7 @@ public class TransitoryDocumentsControllerTests
 
         _mockTransitoryDocumentsService
             .Setup(s => s.ListSharedDocuments(request.LocationId, request.RoomCd, request.Date.ToString("yyyy-MM-dd"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(request.Files.Select(ToSearchFileMetadata));
+            .ReturnsAsync(CreateSearchResponse(request.Files.Select(ToSearchFileMetadata)));
 
         _mockDocumentMerger
             .Setup(m => m.MergeDocuments(It.IsAny<PdfDocumentRequest[]>()))
@@ -818,7 +819,7 @@ public class TransitoryDocumentsControllerTests
 
         _mockTransitoryDocumentsService
             .Setup(s => s.ListSharedDocuments(request.LocationId, request.RoomCd, request.Date.ToString("yyyy-MM-dd"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(request.Files.Select(ToSearchFileMetadata));
+            .ReturnsAsync(CreateSearchResponse(request.Files.Select(ToSearchFileMetadata)));
 
         _mockDocumentMerger
             .Setup(m => m.MergeDocuments(It.IsAny<PdfDocumentRequest[]>()))
@@ -856,7 +857,7 @@ public class TransitoryDocumentsControllerTests
 
         _mockTransitoryDocumentsService
             .Setup(s => s.ListSharedDocuments(request.LocationId, request.RoomCd, request.Date.ToString("yyyy-MM-dd"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(request.Files.Select(ToSearchFileMetadata));
+            .ReturnsAsync(CreateSearchResponse(request.Files.Select(ToSearchFileMetadata)));
 
         _mockDocumentMerger
             .Setup(m => m.MergeDocuments(It.IsAny<PdfDocumentRequest[]>()))
@@ -898,6 +899,16 @@ public class TransitoryDocumentsControllerTests
             CreatedUtc = metadata.CreatedUtc,
             RelativePath = metadata.RelativePath,
             MatchedRoomFolder = metadata.MatchedRoomFolder
+        };
+    }
+
+    private static TransitoryDocumentSearchResponse CreateSearchResponse(IEnumerable<SearchFileMetadata> documents)
+    {
+        return new TransitoryDocumentSearchResponse
+        {
+            Documents = documents.ToList(),
+            RetrievedAtUtc = DateTimeOffset.UtcNow,
+            IsCached = false
         };
     }
 

--- a/tests/api/Documents/DocumentMergerTests.cs
+++ b/tests/api/Documents/DocumentMergerTests.cs
@@ -24,11 +24,6 @@ namespace tests.api.Documents;
 
 public class DocumentMergerTest : ServiceTestBase
 {
-    static DocumentMergerTest()
-    {
-        new LicenseManager().RegisterKEY(string.Empty);
-    }
-
     [Fact]
     public async Task MergeDocuments_RetrievesDocumentsInBatches()
     {

--- a/tests/api/Services/TransitoryDocumentsServiceTests.cs
+++ b/tests/api/Services/TransitoryDocumentsServiceTests.cs
@@ -158,7 +158,9 @@ public class TransitoryDocumentsServiceTests : ServiceTestBase
 
         // Assert
         Assert.NotNull(result);
-        var resultList = result.ToList();
+        Assert.False(result.IsCached);
+        Assert.NotEqual(default, result.RetrievedAtUtc);
+        var resultList = result.Documents;
         Assert.Single(resultList);
         Assert.Equal("test.pdf", resultList[0].FileName);
         Assert.Equal(".pdf", resultList[0].Extension);
@@ -219,7 +221,7 @@ public class TransitoryDocumentsServiceTests : ServiceTestBase
         var result = await service.ListSharedDocuments(locationId, roomCode, date);
 
         // Assert
-        var resultList = result.ToList();
+        var resultList = result.Documents;
         Assert.Single(resultList);
         Assert.Equal(expectedDateTime.UtcDateTime, resultList[0].CreatedUtc);
     }
@@ -257,7 +259,47 @@ public class TransitoryDocumentsServiceTests : ServiceTestBase
 
         // Assert
         Assert.NotNull(result);
-        Assert.Empty(result);
+        Assert.Empty(result.Documents);
+    }
+
+    [Fact]
+    public async Task ListSharedDocuments_ShouldCacheEmptyResults()
+    {
+        // Arrange
+        var locationId = _faker.Random.AlphaNumeric(5);
+        var roomCode = _faker.Random.AlphaNumeric(3);
+        var date = _faker.Date.Recent().ToString("yyyy-MM-dd");
+        var location = Scv.Models.Location.Location.Create(
+            _faker.Address.City(),
+            locationId,
+            locationId,
+            true,
+            []);
+        location.ShortName = _faker.Random.AlphaNumeric(5);
+        location.AgencyIdentifierCd = _faker.Random.AlphaNumeric(3);
+        var region = new JCRegion
+        {
+            RegionId = _faker.Random.Int(1, 10),
+            RegionName = _faker.Address.State(),
+            RegionLocations = []
+        };
+        var (service, mockTdClient, _, _) = SetupService([], location, region);
+
+        // Act
+        var firstResult = await service.ListSharedDocuments(locationId, roomCode, date);
+        var secondResult = await service.ListSharedDocuments(locationId, roomCode, date);
+
+        // Assert
+        Assert.Empty(firstResult.Documents);
+        Assert.Empty(secondResult.Documents);
+        Assert.False(firstResult.IsCached);
+        Assert.True(secondResult.IsCached);
+        Assert.Equal(firstResult.RetrievedAtUtc, secondResult.RetrievedAtUtc);
+        mockTdClient.Verify(
+            client => client.SearchAsync(
+                It.IsAny<TransitoryDocumentSearchRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -502,7 +544,7 @@ public class TransitoryDocumentsServiceTests : ServiceTestBase
         var result = await service.ListSharedDocuments(locationId, roomCode, date);
 
         // Assert
-        var resultList = result.ToList();
+        var resultList = result.Documents;
         Assert.Equal(2, resultList.Count);
         Assert.Equal("test1.pdf", resultList[0].FileName);
         Assert.Equal("test2.docx", resultList[1].FileName);
@@ -553,7 +595,10 @@ public class TransitoryDocumentsServiceTests : ServiceTestBase
         // Assert
         Assert.NotNull(firstResult);
         Assert.NotNull(secondResult);
-        Assert.Single(secondResult);
+        Assert.False(firstResult.IsCached);
+        Assert.True(secondResult.IsCached);
+        Assert.Equal(firstResult.RetrievedAtUtc, secondResult.RetrievedAtUtc);
+        Assert.Single(secondResult.Documents);
 
         mockKeycloakService.Verify(k => k.GetServiceAccountTokenAsync(It.IsAny<KeycloakClientOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         mockLocationService.Verify(l => l.GetLocations(It.IsAny<bool>()), Times.Once);
@@ -586,15 +631,62 @@ public class TransitoryDocumentsServiceTests : ServiceTestBase
         var (service, mockTdClient, _, _) = SetupService([], location, region);
 
         // Act
-        await service.ListSharedDocuments(locationId, roomCode, date);
-        await service.ListSharedDocuments(locationId, roomCode, date, forceRefresh: true);
+        var initialResult = await service.ListSharedDocuments(locationId, roomCode, date);
+        var refreshedResult = await service.ListSharedDocuments(locationId, roomCode, date, forceRefresh: true);
 
         // Assert
+        Assert.False(refreshedResult.IsCached);
+        Assert.True(refreshedResult.RetrievedAtUtc >= initialResult.RetrievedAtUtc);
         mockTdClient.Verify(
             client => client.SearchAsync(
                 It.IsAny<TransitoryDocumentSearchRequest>(),
                 It.IsAny<CancellationToken>()),
             Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ListSharedDocuments_ShouldNotCacheFailedForceRefresh()
+    {
+        // Arrange
+        var locationId = _faker.Random.AlphaNumeric(5);
+        var roomCode = _faker.Random.AlphaNumeric(3);
+        var date = _faker.Date.Recent().ToString("yyyy-MM-dd");
+        var location = Scv.Models.Location.Location.Create(
+            _faker.Address.City(),
+            locationId,
+            locationId,
+            true,
+            []);
+        location.ShortName = _faker.Random.AlphaNumeric(5);
+        location.AgencyIdentifierCd = _faker.Random.AlphaNumeric(3);
+        var region = new JCRegion
+        {
+            RegionId = _faker.Random.Int(1, 10),
+            RegionName = _faker.Address.State(),
+            RegionLocations = []
+        };
+        var (service, mockTdClient, _, _) = SetupService([], location, region);
+        mockTdClient
+            .SetupSequence(client => client.SearchAsync(
+                It.IsAny<TransitoryDocumentSearchRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([])
+            .ThrowsAsync(new InvalidOperationException("Search failed."))
+            .ReturnsAsync([]);
+
+        // Act
+        await service.ListSharedDocuments(locationId, roomCode, date);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.ListSharedDocuments(locationId, roomCode, date, forceRefresh: true));
+        var resultAfterFailure = await service.ListSharedDocuments(locationId, roomCode, date);
+
+        // Assert
+        Assert.False(resultAfterFailure.IsCached);
+        mockTdClient.Verify(
+            client => client.SearchAsync(
+                It.IsAny<TransitoryDocumentSearchRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
     }
 
     #endregion

--- a/web/src/components/courtlist/TransitoryDocumentsTable.vue
+++ b/web/src/components/courtlist/TransitoryDocumentsTable.vue
@@ -17,6 +17,30 @@
       </v-toolbar>
 
       <v-container>
+        <v-alert
+          v-if="searchResult"
+          :type="searchResult.isCached ? 'warning' : 'info'"
+          border="start"
+          density="compact"
+          class="mb-4"
+          data-testid="search-freshness-banner"
+          :data-cache-status="searchResult.isCached ? 'cached' : 'current'"
+        >
+          {{ searchResult.isCached ? 'Cached results' : 'Results' }} as of
+          {{ formatDate(searchResult.retrievedAtUtc) }}. Click
+          <v-btn
+            variant="outlined"
+            size="small"
+            :loading="loading"
+            :disabled="loading"
+            data-testid="refresh-documents-link"
+            @click="refreshDocuments"
+          >
+            refresh
+          </v-btn>
+          to check for newer results.
+        </v-alert>
+
         <v-row
           v-if="documents.length === 0 && !loading"
           justify="center"
@@ -115,7 +139,10 @@
   import { PERMISSIONS } from '@/constants/permissions';
   import { TransitoryDocumentsService } from '@/services/TransitoryDocumentsService';
   import { useCommonStore } from '@/stores';
-  import { FileMetadataDto } from '@/types/transitory-documents';
+  import {
+    FileMetadataDto,
+    TransitoryDocumentSearchResponse,
+  } from '@/types/transitory-documents';
   import {
     mdiClose,
     mdiDownload,
@@ -153,6 +180,7 @@
   });
   const loading = ref(false);
   const documents = ref<FileMetadataDto[]>([]);
+  const searchResult = ref<TransitoryDocumentSearchResponse | null>(null);
   const selectedDocuments = ref<FileMetadataDto[]>([]);
   const downloadingFiles = ref<Record<string, boolean>>({});
   const latestFetchRequestId = ref(0);
@@ -206,6 +234,7 @@
     const requestId = ++latestFetchRequestId.value;
     loading.value = true;
     documents.value = [];
+    searchResult.value = null;
     error.value = null;
 
     try {
@@ -227,7 +256,8 @@
         return;
       }
 
-      documents.value = result || [];
+      documents.value = result?.documents || [];
+      searchResult.value = result || null;
     } catch (e) {
       error.value = e;
       console.error('Error fetching transitory documents:', e);
@@ -324,6 +354,7 @@
         latestFetchRequestId.value++;
         loading.value = false;
         selectedDocuments.value = [];
+        searchResult.value = null;
       }
     },
     { immediate: true }

--- a/web/src/services/TransitoryDocumentsService.ts
+++ b/web/src/services/TransitoryDocumentsService.ts
@@ -1,5 +1,6 @@
 import {
   FileMetadataDto,
+  TransitoryDocumentSearchResponse,
   TransitoryMergeContext,
 } from '@/types/transitory-documents';
 import { HttpService } from './HttpService';
@@ -12,7 +13,7 @@ export class TransitoryDocumentsService {
     roomCd: string,
     date: string,
     forceRefresh = false
-  ): Promise<FileMetadataDto[]> {
+  ): Promise<TransitoryDocumentSearchResponse> {
     const query = {
       locationId,
       roomCd,
@@ -20,7 +21,7 @@ export class TransitoryDocumentsService {
       ...(forceRefresh ? { forceRefresh: true } : {}),
     };
 
-    return this.httpService.get<FileMetadataDto[]>(
+    return this.httpService.get<TransitoryDocumentSearchResponse>(
       'api/TransitoryDocuments',
       query
     );

--- a/web/src/types/transitory-documents.ts
+++ b/web/src/types/transitory-documents.ts
@@ -7,6 +7,12 @@ export interface FileMetadataDto {
   matchedRoomFolder: string | null;
 }
 
+export interface TransitoryDocumentSearchResponse {
+  documents: FileMetadataDto[];
+  retrievedAtUtc: string;
+  isCached: boolean;
+}
+
 export interface TransitoryMergeContext {
   locationId: string;
   roomCd: string;

--- a/web/tests/components/courtList/TransitoryDocumentsDialog.test.ts
+++ b/web/tests/components/courtList/TransitoryDocumentsDialog.test.ts
@@ -1,6 +1,9 @@
 import TransitoryDocumentsTable from '@/components/courtlist/TransitoryDocumentsTable.vue';
 import { useCommonStore } from '@/stores';
-import { FileMetadataDto } from '@/types/transitory-documents';
+import {
+  FileMetadataDto,
+  TransitoryDocumentSearchResponse,
+} from '@/types/transitory-documents';
 import { mount, flushPromises } from '@vue/test-utils';
 import { createPinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -57,6 +60,7 @@ type TransitoryDocumentsTableVm = {
   loading: boolean;
   error: unknown;
   documents: FileMetadataDto[];
+  searchResult: TransitoryDocumentSearchResponse | null;
   selectedDocuments: FileMetadataDto[];
   downloadError: boolean;
   downloadErrorMessage: string;
@@ -111,9 +115,11 @@ describe('TransitoryDocumentsTable', () => {
     mockDocuments: FileMetadataDto[] = [],
     permissions: string[] = [DOWNLOAD_PERMISSION, VIEW_PERMISSION]
   ) => {
-    mockTransitoryDocumentsService.searchDocuments.mockResolvedValue(
-      mockDocuments
-    );
+    mockTransitoryDocumentsService.searchDocuments.mockResolvedValue({
+      documents: mockDocuments,
+      retrievedAtUtc: '2025-11-01T10:30:00Z',
+      isCached: false,
+    });
 
     const pinia = createPiniaWithUser(permissions);
 
@@ -222,7 +228,7 @@ describe('TransitoryDocumentsTable', () => {
     });
 
     it('shows loading state when fetching documents', async () => {
-      const promise = new Promise<FileMetadataDto[]>(() => {
+      const promise = new Promise<TransitoryDocumentSearchResponse>(() => {
         // Intentionally unresolved so loading remains true while assertion runs.
       });
 
@@ -315,6 +321,38 @@ describe('TransitoryDocumentsTable', () => {
   });
 
   describe('Document fetching', () => {
+    it('shows a blue banner for current results', async () => {
+      const wrapper = createWrapper({}, [createMockDocument()]);
+      await flushAll();
+
+      const banner = wrapper.find('[data-testid="search-freshness-banner"]');
+      expect(banner.text()).toContain('Results as of');
+      expect(banner.attributes('data-cache-status')).toBe('current');
+    });
+
+    it('shows a yellow banner for cached results', async () => {
+      mockTransitoryDocumentsService.searchDocuments.mockResolvedValue({
+        documents: [createMockDocument()],
+        retrievedAtUtc: '2025-11-01T10:30:00Z',
+        isCached: true,
+      });
+      const pinia = createPiniaWithUser();
+      const wrapper = mount(TransitoryDocumentsTable, {
+        props: defaultProps,
+        global: {
+          plugins: [vuetify, pinia],
+          provide: {
+            transitoryDocumentsService: mockTransitoryDocumentsService,
+          },
+        },
+      });
+      await flushAll();
+
+      const banner = wrapper.find('[data-testid="search-freshness-banner"]');
+      expect(banner.text()).toContain('Cached results as of');
+      expect(banner.attributes('data-cache-status')).toBe('cached');
+    });
+
     it('fetches documents when dialog is opened', async () => {
       const mockDocs = [createMockDocument()];
       const wrapper = createWrapper({ modelValue: false }, mockDocs);
@@ -353,6 +391,19 @@ describe('TransitoryDocumentsTable', () => {
       const vm = getVm(wrapper);
 
       await vm.refreshDocuments();
+
+      expect(
+        mockTransitoryDocumentsService.searchDocuments
+      ).toHaveBeenLastCalledWith('1', '101', '2025-11-01', true);
+    });
+
+    it('refreshes documents when the banner refresh link is clicked', async () => {
+      const wrapper = createWrapper();
+      await flushAll();
+
+      await wrapper
+        .find('[data-testid="refresh-documents-link"]')
+        .trigger('click');
 
       expect(
         mockTransitoryDocumentsService.searchDocuments
@@ -628,7 +679,9 @@ describe('TransitoryDocumentsTable', () => {
       await wrapper.setProps({ modelValue: true });
       await flushAll();
 
-      expect(wrapper.find('a.text-primary').exists()).toBe(false);
+      expect(
+        wrapper.find('[data-testid="documents-table"] a.text-primary').exists()
+      ).toBe(false);
       expect(wrapper.text()).toContain('test-file.pdf');
     });
 


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**jasper-858**----    

## Issue ticket number and link  
https://jira.justice.gov.bc.ca/browse/JASPER-858

## Description

Further changes, displays date/time of previously retrieved data.

<img width="1897" height="422" alt="image" src="https://github.com/user-attachments/assets/8018e555-2d2b-492c-a2a8-31927d78a88b" />


Fixes # (issue)  

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality) 


## How Has This Been Tested?

Tested all requirements independently against Q drive.
Was unable to validate if the refresh button bypasses issues with caching search results, requires tester with q drive write access.

**Test Configuration**:
If applicable

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules   